### PR TITLE
docs: document Y-up/meters pipeline and shape.color convention

### DIFF
--- a/skills/cad/references/generator-contract.md
+++ b/skills/cad/references/generator-contract.md
@@ -36,6 +36,8 @@ Optional fields include:
 - `glb_tolerance`, `glb_angular_tolerance`
 - `skip_topology`: for parts that should emit GLB without selector topology sidecars
 
+Color is not an envelope field; set it directly on the returned shape via `shape.color = build123d.Color(r, g, b)` to have it written into the exported GLB.
+
 `gen_dxf()` must return:
 
 - `document`: an object with a callable `saveas(...)`
@@ -84,6 +86,24 @@ Envelope output fields and CLI output fields:
 - are resolved as file paths, not through a harness root
 
 The host project may impose its own layout policy, such as keeping outputs under a `models/` directory, but the CAD skill runtime does not hardcode that convention.
+
+## Axis and Units
+
+The harness's derived render artifacts flow through Y-up, meters pipelines:
+
+- GLB export uses the glTF Y-up convention; `build123d.export_gltf` auto-scales millimeters to meters.
+- The `snapshot` camera presets (`front`, `back`, `left`, `right`, `top`, `bottom`, `isometric`) all use `up = (0, 1, 0)`.
+- The CAD Explorer viewer is a Y-up three.js scene.
+
+Neither `build123d` nor STEP imposes an up-axis on generator geometry, so parts authored with Z-up height render rotated in both the viewer and `snapshot` output. Write generators with Y as the height axis:
+
+- Build profiles in the XY plane with Y = height.
+- Extrude along Z for depth/width.
+- Keep the part's floor at Y = 0 unless the design requires otherwise.
+
+Generators that inherit Z-up geometry can apply a terminal `shape.rotate(Axis.X, -90)` before returning, but building Y-up from the start avoids orientation drift across booleans and fillets.
+
+STEP files carry coordinates as written and do not encode an up-axis. Downstream consumers that target Z-up pipelines (e.g. Isaac Sim, ROS) must apply their own conversion on import.
 
 ## Generated Artifacts
 


### PR DESCRIPTION
## Summary

- Adds an "Axis and Units" section to `skills/cad/references/generator-contract.md` documenting that the harness's render pipeline (GLB export, `snapshot` camera presets, CAD Explorer viewer) is Y-up / meters end-to-end.
- Adds a one-line note in "Part Envelopes" that color is carried on `shape.color`, not as an envelope field.

## Motivation

`build123d` has no default up-axis, so a generator written with Z-up (CAD convention) height renders rotated in both the viewer and `snapshot` output. The harness does pick a direction — every `snapshot` camera preset has `up = (0, 1, 0)`, the viewer is a default three.js Y-up scene, and `build123d.export_gltf` auto-scales mm → m — but none of that was written down. Easy to hit a multi-iteration detour diagnosing "why is my bin rotated 90°?" before landing on "oh, everything downstream is Y-up and I should build that way."

Similarly, `color` is a natural thing to look for in the envelope-fields list but it's actually carried on `shape.color`, which wasn't documented either.

## Scope

Pure documentation. No code or behavior changes.

## Verification

Each claim checked against existing code/behavior:
- \`up=(0,1,0)\` camera presets → \`skills/cad/scripts/snapshot/cli.py\` lines 41–47
- Three.js Y-up viewer → \`viewer/components/viewer/hooks/useViewerRuntime.js\` (default \`camera.up\`, no override)
- GLB mm → m auto-scale → empirical (a 190×105×75 mm part exports to a GLB with vertex bounds of 0.193×0.105×0.075)
- \`shape.color\` → GLB material → \`skills/cad/scripts/common/glb.py\` (\`shape.color = build123d.Color(*color)\`)

Happy to rework tone / wording / recommendations if preferred — e.g. dropping the prescriptive "build profiles in XY" in favor of a neutral "decide on an up-axis convention for your project."

🤖 Generated with [Claude Code](https://claude.com/claude-code)