### PR TITLE
Add measurement workbench panel and advanced CAD measurements

### DIFF
--- a/.agents/skills/cad/explorer/components/CadExplorer.js
+++ b/.agents/skills/cad/explorer/components/CadExplorer.js
@@ -3189,54 +3189,7 @@ function buildEdgePickLines(THREE, selectorRuntime) {
   return lines;
 }
 
-function buildVertexPickPointsFromReferences(THREE, references) {
-  const pointReferences = (Array.isArray(references) ? references : [])
-    .map((reference) => {
-      const center = reference?.pickData?.center;
-      if (!isFinitePoint3(center)) {
-        return null;
-      }
-      return {
-        reference,
-        center: [Number(center[0]), Number(center[1]), Number(center[2])]
-      };
-    })
-    .filter(Boolean);
-  if (!pointReferences.length) {
-    return null;
-  }
-  const positions = new Float32Array(pointReferences.length * 3);
-  const vertexIds = new Uint32Array(pointReferences.length);
-  for (let index = 0; index < pointReferences.length; index += 1) {
-    const center = pointReferences[index].center;
-    positions[index * 3] = center[0];
-    positions[(index * 3) + 1] = center[1];
-    positions[(index * 3) + 2] = center[2];
-    vertexIds[index] = index;
-  }
-  const geometry = new THREE.BufferGeometry();
-  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
-  const material = new THREE.PointsMaterial({
-    color: 0xffffff,
-    transparent: true,
-    opacity: 0,
-    size: 1.5,
-    sizeAttenuation: false,
-    depthWrite: false,
-    toneMapped: false,
-  });
-  const points = new THREE.Points(geometry, material);
-  points.userData.vertexIds = vertexIds;
-  points.userData.vertexReferences = pointReferences.map((entry) => entry.reference);
-  points.frustumCulled = false;
-  return points;
-}
-
-function buildVertexPickPoints(THREE, selectorRuntime, pickableVertices = []) {
-  const referencePoints = buildVertexPickPointsFromReferences(THREE, pickableVertices);
-  if (referencePoints) {
-    return referencePoints;
-  }
+function buildVertexPickPoints(THREE, selectorRuntime) {
   const proxy = selectorRuntime?.proxy || {};
   if (!(proxy.vertexPositions instanceof Float32Array) || !proxy.vertexPositions.length) {
     return null;
@@ -3487,6 +3440,34 @@ function buildVertexMarkerMesh(runtime, THREE, reference, {
   const mesh = new THREE.Points(geometry, material);
   mesh.renderOrder = renderOrder;
   return mesh;
+}
+
+function buildMeasurementLineMesh(THREE, start, end, {
+  color,
+  opacity = 1,
+  renderOrder = 80,
+  depthTest = false
+} = {}) {
+  if (!isFinitePoint3(start) || !isFinitePoint3(end)) {
+    return null;
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array([
+    Number(start[0]), Number(start[1]), Number(start[2]),
+    Number(end[0]), Number(end[1]), Number(end[2])
+  ]), 3));
+  const material = new THREE.LineBasicMaterial({
+    color,
+    transparent: true,
+    opacity,
+    depthTest,
+    depthWrite: false,
+    toneMapped: false
+  });
+  const line = new THREE.LineSegments(geometry, material);
+  line.renderOrder = renderOrder;
+  line.frustumCulled = false;
+  return line;
 }
 
 function subtract(a, b) {
@@ -6416,6 +6397,15 @@ const CadExplorer = forwardRef(function CadExplorer({
       const firstCenter = selectedTopologyReferences[0]?.pickData?.center;
       const secondCenter = selectedTopologyReferences[1]?.pickData?.center;
       if (isFinitePoint3(firstCenter) && isFinitePoint3(secondCenter)) {
+        const measurementLineFallback = buildMeasurementLineMesh(THREE, firstCenter, secondCenter, {
+          color: SURFACE_LINE_COLOR,
+          opacity: 1,
+          renderOrder: 80,
+          depthTest: false
+        });
+        if (measurementLineFallback) {
+          highlightGroup.add(measurementLineFallback);
+        }
         const measurementLine = createScreenSpaceLineSegments(runtime, [
           Number(firstCenter[0]), Number(firstCenter[1]), Number(firstCenter[2]),
           Number(secondCenter[0]), Number(secondCenter[1]), Number(secondCenter[2])
@@ -6423,7 +6413,7 @@ const CadExplorer = forwardRef(function CadExplorer({
           color: SURFACE_LINE_COLOR,
           opacity: 0.98,
           lineWidth: Math.max(baseEdgeThickness * 2, 2),
-          renderOrder: 28,
+          renderOrder: 81,
           depthTest: false,
           depthWrite: false
         });

--- a/.agents/skills/cad/explorer/components/CadExplorer.js
+++ b/.agents/skills/cad/explorer/components/CadExplorer.js
@@ -6408,9 +6408,9 @@ const CadExplorer = forwardRef(function CadExplorer({
       }
       const marker = buildVertexMarkerMesh(runtime, THREE, reference, {
         color: REFERENCE_CORNER_COLOR,
-        opacity: 0.42,
+        opacity: 0.76,
         renderOrder: 24,
-        radiusScale: 0.62,
+        radiusScale: 1.15,
         depthTest: false
       });
       if (marker) {
@@ -6433,6 +6433,7 @@ const CadExplorer = forwardRef(function CadExplorer({
         const marker = buildVertexMarkerMesh(runtime, THREE, topologyReference, {
           color: REFERENCE_CORNER_COLOR,
           opacity: isHovered ? 0.96 : 0.88,
+          radiusScale: isHovered ? 1.45 : 1.25,
           depthTest: false
         });
         if (marker) {

--- a/.agents/skills/cad/explorer/components/CadExplorer.js
+++ b/.agents/skills/cad/explorer/components/CadExplorer.js
@@ -3189,7 +3189,54 @@ function buildEdgePickLines(THREE, selectorRuntime) {
   return lines;
 }
 
-function buildVertexPickPoints(THREE, selectorRuntime) {
+function buildVertexPickPointsFromReferences(THREE, references) {
+  const pointReferences = (Array.isArray(references) ? references : [])
+    .map((reference) => {
+      const center = reference?.pickData?.center;
+      if (!isFinitePoint3(center)) {
+        return null;
+      }
+      return {
+        reference,
+        center: [Number(center[0]), Number(center[1]), Number(center[2])]
+      };
+    })
+    .filter(Boolean);
+  if (!pointReferences.length) {
+    return null;
+  }
+  const positions = new Float32Array(pointReferences.length * 3);
+  const vertexIds = new Uint32Array(pointReferences.length);
+  for (let index = 0; index < pointReferences.length; index += 1) {
+    const center = pointReferences[index].center;
+    positions[index * 3] = center[0];
+    positions[(index * 3) + 1] = center[1];
+    positions[(index * 3) + 2] = center[2];
+    vertexIds[index] = index;
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+  const material = new THREE.PointsMaterial({
+    color: 0xffffff,
+    transparent: true,
+    opacity: 0,
+    size: 1.5,
+    sizeAttenuation: false,
+    depthWrite: false,
+    toneMapped: false,
+  });
+  const points = new THREE.Points(geometry, material);
+  points.userData.vertexIds = vertexIds;
+  points.userData.vertexReferences = pointReferences.map((entry) => entry.reference);
+  points.frustumCulled = false;
+  return points;
+}
+
+function buildVertexPickPoints(THREE, selectorRuntime, pickableVertices = []) {
+  const referencePoints = buildVertexPickPointsFromReferences(THREE, pickableVertices);
+  if (referencePoints) {
+    return referencePoints;
+  }
   const proxy = selectorRuntime?.proxy || {};
   if (!(proxy.vertexPositions instanceof Float32Array) || !proxy.vertexPositions.length) {
     return null;
@@ -3211,7 +3258,7 @@ function buildVertexPickPoints(THREE, selectorRuntime) {
   return points;
 }
 
-function syncSelectorPickGroups(runtime, selectorRuntime, modelOffset = null) {
+function syncSelectorPickGroups(runtime, selectorRuntime, modelOffset = null, pickableVertices = []) {
   if (!runtime?.THREE || !runtime?.facePickGroup || !runtime?.edgePickGroup || !runtime?.vertexPickGroup) {
     return;
   }
@@ -3237,7 +3284,7 @@ function syncSelectorPickGroups(runtime, selectorRuntime, modelOffset = null) {
     runtime.edgePickObjects = [edgePickLines];
   }
 
-  const vertexPickPoints = buildVertexPickPoints(runtime.THREE, selectorRuntime);
+  const vertexPickPoints = buildVertexPickPoints(runtime.THREE, selectorRuntime, pickableVertices);
   if (vertexPickPoints) {
     runtime.vertexPickPoints = vertexPickPoints;
     runtime.vertexPickGroup.add(vertexPickPoints);
@@ -3413,19 +3460,21 @@ function buildFaceBoundaryLinePositions(selectorRuntime, reference) {
 function buildVertexMarkerMesh(runtime, THREE, reference, {
   color,
   opacity,
-  renderOrder = 27
+  renderOrder = 27,
+  radiusScale = 1,
+  depthTest = true
 } = {}) {
   const center = Array.isArray(reference?.pickData?.center) ? reference.pickData.center : null;
   if (!center || center.length < 3) {
     return null;
   }
-  const radius = Math.max(Number(runtime?.modelRadius || 1) * 0.0045, 0.2);
+  const radius = Math.max(Number(runtime?.modelRadius || 1) * 0.0045, 0.2) * Math.max(Number(radiusScale) || 1, 0.2);
   const geometry = new THREE.SphereGeometry(radius, 16, 16);
   const material = new THREE.MeshBasicMaterial({
     color,
     transparent: true,
     opacity,
-    depthTest: true,
+    depthTest,
     depthWrite: false,
     toneMapped: false,
   });
@@ -4869,10 +4918,9 @@ const CadExplorer = forwardRef(function CadExplorer({
       : (Array.isArray(pickableVertices) ? pickableVertices : [])
   ), [focusedPartIdSet, pickableVertices]);
   const pickableReferenceMap = useMemo(() => {
-    if (selectorRuntime?.referenceMap instanceof Map) {
-      return selectorRuntime.referenceMap;
-    }
-    const map = new Map();
+    const map = selectorRuntime?.referenceMap instanceof Map
+      ? new Map(selectorRuntime.referenceMap)
+      : new Map();
     for (const reference of [...filteredPickableFaces, ...filteredPickableEdges, ...filteredPickableVertices]) {
       const referenceId = String(reference?.id || "").trim();
       if (!referenceId) {
@@ -5871,7 +5919,7 @@ const CadExplorer = forwardRef(function CadExplorer({
     facePickGroup.updateMatrixWorld(true);
     edgePickGroup.updateMatrixWorld(true);
     vertexPickGroup.updateMatrixWorld(true);
-    syncSelectorPickGroups(runtime, selectorRuntimeRef.current, modelOffset);
+    syncSelectorPickGroups(runtime, selectorRuntimeRef.current, modelOffset, filteredPickableVertices);
 
     const currentPartVisualState = partVisualStateRef.current;
     applyPartVisualState(THREE, displayRecords, shouldRenderParts
@@ -5941,6 +5989,7 @@ const CadExplorer = forwardRef(function CadExplorer({
     pickMode,
     renderPartsIndividually,
     pickableParts,
+    filteredPickableVertices,
     normalizedSceneScaleMode,
     resolvedFloorMode,
     explorerTheme,
@@ -6130,8 +6179,8 @@ const CadExplorer = forwardRef(function CadExplorer({
     }
 
     syncDisplayMeshFaceIds(runtime, meshData, selectorRuntime);
-    syncSelectorPickGroups(runtime, selectorRuntime, modelTransformRef.current.offset);
-  }, [meshData, modelKey, selectorRuntime, explorerReadyTick]);
+    syncSelectorPickGroups(runtime, selectorRuntime, modelTransformRef.current.offset, filteredPickableVertices);
+  }, [meshData, modelKey, selectorRuntime, filteredPickableVertices, explorerReadyTick]);
 
   useEffect(() => {
     const runtime = runtimeRef.current;
@@ -6349,6 +6398,24 @@ const CadExplorer = forwardRef(function CadExplorer({
     const normalizedHoveredReferenceId = String(hoveredReferenceId || "").trim();
     if (normalizedHoveredReferenceId && !seenReferenceIds.has(normalizedHoveredReferenceId)) {
       orderedReferenceIds.push(normalizedHoveredReferenceId);
+      seenReferenceIds.add(normalizedHoveredReferenceId);
+    }
+
+    for (const reference of filteredPickableVertices) {
+      const referenceId = String(reference?.id || "").trim();
+      if (!referenceId || seenReferenceIds.has(referenceId)) {
+        continue;
+      }
+      const marker = buildVertexMarkerMesh(runtime, THREE, reference, {
+        color: REFERENCE_CORNER_COLOR,
+        opacity: 0.42,
+        renderOrder: 24,
+        radiusScale: 0.62,
+        depthTest: false
+      });
+      if (marker) {
+        highlightGroup.add(marker);
+      }
     }
 
     for (const referenceId of orderedReferenceIds) {
@@ -6366,6 +6433,7 @@ const CadExplorer = forwardRef(function CadExplorer({
         const marker = buildVertexMarkerMesh(runtime, THREE, topologyReference, {
           color: REFERENCE_CORNER_COLOR,
           opacity: isHovered ? 0.96 : 0.88,
+          depthTest: false
         });
         if (marker) {
           highlightGroup.add(marker);
@@ -6423,7 +6491,7 @@ const CadExplorer = forwardRef(function CadExplorer({
       clearOverlayGroup(runtime, highlightGroup);
       clearOverlayGroup(runtime, faceFillGroup);
     };
-  }, [hoveredReferenceId, pickableReferenceMap, selectedReferenceIds, selectorRuntime, explorerReadyTick, explorerTheme, normalizedLookSettings.edges]);
+  }, [filteredPickableVertices, hoveredReferenceId, pickableReferenceMap, selectedReferenceIds, selectorRuntime, explorerReadyTick, explorerTheme, normalizedLookSettings.edges]);
 
   useExplorerDrawingOverlay({
     drawingCanvasRef,

--- a/.agents/skills/cad/explorer/components/CadExplorer.js
+++ b/.agents/skills/cad/explorer/components/CadExplorer.js
@@ -3468,18 +3468,23 @@ function buildVertexMarkerMesh(runtime, THREE, reference, {
   if (!center || center.length < 3) {
     return null;
   }
-  const radius = Math.max(Number(runtime?.modelRadius || 1) * 0.0045, 0.2) * Math.max(Number(radiusScale) || 1, 0.2);
-  const geometry = new THREE.SphereGeometry(radius, 16, 16);
-  const material = new THREE.MeshBasicMaterial({
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array([
+    Number(center[0]),
+    Number(center[1]),
+    Number(center[2])
+  ]), 3));
+  const material = new THREE.PointsMaterial({
     color,
     transparent: true,
     opacity,
+    size: Math.max(3, 5.5 * Math.max(Number(radiusScale) || 1, 0.2)),
+    sizeAttenuation: false,
     depthTest,
     depthWrite: false,
     toneMapped: false,
   });
-  const mesh = new THREE.Mesh(geometry, material);
-  mesh.position.set(center[0], center[1], center[2]);
+  const mesh = new THREE.Points(geometry, material);
   mesh.renderOrder = renderOrder;
   return mesh;
 }
@@ -6401,20 +6406,30 @@ const CadExplorer = forwardRef(function CadExplorer({
       seenReferenceIds.add(normalizedHoveredReferenceId);
     }
 
-    for (const reference of filteredPickableVertices) {
-      const referenceId = String(reference?.id || "").trim();
-      if (!referenceId || seenReferenceIds.has(referenceId)) {
-        continue;
-      }
-      const marker = buildVertexMarkerMesh(runtime, THREE, reference, {
-        color: REFERENCE_CORNER_COLOR,
-        opacity: 0.76,
-        renderOrder: 24,
-        radiusScale: 1.15,
-        depthTest: false
-      });
-      if (marker) {
-        highlightGroup.add(marker);
+    const selectedTopologyReferences = (Array.isArray(selectedReferenceIds) ? selectedReferenceIds : [])
+      .map((referenceId) => pickableReferenceMap.get(String(referenceId || "").trim()) || selectorRuntime?.referenceMap?.get(String(referenceId || "").trim()) || null)
+      .filter(Boolean);
+    if (
+      selectedTopologyReferences.length === 2 &&
+      selectedTopologyReferences.some((reference) => String(reference?.selectorType || "").trim() === "vertex")
+    ) {
+      const firstCenter = selectedTopologyReferences[0]?.pickData?.center;
+      const secondCenter = selectedTopologyReferences[1]?.pickData?.center;
+      if (isFinitePoint3(firstCenter) && isFinitePoint3(secondCenter)) {
+        const measurementLine = createScreenSpaceLineSegments(runtime, [
+          Number(firstCenter[0]), Number(firstCenter[1]), Number(firstCenter[2]),
+          Number(secondCenter[0]), Number(secondCenter[1]), Number(secondCenter[2])
+        ], {
+          color: SURFACE_LINE_COLOR,
+          opacity: 0.98,
+          lineWidth: Math.max(baseEdgeThickness * 2, 2),
+          renderOrder: 28,
+          depthTest: false,
+          depthWrite: false
+        });
+        if (measurementLine) {
+          highlightGroup.add(measurementLine);
+        }
       }
     }
 
@@ -6431,9 +6446,9 @@ const CadExplorer = forwardRef(function CadExplorer({
       const isHovered = referenceId === normalizedHoveredReferenceId;
       if (selectorType === "vertex") {
         const marker = buildVertexMarkerMesh(runtime, THREE, topologyReference, {
-          color: REFERENCE_CORNER_COLOR,
+          color: isHovered ? REFERENCE_HOVER_COLOR : REFERENCE_SELECTED_COLOR,
           opacity: isHovered ? 0.96 : 0.88,
-          radiusScale: isHovered ? 1.45 : 1.25,
+          radiusScale: isHovered ? 1.05 : 0.85,
           depthTest: false
         });
         if (marker) {

--- a/.agents/skills/cad/explorer/components/CadWorkspace.js
+++ b/.agents/skills/cad/explorer/components/CadWorkspace.js
@@ -114,6 +114,7 @@ import {
 } from "../lib/urdf/jointAnimation";
 import { buildSelectorRuntime } from "../lib/selectors/runtime";
 import { measurementKey, measurementsForReferences } from "../lib/measurements/measureTopology";
+import { buildMeasurePointReferences } from "../lib/measurements/measurePoints";
 import {
   assemblyBreadcrumb,
   buildAssemblyLeafToNodePickMap,
@@ -3066,11 +3067,31 @@ export default function CadWorkspace({
     }
     return map;
   }, [activeReferenceMap, effectiveVisibleReferences]);
+  const measureToolAvailable = effectiveRenderFormat === RENDER_FORMAT.STEP && selectedFileSheetKind === "stepPart" && !explorerInAssemblyMode;
+  const measureToolActive = measureToolAvailable && tabToolMode === TAB_TOOL_MODE.MEASURE;
+  const measureCandidateEdgeReferences = useMemo(
+    () => effectiveVisibleReferences.filter((reference) => isEdgeReference(reference)),
+    [effectiveVisibleReferences, isEdgeReference]
+  );
+  const measurePointReferences = useMemo(
+    () => measureToolActive ? buildMeasurePointReferences(measureCandidateEdgeReferences, effectiveSelectorRuntime) : EMPTY_LIST,
+    [effectiveSelectorRuntime, measureCandidateEdgeReferences, measureToolActive]
+  );
+  const measurementReferenceMap = useMemo(() => {
+    const map = new Map(effectiveActiveReferenceMap);
+    for (const reference of measurePointReferences) {
+      const referenceId = String(reference?.id || "").trim();
+      if (referenceId) {
+        map.set(referenceId, reference);
+      }
+    }
+    return map;
+  }, [effectiveActiveReferenceMap, measurePointReferences]);
   const measurementReferences = useMemo(() => (
     measurementReferenceIds
-      .map((id) => effectiveActiveReferenceMap.get(id))
+      .map((id) => measurementReferenceMap.get(id))
       .filter(Boolean)
-  ), [effectiveActiveReferenceMap, measurementReferenceIds]);
+  ), [measurementReferenceMap, measurementReferenceIds]);
   const activeMeasurementResults = useMemo(() => (
     selectedFileSheetKind === "stepPart"
       ? measurementsForReferences(measurementReferences, effectiveSelectorRuntime)
@@ -3119,7 +3140,7 @@ export default function CadWorkspace({
     () => explorerPickableReferences.filter((reference) => isEdgeReference(reference)),
     [isEdgeReference, explorerPickableReferences]
   );
-  const explorerPickableVertices = EMPTY_LIST;
+  const explorerPickableVertices = measureToolActive ? measurePointReferences : EMPTY_LIST;
   const referenceSelectionStatus = isAssemblyView && isInspectingAssemblyPart
     ? inspectedAssemblyReferenceStatus
     : referenceStatus;
@@ -4230,14 +4251,16 @@ export default function CadWorkspace({
       }
       return;
     }
-    if (!effectiveActiveReferenceMap.has(nextReferenceId)) {
+    const isMeasureActivation = tabToolMode === TAB_TOOL_MODE.MEASURE && selectedFileSheetKind === "stepPart";
+    const activeReferenceMapForActivation = isMeasureActivation ? measurementReferenceMap : effectiveActiveReferenceMap;
+    if (!activeReferenceMapForActivation.has(nextReferenceId)) {
       return;
     }
-    if (tabToolMode === TAB_TOOL_MODE.MEASURE && selectedFileSheetKind === "stepPart") {
+    if (isMeasureActivation) {
       const nextIds = computeNextMeasurementIds(
         measurementReferenceIds,
         nextReferenceId,
-        effectiveActiveReferenceMap,
+        measurementReferenceMap,
         effectiveSelectorRuntime
       );
       setMeasurementReferenceIds(nextIds);
@@ -4253,6 +4276,7 @@ export default function CadWorkspace({
     clearReferenceSelection,
     effectiveSelectorRuntime,
     effectiveActiveReferenceMap,
+    measurementReferenceMap,
     assemblyPickPartIdMap,
     measurementReferenceIds,
     selectedFileSheetKind,
@@ -4520,8 +4544,6 @@ export default function CadWorkspace({
     });
   };
   const selectionToolActive = effectiveRenderFormat === RENDER_FORMAT.STEP && tabToolMode === TAB_TOOL_MODE.REFERENCES;
-  const measureToolAvailable = effectiveRenderFormat === RENDER_FORMAT.STEP && selectedFileSheetKind === "stepPart" && !explorerInAssemblyMode;
-  const measureToolActive = measureToolAvailable && tabToolMode === TAB_TOOL_MODE.MEASURE;
   const drawToolActive = drawModeActive;
   const viewerSelectedReferenceIds = measureToolActive ? measurementReferenceIds : selectedReferenceIds;
   const selectionCount = measureToolActive ? 0 : selectionCountBase;

--- a/.agents/skills/cad/explorer/components/CadWorkspace.js
+++ b/.agents/skills/cad/explorer/components/CadWorkspace.js
@@ -8,6 +8,7 @@ import DxfFileSheet from "./workbench/DxfFileSheet";
 import FileExplorerSidebar from "./workbench/FileExplorerSidebar";
 import LookSettingsPopover from "./workbench/LookSettingsPopover";
 import StepAssemblyFileSheet from "./workbench/StepAssemblyFileSheet";
+import StepPartInfoFileSheet from "./workbench/StepPartInfoFileSheet";
 import StatusToast from "./workbench/StatusToast";
 import UrdfFileSheet from "./workbench/UrdfFileSheet";
 import ExplorerAlertDialog from "./workbench/ExplorerAlertDialog";
@@ -112,6 +113,7 @@ import {
   URDF_JOINT_ANIMATION_FOLLOW_MS
 } from "../lib/urdf/jointAnimation";
 import { buildSelectorRuntime } from "../lib/selectors/runtime";
+import { measurementKey, measurementsForReferences } from "../lib/measurements/measureTopology";
 import {
   assemblyBreadcrumb,
   buildAssemblyLeafToNodePickMap,
@@ -146,6 +148,7 @@ const DESKTOP_TAB_TOOLS_MAX_WIDTH = 560;
 const DEFAULT_TAB_TOOLS_WIDTH = CAD_WORKSPACE_DEFAULT_TAB_TOOLS_WIDTH;
 const CAD_WORKSPACE_TOP_BAR_HEIGHT = 44;
 const CAD_WORKSPACE_SESSION_PERSIST_DELAY_MS = 120;
+const DEFAULT_MEASURE_DENSITY_G_CM3 = "1.24";
 
 function clampPanelWidth(value, minWidth, maxWidth) {
   return Math.min(Math.max(value, minWidth), Math.max(minWidth, maxWidth));
@@ -559,6 +562,9 @@ function fileSheetKindForEntry(entry) {
   }
   if (kind === "assembly") {
     return "stepAssembly";
+  }
+  if (entrySourceFormat(entry) === RENDER_FORMAT.STEP && entryHasReferences(entry)) {
+    return "stepPart";
   }
   return "";
 }
@@ -1067,6 +1073,30 @@ function computeNextSelectionIds(currentIds, selectionId, { multiSelect = false 
   return [normalizedSelectionId];
 }
 
+function computeNextMeasurementIds(currentIds, selectionId, referenceMap, selectorRuntime) {
+  const normalizedSelectionId = String(selectionId || "").trim();
+  if (!normalizedSelectionId) {
+    return [];
+  }
+  const nextReference = referenceMap?.get?.(normalizedSelectionId);
+  if (!nextReference) {
+    return [];
+  }
+  const current = Array.isArray(currentIds) ? currentIds : [];
+  if (current.length === 1 && current[0] === normalizedSelectionId) {
+    return [];
+  }
+  const previousReference = current.length === 1 ? referenceMap.get(current[0]) : null;
+  if (
+    previousReference &&
+    previousReference.id !== normalizedSelectionId &&
+    measurementsForReferences([previousReference, nextReference], selectorRuntime).length
+  ) {
+    return [previousReference.id, normalizedSelectionId];
+  }
+  return [normalizedSelectionId];
+}
+
 function buildExplorerMeshAlert(entry, hasMeshData, loadError) {
   const fileRef = fileKey(entry);
   if (!fileRef) {
@@ -1220,6 +1250,9 @@ export default function CadWorkspace({
   const [drawingTool, setDrawingTool] = useState(DRAWING_TOOL.FREEHAND);
   const [explorerPerspective, setExplorerPerspective] = useState(null);
   const [tabToolMode, setTabToolMode] = useState(TAB_TOOL_MODE.REFERENCES);
+  const [measureDensity, setMeasureDensity] = useState(DEFAULT_MEASURE_DENSITY_G_CM3);
+  const [measurementReferenceIds, setMeasurementReferenceIds] = useState([]);
+  const [measurementHistory, setMeasurementHistory] = useState([]);
   const [drawingStrokes, setDrawingStrokes] = useState([]);
   const [drawingUndoStack, setDrawingUndoStack] = useState([]);
   const [drawingRedoStack, setDrawingRedoStack] = useState([]);
@@ -1234,6 +1267,8 @@ export default function CadWorkspace({
   const [inspectedAssemblyReferenceStatus, setInspectedAssemblyReferenceStatus] = useState(REFERENCE_STATUS.IDLE);
   const [, setInspectedAssemblyReferenceError] = useState("");
   const lastPersistenceFailureKeyRef = useRef("");
+  const measurementHistoryIdRef = useRef(0);
+  const lastMeasurementHistoryKeyRef = useRef("");
   const urdfTrajectoryPlaybackRef = useRef({
     frameId: 0,
     token: 0
@@ -2031,6 +2066,7 @@ export default function CadWorkspace({
     selectedReferenceIdsRef.current = [];
     setSelectedPartIds([]);
     setSelectedReferenceIds([]);
+    setMeasurementReferenceIds([]);
     setSelectedRenderPartIdByAssemblyPartId({});
     setSelectedWholeEntryCadRefToken("");
     setHoveredListReferenceId("");
@@ -2193,6 +2229,7 @@ export default function CadWorkspace({
     setReferenceQuery(nextTab.referenceQuery);
     selectedReferenceIdsRef.current = nextTab.selectedReferenceIds;
     setSelectedReferenceIds(nextTab.selectedReferenceIds);
+    setMeasurementReferenceIds([]);
     selectedPartIdsRef.current = nextTab.selectedPartIds;
     setSelectedPartIds(nextTab.selectedPartIds);
     setSelectedRenderPartIdByAssemblyPartId({});
@@ -2224,6 +2261,7 @@ export default function CadWorkspace({
     setDxfBendSettings([]);
     setReferenceQuery("");
     setSelectedReferenceIds([]);
+    setMeasurementReferenceIds([]);
     setSelectedPartIds([]);
     setSelectedRenderPartIdByAssemblyPartId({});
     setExpandedAssemblyPartIds([]);
@@ -2512,13 +2550,17 @@ export default function CadWorkspace({
 
   useEffect(() => {
     if (effectiveRenderFormat !== RENDER_FORMAT.STEP || !selectedEntryHasReferences) {
+      setTabToolMode((current) => (
+        current === TAB_TOOL_MODE.MEASURE || (current === TAB_TOOL_MODE.DRAW && !drawingStrokesRef.current.length)
+          ? TAB_TOOL_MODE.REFERENCES
+          : current
+      ));
       return;
     }
     setTabToolMode((current) => {
-      if (current !== TAB_TOOL_MODE.DRAW) {
-        return current;
-      }
-      return drawingStrokesRef.current.length ? current : TAB_TOOL_MODE.REFERENCES;
+      return current === TAB_TOOL_MODE.DRAW && !drawingStrokesRef.current.length
+        ? TAB_TOOL_MODE.REFERENCES
+        : current;
     });
   }, [effectiveRenderFormat, selectedKey, selectedEntryHasReferences]);
 
@@ -3024,6 +3066,44 @@ export default function CadWorkspace({
     }
     return map;
   }, [activeReferenceMap, effectiveVisibleReferences]);
+  const measurementReferences = useMemo(() => (
+    measurementReferenceIds
+      .map((id) => effectiveActiveReferenceMap.get(id))
+      .filter(Boolean)
+  ), [effectiveActiveReferenceMap, measurementReferenceIds]);
+  const activeMeasurementResults = useMemo(() => (
+    selectedFileSheetKind === "stepPart"
+      ? measurementsForReferences(measurementReferences, effectiveSelectorRuntime)
+      : []
+  ), [effectiveSelectorRuntime, measurementReferences, selectedFileSheetKind]);
+  const primaryMeasurementResult = activeMeasurementResults[0] || null;
+
+  useEffect(() => {
+    setMeasurementReferenceIds([]);
+    measurementHistoryIdRef.current = 0;
+    lastMeasurementHistoryKeyRef.current = "";
+    setMeasurementHistory([]);
+  }, [selectedKey]);
+
+  useEffect(() => {
+    const nextMeasurementKey = measurementKey(primaryMeasurementResult);
+    if (!nextMeasurementKey) {
+      lastMeasurementHistoryKeyRef.current = "";
+      return;
+    }
+    if (lastMeasurementHistoryKeyRef.current === nextMeasurementKey) {
+      return;
+    }
+    lastMeasurementHistoryKeyRef.current = nextMeasurementKey;
+    measurementHistoryIdRef.current += 1;
+    setMeasurementHistory((current) => [
+      {
+        ...primaryMeasurementResult,
+        id: `measurement:${measurementHistoryIdRef.current}`
+      },
+      ...current
+    ].slice(0, 30));
+  }, [primaryMeasurementResult]);
 
   const explorerPickableReferences = useMemo(() => {
     if (explorerInAssemblyMode) {
@@ -4143,19 +4223,43 @@ export default function CadWorkspace({
     }
     const nextReferenceId = String(referenceId || "").trim();
     if (!nextReferenceId) {
-      clearReferenceSelection();
+      if (tabToolMode === TAB_TOOL_MODE.MEASURE) {
+        setMeasurementReferenceIds([]);
+      } else {
+        clearReferenceSelection();
+      }
       return;
     }
     if (!effectiveActiveReferenceMap.has(nextReferenceId)) {
+      return;
+    }
+    if (tabToolMode === TAB_TOOL_MODE.MEASURE && selectedFileSheetKind === "stepPart") {
+      const nextIds = computeNextMeasurementIds(
+        measurementReferenceIds,
+        nextReferenceId,
+        effectiveActiveReferenceMap,
+        effectiveSelectorRuntime
+      );
+      setMeasurementReferenceIds(nextIds);
+      if (nextIds.length && selectedFileSheetKind === "stepPart") {
+        setLookMenuOpen(false);
+        setTabToolsOpen(true);
+      }
       return;
     }
     toggleReferenceSelection(nextReferenceId, { multiSelect });
   }, [
     clearAssemblySelection,
     clearReferenceSelection,
+    effectiveSelectorRuntime,
     effectiveActiveReferenceMap,
     assemblyPickPartIdMap,
+    measurementReferenceIds,
+    selectedFileSheetKind,
+    setLookMenuOpen,
+    setTabToolsOpen,
     stepUpdateInProgress,
+    tabToolMode,
     toggleReferenceSelection,
     togglePartSelection,
     explorerInAssemblyMode
@@ -4196,12 +4300,20 @@ export default function CadWorkspace({
 
   const handleSelectTabToolMode = useCallback((mode) => {
     setExplorerAlertOpen(false);
-    const normalizedMode = mode === TAB_TOOL_MODE.DRAW ? TAB_TOOL_MODE.DRAW : TAB_TOOL_MODE.REFERENCES;
+    const normalizedMode = mode === TAB_TOOL_MODE.DRAW
+      ? TAB_TOOL_MODE.DRAW
+      : mode === TAB_TOOL_MODE.MEASURE
+        ? TAB_TOOL_MODE.MEASURE
+        : TAB_TOOL_MODE.REFERENCES;
     setTabToolMode(normalizedMode);
+    if (normalizedMode === TAB_TOOL_MODE.MEASURE && selectedFileSheetKind === "stepPart") {
+      setLookMenuOpen(false);
+      setTabToolsOpen(true);
+    }
     if (normalizedMode === TAB_TOOL_MODE.DRAW && drawingTool === DRAWING_TOOL.SURFACE_LINE) {
       setDrawingTool(DRAWING_TOOL.FREEHAND);
     }
-  }, [drawingTool]);
+  }, [drawingTool, selectedFileSheetKind, setLookMenuOpen, setTabToolsOpen]);
 
   const handleToggleFileSheet = useCallback(() => {
     if (!selectedFileSheetKind) {
@@ -4408,8 +4520,11 @@ export default function CadWorkspace({
     });
   };
   const selectionToolActive = effectiveRenderFormat === RENDER_FORMAT.STEP && tabToolMode === TAB_TOOL_MODE.REFERENCES;
+  const measureToolAvailable = effectiveRenderFormat === RENDER_FORMAT.STEP && selectedFileSheetKind === "stepPart" && !explorerInAssemblyMode;
+  const measureToolActive = measureToolAvailable && tabToolMode === TAB_TOOL_MODE.MEASURE;
   const drawToolActive = drawModeActive;
-  const selectionCount = selectionCountBase;
+  const viewerSelectedReferenceIds = measureToolActive ? measurementReferenceIds : selectedReferenceIds;
+  const selectionCount = measureToolActive ? 0 : selectionCountBase;
   const canUndoDrawing = drawingUndoStack.length > 0;
   const canRedoDrawing = drawingRedoStack.length > 0;
   const lookSheetOpen = lookMenuOpen && !previewMode;
@@ -4479,7 +4594,7 @@ export default function CadWorkspace({
           selectedPartIds={explorerSelectedPartIds}
           hoveredPartId={explorerHoveredPartIds}
           hoveredReferenceId={hoveredReferenceId}
-          selectedReferenceIds={selectedReferenceIds}
+          selectedReferenceIds={viewerSelectedReferenceIds}
           selectorRuntime={effectiveSelectorRuntime}
           pickableFaces={explorerPickableFaces}
           pickableEdges={explorerPickableEdges}
@@ -4552,6 +4667,8 @@ export default function CadWorkspace({
                 renderFormat={effectiveRenderFormat}
                 floatingCadToolbarPosition={floatingCadToolbarPosition}
                 selectionToolActive={selectionToolActive}
+                measureToolAvailable={measureToolAvailable}
+                measureToolActive={measureToolActive}
                 referenceSelectionPending={referenceSelectionPending}
                 referenceSelectionUnavailable={referenceSelectionUnavailable}
                 urdfPosePickerAvailable={Boolean(selectedUrdfMotionControls)}
@@ -4633,6 +4750,28 @@ export default function CadWorkspace({
                 hideSelectedParts={handleHideSelectedParts}
                 showAllHiddenParts={handleShowAllHiddenParts}
                 inspectedAssemblyPart={inspectedAssemblyPart}
+              />
+            ) : null}
+
+            {selectedFileSheetKind === "stepPart" ? (
+              <StepPartInfoFileSheet
+                key={`stepPart:${selectedKey}`}
+                open={fileSheetOpen}
+                isDesktop={isDesktop}
+                width={activeSheetWidth || tabToolsWidth}
+                onStartResize={handleStartFileSheetResize}
+                selectedEntry={selectedEntry}
+                selectedMeshData={selectedMeshData}
+                selectorRuntime={effectiveSelectorRuntime}
+                selectedReferences={measureToolActive ? measurementReferences : EMPTY_LIST}
+                density={measureDensity}
+                onDensityChange={setMeasureDensity}
+                history={measurementHistory}
+                onClearHistory={() => {
+                  measurementHistoryIdRef.current = 0;
+                  lastMeasurementHistoryKeyRef.current = "";
+                  setMeasurementHistory([]);
+                }}
               />
             ) : null}
 

--- a/.agents/skills/cad/explorer/components/explorer/hooks/useExplorerPicking.js
+++ b/.agents/skills/cad/explorer/components/explorer/hooks/useExplorerPicking.js
@@ -16,10 +16,10 @@ const EDGE_HOVER_MAX_SCREEN_DISTANCE_PX = 6;
 const EDGE_HOVER_MAX_SCREEN_DISTANCE_WITH_FACE_PX = EDGE_HOVER_MAX_SCREEN_DISTANCE_PX;
 const EDGE_PICK_PRIORITY_WITH_FACE_PX = EDGE_PICK_MAX_SCREEN_DISTANCE_WITH_FACE_PX;
 const EDGE_HOVER_PRIORITY_WITH_FACE_PX = EDGE_HOVER_MAX_SCREEN_DISTANCE_WITH_FACE_PX;
-const CORNER_PICK_MAX_SCREEN_DISTANCE_PX = 5;
-const CORNER_HOVER_MAX_SCREEN_DISTANCE_PX = 4;
-const CORNER_PICK_PRIORITY_WITH_OTHER_PX = 4;
-const CORNER_HOVER_PRIORITY_WITH_OTHER_PX = 3;
+const CORNER_PICK_MAX_SCREEN_DISTANCE_PX = 14;
+const CORNER_HOVER_MAX_SCREEN_DISTANCE_PX = 11;
+const CORNER_PICK_PRIORITY_WITH_OTHER_PX = 14;
+const CORNER_HOVER_PRIORITY_WITH_OTHER_PX = 11;
 const HOVER_PICK_MIN_MOVE_PX = 2;
 const FINE_POINTER_TAP_SLOP_PX = 4;
 const COARSE_POINTER_TAP_SLOP_PX = 12;
@@ -531,6 +531,29 @@ export function useExplorerPicking({
       return Math.hypot(clientX - clientPoint.x, clientY - clientPoint.y);
     }
 
+    function vertexReferenceScreenDistance(reference, clientX, clientY) {
+      const center = reference?.pickData?.center;
+      if (!Array.isArray(center) || center.length < 3 || !runtime?.THREE) {
+        return Infinity;
+      }
+      const worldPoint = new runtime.THREE.Vector3(
+        Number(center[0]),
+        Number(center[1]),
+        Number(center[2])
+      );
+      if (![worldPoint.x, worldPoint.y, worldPoint.z].every(Number.isFinite)) {
+        return Infinity;
+      }
+      if (runtime.vertexPickGroup) {
+        runtime.vertexPickGroup.localToWorld(worldPoint);
+      }
+      const clientPoint = projectPointToClient(worldPoint);
+      if (!clientPoint) {
+        return Infinity;
+      }
+      return Math.hypot(clientX - clientPoint.x, clientY - clientPoint.y);
+    }
+
     function pickViewportHeightPx() {
       return container.clientHeight || container.getBoundingClientRect().height || 1;
     }
@@ -767,20 +790,32 @@ export function useExplorerPicking({
         filteredIntersections,
         (intersection) => edgeScreenDistance(intersection, clientX, clientY)
       );
-      if (!best) {
-        return null;
+      const bestScreenDistance = best ? edgeScreenDistance(best, clientX, clientY) : Infinity;
+      const reference = best && bestScreenDistance <= maxScreenDistancePx
+        ? vertexReferenceFromIntersection(best)
+        : null;
+      if (reference) {
+        return {
+          reference,
+          screenDistance: bestScreenDistance
+        };
       }
-      const bestScreenDistance = edgeScreenDistance(best, clientX, clientY);
-      if (Number.isFinite(bestScreenDistance) && bestScreenDistance > maxScreenDistancePx) {
-        return null;
+
+      let nearestReference = null;
+      let nearestDistance = Infinity;
+      for (const candidateReference of pickableVertices) {
+        const distance = vertexReferenceScreenDistance(candidateReference, clientX, clientY);
+        if (distance < nearestDistance) {
+          nearestDistance = distance;
+          nearestReference = candidateReference;
+        }
       }
-      const reference = vertexReferenceFromIntersection(best);
-      if (!reference) {
+      if (!nearestReference || !Number.isFinite(nearestDistance) || nearestDistance > maxScreenDistancePx) {
         return null;
       }
       return {
-        reference,
-        screenDistance: bestScreenDistance
+        reference: nearestReference,
+        screenDistance: nearestDistance
       };
     }
 
@@ -863,6 +898,9 @@ export function useExplorerPicking({
       );
       if (vertexCandidate) {
         const vertexPriorityDistancePx = hover ? CORNER_HOVER_PRIORITY_WITH_OTHER_PX : CORNER_PICK_PRIORITY_WITH_OTHER_PX;
+        if (Number(vertexCandidate.screenDistance) <= vertexPriorityDistancePx) {
+          return vertexCandidate.reference.id;
+        }
         const adjacentToEdge = edgeCandidate && areEdgeAndVertexAdjacent(edgeCandidate.reference, vertexCandidate.reference);
         const adjacentToFace = faceReference && areFaceAndVertexAdjacent(faceReference, vertexCandidate.reference);
         if (!faceReference && !edgeCandidate) {
@@ -903,7 +941,7 @@ export function useExplorerPicking({
 
     function pickActivationReference(clientX, clientY, pointerType = "") {
       if (canHoverWithPointer(pointerType)) {
-        return String(hoverState.hoveredReferenceId || "").trim() || pickReferenceAtPosition(clientX, clientY, { hover: true });
+        return pickReferenceAtPosition(clientX, clientY, { hover: true }) || String(hoverState.hoveredReferenceId || "").trim();
       }
       return pickReferenceAtPosition(clientX, clientY);
     }

--- a/.agents/skills/cad/explorer/components/explorer/hooks/useExplorerPicking.js
+++ b/.agents/skills/cad/explorer/components/explorer/hooks/useExplorerPicking.js
@@ -763,7 +763,7 @@ export function useExplorerPicking({
       maxScreenDistancePx = CORNER_PICK_MAX_SCREEN_DISTANCE_PX
     } = {}) {
       const pickableVertices = Array.isArray(pickableVerticesRef.current) ? pickableVerticesRef.current : [];
-      if (!pickableVertices.length || !runtime.vertexPickPoints) {
+      if (!pickableVertices.length) {
         return null;
       }
       const vertexThreshold = currentPickThreshold(
@@ -775,25 +775,29 @@ export function useExplorerPicking({
       if (runtime.raycaster?.params?.Points) {
         runtime.raycaster.params.Points.threshold = vertexThreshold;
       }
-      let filteredIntersections = runtime.raycaster.intersectObject(runtime.vertexPickPoints, false);
-      const nearestSurfaceDistance = Number(modelIntersections?.[0]?.distance);
-      if (Number.isFinite(nearestSurfaceDistance)) {
-        const depthAllowance = Math.max(
-          EDGE_OCCLUSION_EPSILON_MIN,
-          vertexThreshold * EDGE_OCCLUSION_EPSILON_FACTOR
+      let reference = null;
+      let bestScreenDistance = Infinity;
+      if (runtime.vertexPickPoints) {
+        let filteredIntersections = runtime.raycaster.intersectObject(runtime.vertexPickPoints, false);
+        const nearestSurfaceDistance = Number(modelIntersections?.[0]?.distance);
+        if (Number.isFinite(nearestSurfaceDistance)) {
+          const depthAllowance = Math.max(
+            EDGE_OCCLUSION_EPSILON_MIN,
+            vertexThreshold * EDGE_OCCLUSION_EPSILON_FACTOR
+          );
+          filteredIntersections = filteredIntersections.filter(
+            (intersection) => Number(intersection?.distance) <= nearestSurfaceDistance + depthAllowance
+          );
+        }
+        const best = chooseBestEdgeIntersection(
+          filteredIntersections,
+          (intersection) => edgeScreenDistance(intersection, clientX, clientY)
         );
-        filteredIntersections = filteredIntersections.filter(
-          (intersection) => Number(intersection?.distance) <= nearestSurfaceDistance + depthAllowance
-        );
+        bestScreenDistance = best ? edgeScreenDistance(best, clientX, clientY) : Infinity;
+        reference = best && bestScreenDistance <= maxScreenDistancePx
+          ? vertexReferenceFromIntersection(best)
+          : null;
       }
-      const best = chooseBestEdgeIntersection(
-        filteredIntersections,
-        (intersection) => edgeScreenDistance(intersection, clientX, clientY)
-      );
-      const bestScreenDistance = best ? edgeScreenDistance(best, clientX, clientY) : Infinity;
-      const reference = best && bestScreenDistance <= maxScreenDistancePx
-        ? vertexReferenceFromIntersection(best)
-        : null;
       if (reference) {
         return {
           reference,

--- a/.agents/skills/cad/explorer/components/explorer/hooks/useExplorerPicking.js
+++ b/.agents/skills/cad/explorer/components/explorer/hooks/useExplorerPicking.js
@@ -635,10 +635,13 @@ export function useExplorerPicking({
       const pointIndex = Number(intersection?.index);
       const vertexIds = intersection?.object?.userData?.vertexIds;
       const rowIndex = Number.isInteger(pointIndex) ? Number(vertexIds?.[pointIndex]) : NaN;
-      if (!Number.isInteger(rowIndex)) {
+      const directReference = Number.isInteger(pointIndex)
+        ? intersection?.object?.userData?.vertexReferences?.[pointIndex] || null
+        : null;
+      if (!Number.isInteger(rowIndex) && !directReference) {
         return null;
       }
-      const reference = selectorRuntimeRef.current?.vertexReferenceByRowIndex?.get?.(rowIndex) || null;
+      const reference = selectorRuntimeRef.current?.vertexReferenceByRowIndex?.get?.(rowIndex) || directReference || null;
       const referenceId = String(reference?.id || "").trim();
       const allowedVertexReferenceIds = allowedVertexReferenceIdsRef.current;
       if (!referenceId || (allowedVertexReferenceIds.size && !allowedVertexReferenceIds.has(referenceId))) {

--- a/.agents/skills/cad/explorer/components/workbench/CadWorkspaceTopBar.js
+++ b/.agents/skills/cad/explorer/components/workbench/CadWorkspaceTopBar.js
@@ -60,6 +60,9 @@ function fileSheetLabel(fileSheetKind) {
   if (fileSheetKind === "stepAssembly") {
     return "assembly sheet";
   }
+  if (fileSheetKind === "stepPart") {
+    return "measure sheet";
+  }
   return "file sheet";
 }
 

--- a/.agents/skills/cad/explorer/components/workbench/FloatingToolBar.js
+++ b/.agents/skills/cad/explorer/components/workbench/FloatingToolBar.js
@@ -4,7 +4,8 @@ import {
   Download,
   MousePointer2,
   Play,
-  PenTool
+  PenTool,
+  Ruler
 } from "lucide-react";
 import { RENDER_FORMAT } from "../../lib/workbench/constants";
 import { TooltipProvider } from "../ui/tooltip";
@@ -19,6 +20,8 @@ function DesktopFloatingToolBar({
   renderFormat,
   floatingCadToolbarPosition,
   selectionToolActive,
+  measureToolAvailable = false,
+  measureToolActive = false,
   referenceSelectionPending = false,
   referenceSelectionUnavailable = false,
   urdfPosePickerAvailable = false,
@@ -48,6 +51,7 @@ function DesktopFloatingToolBar({
   const meshOnlyMode = stlMode || renderFormat === RENDER_FORMAT.THREE_MF;
   const captureDisabled = explorerLoading || (dxfMode ? !selectedDxfData : !selectedMeshData);
   const selectDisabled = explorerLoading || !selectedMeshData || referenceSelectionPending || referenceSelectionUnavailable;
+  const measureDisabled = !measureToolAvailable || selectDisabled;
   const posePickerDisabled = explorerLoading || !selectedMeshData || !urdfPosePickerAvailable;
   const selectLabel = referenceSelectionUnavailable
     ? "Selectable topology unavailable"
@@ -74,6 +78,16 @@ function DesktopFloatingToolBar({
                     aria-pressed={selectionToolActive}
                   >
                     <MousePointer2 className="size-3.5" strokeWidth={2} aria-hidden="true" />
+                  </ToolbarButton>
+
+                  <ToolbarButton
+                    label="Measure"
+                    active={measureToolActive}
+                    onClick={() => handleSelectTabToolMode("measure")}
+                    disabled={measureDisabled}
+                    aria-pressed={measureToolActive}
+                  >
+                    <Ruler className="size-3.5" strokeWidth={2} aria-hidden="true" />
                   </ToolbarButton>
 
                   <ToolbarButton

--- a/.agents/skills/cad/explorer/components/workbench/StepPartInfoFileSheet.js
+++ b/.agents/skills/cad/explorer/components/workbench/StepPartInfoFileSheet.js
@@ -1,0 +1,315 @@
+import { useMemo } from "react";
+import { Ruler, Trash2 } from "lucide-react";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from "../ui/accordion";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import {
+  formatNumber,
+  measurementsForReferences
+} from "../../lib/measurements/measureTopology";
+import FileSheet from "./FileSheet";
+
+const compactButtonClasses = "h-8 px-2 text-xs";
+const compactInputClasses = "h-8 text-[11px] md:text-[11px]";
+const fieldLabelClasses = "block text-xs font-medium text-muted-foreground";
+
+const DENSITY_PRESETS = [
+  { label: "PLA", value: 1.24 },
+  { label: "Aluminum", value: 2.7 },
+  { label: "Steel", value: 7.85 },
+  { label: "Acrylic", value: 1.18 },
+  { label: "Wood", value: 0.7 },
+  { label: "MDF", value: 0.75 }
+];
+
+function finiteNumber(value) {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+}
+
+function boundsDimensions(bounds) {
+  const min = Array.isArray(bounds?.min) ? bounds.min : null;
+  const max = Array.isArray(bounds?.max) ? bounds.max : null;
+  if (!min || !max || min.length < 3 || max.length < 3) {
+    return null;
+  }
+  const dimensions = [
+    Number(max[0]) - Number(min[0]),
+    Number(max[1]) - Number(min[1]),
+    Number(max[2]) - Number(min[2])
+  ];
+  return dimensions.every(Number.isFinite) ? dimensions : null;
+}
+
+function mergeBounds(boundsList) {
+  const normalizedBounds = (Array.isArray(boundsList) ? boundsList : [])
+    .filter((bounds) => Array.isArray(bounds?.min) && Array.isArray(bounds?.max));
+  if (!normalizedBounds.length) {
+    return null;
+  }
+  const min = [Infinity, Infinity, Infinity];
+  const max = [-Infinity, -Infinity, -Infinity];
+  for (const bounds of normalizedBounds) {
+    for (let index = 0; index < 3; index += 1) {
+      const minValue = Number(bounds.min[index]);
+      const maxValue = Number(bounds.max[index]);
+      if (!Number.isFinite(minValue) || !Number.isFinite(maxValue)) {
+        continue;
+      }
+      min[index] = Math.min(min[index], minValue);
+      max[index] = Math.max(max[index], maxValue);
+    }
+  }
+  return min.every(Number.isFinite) && max.every(Number.isFinite) ? { min, max } : null;
+}
+
+function partPropertiesForRuntime(selectorRuntime, selectedMeshData) {
+  const shapes = Array.isArray(selectorRuntime?.shapes) ? selectorRuntime.shapes : [];
+  const solidShapes = shapes.filter((shape) => String(shape?.kind || "").trim().toLowerCase() === "solid");
+  const measuredShapes = solidShapes.length ? solidShapes : shapes;
+  const volumeValues = measuredShapes.map((shape) => finiteNumber(shape?.volume)).filter((value) => value !== null);
+  const areaValues = measuredShapes.map((shape) => finiteNumber(shape?.area)).filter((value) => value !== null);
+  const shapeBounds = measuredShapes.map((shape) => shape?.bbox).filter(Boolean);
+  return {
+    volume: volumeValues.length ? volumeValues.reduce((sum, value) => sum + value, 0) : null,
+    surfaceArea: areaValues.length ? areaValues.reduce((sum, value) => sum + value, 0) : null,
+    bounds: mergeBounds(shapeBounds) || selectorRuntime?.bbox || selectedMeshData?.bounds || null
+  };
+}
+
+function formatMass(grams) {
+  const numericGrams = finiteNumber(grams);
+  if (numericGrams === null) {
+    return "-";
+  }
+  if (Math.abs(numericGrams) >= 1000) {
+    return `${formatNumber(numericGrams / 1000, 3)} kg`;
+  }
+  return `${formatNumber(numericGrams, 2)} g`;
+}
+
+function MetricRow({ label, value }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md bg-[var(--ui-panel-muted)] px-2 py-1.5">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="min-w-0 truncate text-right text-xs font-semibold text-[var(--ui-text)]">{value}</span>
+    </div>
+  );
+}
+
+function UnitValue({ value, unit = "mm", exponent = "" }) {
+  if (value === "-") {
+    return "-";
+  }
+  return (
+    <>
+      {value} {unit}
+      {exponent ? <sup className="text-[0.62em] leading-none">{exponent}</sup> : null}
+    </>
+  );
+}
+
+function MeasurementValue({ measurement }) {
+  const value = formatNumber(measurement?.value);
+  if (!value) {
+    return "-";
+  }
+  if (measurement.unit === "deg") {
+    return <>{value} deg</>;
+  }
+  if (measurement.unit === "mm2") {
+    return <UnitValue value={value} unit="mm" exponent="2" />;
+  }
+  if (measurement.unit === "mm3") {
+    return <UnitValue value={value} unit="mm" exponent="3" />;
+  }
+  return <UnitValue value={value} unit={measurement.unit || "mm"} />;
+}
+
+function MeasurementRow({ measurement }) {
+  return (
+    <div className="rounded-md border border-sidebar-border bg-[var(--ui-panel-muted)] px-2 py-1.5">
+      <div className="flex items-start justify-between gap-2">
+        <p className="min-w-0 truncate text-xs font-semibold text-[var(--ui-text)]">{measurement.title}</p>
+        <p className="shrink-0 text-xs font-semibold text-[var(--ui-text)]">
+          <MeasurementValue measurement={measurement} />
+        </p>
+      </div>
+      {measurement.detail ? (
+        <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{measurement.detail}</p>
+      ) : null}
+    </div>
+  );
+}
+
+export default function StepPartInfoFileSheet({
+  open,
+  isDesktop,
+  width,
+  onStartResize,
+  selectedEntry,
+  selectedMeshData,
+  selectorRuntime,
+  selectedReferences,
+  density,
+  onDensityChange,
+  history,
+  onClearHistory
+}) {
+  const selectedReferenceRows = Array.isArray(selectedReferences) ? selectedReferences : [];
+  const selectionMeasurements = useMemo(
+    () => measurementsForReferences(selectedReferenceRows, selectorRuntime),
+    [selectedReferenceRows, selectorRuntime]
+  );
+  const properties = useMemo(
+    () => partPropertiesForRuntime(selectorRuntime, selectedMeshData),
+    [selectedMeshData, selectorRuntime]
+  );
+  const dimensions = boundsDimensions(properties.bounds);
+  const volume = finiteNumber(properties.volume);
+  const surfaceArea = finiteNumber(properties.surfaceArea);
+  const densityValue = finiteNumber(density);
+  const massGrams = volume !== null && densityValue !== null ? (volume / 1000) * densityValue : null;
+  const densityText = String(density ?? "");
+  const historyRows = Array.isArray(history) ? history : [];
+  const fileLabel = String(selectedEntry?.file || selectedEntry?.label || selectedEntry?.name || "Part").trim();
+  const dimensionText = dimensions
+    ? `${formatNumber(dimensions[0])} x ${formatNumber(dimensions[1])} x ${formatNumber(dimensions[2])} mm`
+    : "-";
+
+  return (
+    <FileSheet
+      open={open}
+      title="Measure"
+      isDesktop={isDesktop}
+      width={width}
+      onStartResize={onStartResize}
+    >
+      <Accordion type="multiple" defaultValue={["selection", "properties", "history"]} className="text-sm">
+        <AccordionItem value="selection">
+          <AccordionTrigger>Measure</AccordionTrigger>
+          <AccordionContent>
+            <div className="space-y-2 px-3 py-2">
+              {selectedReferenceRows.length ? (
+                <div className="rounded-md border border-sidebar-border bg-[var(--ui-panel-muted)] px-2 py-2">
+                  <p className="truncate text-xs font-semibold text-[var(--ui-text)]">
+                    {selectedReferenceRows.length === 1
+                      ? selectedReferenceRows[0]?.label || "Selected reference"
+                      : `${selectedReferenceRows.length} references`}
+                  </p>
+                  {selectedReferenceRows.length === 1 && selectedReferenceRows[0]?.summary ? (
+                    <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{selectedReferenceRows[0].summary}</p>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {selectionMeasurements.map((measurement) => (
+                <MeasurementRow
+                  key={`${measurement.kind}:${measurement.referenceIds.join(",")}:${measurement.value}`}
+                  measurement={measurement}
+                />
+              ))}
+
+              {!selectionMeasurements.length ? (
+                <div className="flex items-center gap-2 rounded-md border border-dashed border-sidebar-border px-2 py-3 text-xs text-muted-foreground">
+                  <Ruler className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+                  <span>No active measurement</span>
+                </div>
+              ) : null}
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem value="properties">
+          <AccordionTrigger>Properties</AccordionTrigger>
+          <AccordionContent>
+            <div className="space-y-2 px-3 py-2">
+              <div className="rounded-md border border-sidebar-border bg-[var(--ui-panel-muted)] px-2 py-2">
+                <p className="truncate text-xs font-semibold text-[var(--ui-text)]">{fileLabel}</p>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">STEP topology</p>
+              </div>
+
+              <MetricRow label="Bounding box" value={dimensionText} />
+              <MetricRow label="Volume" value={<UnitValue value={volume === null ? "-" : formatNumber(volume)} unit="mm" exponent="3" />} />
+              <MetricRow label="Surface area" value={<UnitValue value={surfaceArea === null ? "-" : formatNumber(surfaceArea)} unit="mm" exponent="2" />} />
+              <MetricRow label="Mass" value={formatMass(massGrams)} />
+
+              <label className="block pt-1">
+                <span className={fieldLabelClasses}>
+                  Density g/cm<sup className="text-[0.62em] leading-none">3</sup>
+                </span>
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  className={`${compactInputClasses} mt-1.5`}
+                  value={densityText}
+                  onChange={(event) => onDensityChange?.(event.target.value)}
+                />
+              </label>
+
+              <div className="grid grid-cols-2 gap-1.5">
+                {DENSITY_PRESETS.map((preset) => (
+                  <Button
+                    key={preset.label}
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className={compactButtonClasses}
+                    onClick={() => onDensityChange?.(String(preset.value))}
+                    title={`${preset.value} g/cm3 estimate`}
+                  >
+                    {preset.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem value="history">
+          <AccordionTrigger>History</AccordionTrigger>
+          <AccordionContent>
+            <div className="space-y-2 px-3 py-2">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs text-muted-foreground">{historyRows.length} measurements</p>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className={compactButtonClasses}
+                  disabled={!historyRows.length}
+                  onClick={onClearHistory}
+                >
+                  <Trash2 className="h-3 w-3" strokeWidth={2} aria-hidden="true" />
+                  Clear
+                </Button>
+              </div>
+
+              <div className="space-y-1.5">
+                {historyRows.map((entry) => (
+                  <MeasurementRow key={entry.id} measurement={entry} />
+                ))}
+
+                {!historyRows.length ? (
+                  <div className="flex items-center gap-2 rounded-md border border-dashed border-sidebar-border px-2 py-3 text-xs text-muted-foreground">
+                    <Ruler className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+                    <span>No measurements yet</span>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    </FileSheet>
+  );
+}

--- a/.agents/skills/cad/explorer/lib/measurements/measurePoints.js
+++ b/.agents/skills/cad/explorer/lib/measurements/measurePoints.js
@@ -1,0 +1,202 @@
+function finitePoint3(value) {
+  if (!Array.isArray(value) || value.length < 3) {
+    return null;
+  }
+  const point = value.slice(0, 3).map((component) => Number(component));
+  return point.every(Number.isFinite) ? point : null;
+}
+
+function roundedPointKey(point) {
+  return point.map((component) => String(Math.round(component * 100000) / 100000)).join(",");
+}
+
+function sameFinitePoint(a, b) {
+  return !!(a && b) && Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]) <= 1e-7;
+}
+
+function typedArrayLength(value) {
+  return Number.isFinite(Number(value?.length)) ? Number(value.length) : 0;
+}
+
+function uniqueStringList(values) {
+  const seen = new Set();
+  const result = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const normalizedValue = String(value || "").trim();
+    if (!normalizedValue || seen.has(normalizedValue)) {
+      continue;
+    }
+    seen.add(normalizedValue);
+    result.push(normalizedValue);
+  }
+  return result;
+}
+
+function pointFromProxyPosition(positions, pointIndex) {
+  const offset = Number(pointIndex) * 3;
+  if (!Number.isInteger(offset) || offset < 0 || offset + 2 >= typedArrayLength(positions)) {
+    return null;
+  }
+  return finitePoint3([positions[offset], positions[offset + 1], positions[offset + 2]]);
+}
+
+function edgeProxyPoints(reference, selectorRuntime) {
+  const proxy = selectorRuntime?.proxy || {};
+  const positions = proxy.edgePositions;
+  const indices = proxy.edgeIndices;
+  const edgeIds = proxy.edgeIds;
+  if (!(positions instanceof Float32Array) || !(indices instanceof Uint32Array)) {
+    return [];
+  }
+
+  const pickData = reference?.pickData || {};
+  const segmentStart = Math.max(0, Number(pickData.segmentStart || 0));
+  const segmentCount = Math.max(0, Number(pickData.segmentCount || 0));
+  const rowIndex = pickData.rowIndex === null || pickData.rowIndex === undefined
+    ? NaN
+    : Number(pickData.rowIndex);
+  const points = [];
+  const appendPoint = (point) => {
+    if (!point) {
+      return;
+    }
+    const previous = points[points.length - 1];
+    if (!previous || !sameFinitePoint(previous, point)) {
+      points.push(point);
+    }
+  };
+  const appendSegment = (segmentIndex) => {
+    const firstPointIndex = indices[segmentIndex * 2];
+    const secondPointIndex = indices[(segmentIndex * 2) + 1];
+    appendPoint(pointFromProxyPosition(positions, firstPointIndex));
+    appendPoint(pointFromProxyPosition(positions, secondPointIndex));
+  };
+
+  if (segmentCount > 0 && Number.isFinite(segmentStart)) {
+    const end = Math.min(segmentStart + segmentCount, Math.floor(typedArrayLength(indices) / 2));
+    for (let segmentIndex = segmentStart; segmentIndex < end; segmentIndex += 1) {
+      appendSegment(segmentIndex);
+    }
+    return points;
+  }
+
+  if (Number.isInteger(rowIndex) && edgeIds) {
+    for (let segmentIndex = 0; segmentIndex < typedArrayLength(edgeIds); segmentIndex += 1) {
+      if (Number(edgeIds[segmentIndex]) === rowIndex) {
+        appendSegment(segmentIndex);
+      }
+    }
+  }
+
+  return points;
+}
+
+function addMeasurePointReference(pointMap, {
+  reference,
+  center,
+  measurePointKind,
+  selectorSuffix,
+  summary,
+  radius = null
+}) {
+  const point = finitePoint3(center);
+  if (!point) {
+    return;
+  }
+  const pickData = reference?.pickData || {};
+  const partId = String(reference?.partId || "").trim();
+  const key = `${partId}|${roundedPointKey(point)}`;
+  const adjacentSelectors = uniqueStringList([
+    reference?.displaySelector,
+    reference?.normalizedSelector,
+    ...(Array.isArray(pickData.adjacentSelectors) ? pickData.adjacentSelectors : [])
+  ]);
+  const existing = pointMap.get(key);
+  if (existing) {
+    existing.pickData.adjacentSelectors = uniqueStringList([
+      ...existing.pickData.adjacentSelectors,
+      ...adjacentSelectors
+    ]);
+    existing.pickData.sourceReferenceIds = uniqueStringList([
+      ...existing.pickData.sourceReferenceIds,
+      reference?.id
+    ]);
+    return;
+  }
+  const sourceSelector = String(reference?.displaySelector || reference?.normalizedSelector || reference?.id || "").trim();
+  const normalizedSuffix = String(selectorSuffix || measurePointKind || "point").trim();
+  const sourceId = String(reference?.id || key).trim();
+  pointMap.set(key, {
+    id: `measure-point|${sourceId}|${normalizedSuffix}`,
+    selectorType: "vertex",
+    normalizedSelector: sourceSelector ? `${sourceSelector}:${normalizedSuffix}` : `measure-point:${key}`,
+    displaySelector: sourceSelector ? `${sourceSelector}:${normalizedSuffix}` : "measure point",
+    label: sourceSelector ? `${summary} ${sourceSelector}` : summary,
+    summary,
+    shortSummary: summary,
+    copyText: reference?.copyText || "",
+    partId: reference?.partId || "",
+    occurrenceId: reference?.occurrenceId || "",
+    shapeId: reference?.shapeId || "",
+    rowIndex: null,
+    pickData: {
+      selectorType: "vertex",
+      kind: "measure-point",
+      measurePointKind,
+      sourceReferenceId: reference?.id || "",
+      sourceReferenceIds: uniqueStringList([reference?.id]),
+      sourceSelectorType: reference?.selectorType || "",
+      sourceCurveType: pickData.curveType || "",
+      center: point,
+      radius: Number.isFinite(Number(radius)) ? Number(radius) : null,
+      adjacentSelectors,
+      transform: pickData.transform || null
+    }
+  });
+}
+
+export function buildMeasurePointReferences(edgeReferences, selectorRuntime) {
+  const pointMap = new Map();
+  for (const reference of Array.isArray(edgeReferences) ? edgeReferences : []) {
+    if (String(reference?.selectorType || "").trim().toLowerCase() !== "edge") {
+      continue;
+    }
+    const pickData = reference?.pickData || {};
+    const curveType = String(pickData.curveType || "").trim().toLowerCase();
+    const params = pickData.params || {};
+    const radius = Number(params.radius);
+    if (Number.isFinite(radius) && radius > 0 && (curveType.includes("circle") || curveType.includes("arc"))) {
+      addMeasurePointReference(pointMap, {
+        reference,
+        center: finitePoint3(params.center) || finitePoint3(pickData.center),
+        measurePointKind: "circle-center",
+        selectorSuffix: "center",
+        summary: "Circle center",
+        radius
+      });
+    }
+
+    const proxyPoints = edgeProxyPoints(reference, selectorRuntime);
+    if (proxyPoints.length >= 2 && (!curveType.includes("circle") || curveType.includes("arc"))) {
+      const startPoint = proxyPoints[0];
+      const endPoint = proxyPoints[proxyPoints.length - 1];
+      addMeasurePointReference(pointMap, {
+        reference,
+        center: startPoint,
+        measurePointKind: "edge-endpoint",
+        selectorSuffix: "start",
+        summary: "Edge endpoint"
+      });
+      if (!sameFinitePoint(startPoint, endPoint)) {
+        addMeasurePointReference(pointMap, {
+          reference,
+          center: endPoint,
+          measurePointKind: "edge-endpoint",
+          selectorSuffix: "end",
+          summary: "Edge endpoint"
+        });
+      }
+    }
+  }
+  return [...pointMap.values()];
+}

--- a/.agents/skills/cad/explorer/lib/measurements/measurePoints.js
+++ b/.agents/skills/cad/explorer/lib/measurements/measurePoints.js
@@ -1,8 +1,8 @@
 function finitePoint3(value) {
-  if (!Array.isArray(value) || value.length < 3) {
+  if (!(Array.isArray(value) || ArrayBuffer.isView(value)) || value.length < 3) {
     return null;
   }
-  const point = value.slice(0, 3).map((component) => Number(component));
+  const point = Array.from(value.slice(0, 3), (component) => Number(component));
   return point.every(Number.isFinite) ? point : null;
 }
 
@@ -45,7 +45,7 @@ function edgeProxyPoints(reference, selectorRuntime) {
   const positions = proxy.edgePositions;
   const indices = proxy.edgeIndices;
   const edgeIds = proxy.edgeIds;
-  if (!(positions instanceof Float32Array) || !(indices instanceof Uint32Array)) {
+  if (!ArrayBuffer.isView(positions) || !ArrayBuffer.isView(indices)) {
     return [];
   }
 

--- a/.agents/skills/cad/explorer/lib/measurements/measurePoints.test.js
+++ b/.agents/skills/cad/explorer/lib/measurements/measurePoints.test.js
@@ -23,6 +23,23 @@ test("creates a client-side measure point for a circular edge center", () => {
   assert.equal(points[0].pickData.measurePointKind, "circle-center");
 });
 
+test("accepts typed-array circle centers from selector metadata", () => {
+  const points = buildMeasurePointReferences([{
+    id: "edge-circle",
+    selectorType: "edge",
+    displaySelector: "models/part.step#edge[4]",
+    normalizedSelector: "models/part.step#edge[4]",
+    pickData: {
+      curveType: "circle",
+      center: new Float32Array([1, 2, 3]),
+      params: { radius: 5 }
+    }
+  }]);
+
+  assert.equal(points.length, 1);
+  assert.deepEqual(points[0].pickData.center, [1, 2, 3]);
+});
+
 test("creates client-side measure points for edge endpoints from the selector proxy", () => {
   const selectorRuntime = {
     proxy: {

--- a/.agents/skills/cad/explorer/lib/measurements/measurePoints.test.js
+++ b/.agents/skills/cad/explorer/lib/measurements/measurePoints.test.js
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildMeasurePointReferences } from "./measurePoints.js";
+
+test("creates a client-side measure point for a circular edge center", () => {
+  const points = buildMeasurePointReferences([{
+    id: "edge-circle",
+    selectorType: "edge",
+    displaySelector: "models/part.step#edge[4]",
+    normalizedSelector: "models/part.step#edge[4]",
+    pickData: {
+      curveType: "circle",
+      center: [10, 20, 30],
+      params: { radius: 5 }
+    }
+  }]);
+
+  assert.equal(points.length, 1);
+  assert.equal(points[0].selectorType, "vertex");
+  assert.equal(points[0].summary, "Circle center");
+  assert.deepEqual(points[0].pickData.center, [10, 20, 30]);
+  assert.equal(points[0].pickData.measurePointKind, "circle-center");
+});
+
+test("creates client-side measure points for edge endpoints from the selector proxy", () => {
+  const selectorRuntime = {
+    proxy: {
+      edgePositions: new Float32Array([
+        0, 0, 0,
+        3, 4, 0
+      ]),
+      edgeIndices: new Uint32Array([0, 1]),
+      edgeIds: new Uint32Array([7])
+    }
+  };
+  const points = buildMeasurePointReferences([{
+    id: "edge-line",
+    selectorType: "edge",
+    displaySelector: "models/part.step#edge[7]",
+    normalizedSelector: "models/part.step#edge[7]",
+    pickData: {
+      curveType: "line",
+      rowIndex: 7,
+      params: {}
+    }
+  }], selectorRuntime);
+
+  assert.equal(points.length, 2);
+  assert.deepEqual(points.map((point) => point.pickData.center), [[0, 0, 0], [3, 4, 0]]);
+  assert.deepEqual(points.map((point) => point.pickData.measurePointKind), ["edge-endpoint", "edge-endpoint"]);
+});

--- a/.agents/skills/cad/explorer/lib/measurements/measureTopology.js
+++ b/.agents/skills/cad/explorer/lib/measurements/measureTopology.js
@@ -1,0 +1,416 @@
+const EPSILON = 1e-9;
+
+function finiteNumber(value) {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+}
+
+function lower(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+export function point3(value) {
+  if (!Array.isArray(value) || value.length < 3) {
+    return null;
+  }
+  const point = value.slice(0, 3).map((component) => Number(component));
+  return point.every(Number.isFinite) ? point : null;
+}
+
+function vector3(value) {
+  const vector = point3(value);
+  if (!vector) {
+    return null;
+  }
+  const vectorLength = Math.hypot(vector[0], vector[1], vector[2]);
+  if (vectorLength <= EPSILON) {
+    return null;
+  }
+  return [vector[0] / vectorLength, vector[1] / vectorLength, vector[2] / vectorLength];
+}
+
+function distanceBetweenPoints(a, b) {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+function samePoint(a, b) {
+  return distanceBetweenPoints(a, b) <= EPSILON;
+}
+
+export function formatNumber(value, digits = 3) {
+  const numericValue = finiteNumber(value);
+  if (numericValue === null) {
+    return "";
+  }
+  const rounded = Math.round(numericValue * (10 ** digits)) / (10 ** digits);
+  return String(Object.is(rounded, -0) ? 0 : rounded);
+}
+
+export function formatPoint(point) {
+  const normalizedPoint = point3(point);
+  if (!normalizedPoint) {
+    return "";
+  }
+  return normalizedPoint.map((component) => formatNumber(component)).join(", ");
+}
+
+export function formatMeasurementValue(value, unit = "mm") {
+  const formatted = formatNumber(value);
+  if (!formatted) {
+    return "";
+  }
+  if (unit === "deg") {
+    return `${formatted} deg`;
+  }
+  if (unit === "mm2") {
+    return `${formatted} mm^2`;
+  }
+  if (unit === "mm3") {
+    return `${formatted} mm^3`;
+  }
+  return `${formatted} ${unit || "mm"}`;
+}
+
+function measurementResult({
+  kind,
+  title,
+  value,
+  unit = "mm",
+  detail = "",
+  referenceIds = []
+}) {
+  const numericValue = finiteNumber(value);
+  if (numericValue === null) {
+    return null;
+  }
+  return {
+    kind,
+    title,
+    value: numericValue,
+    unit,
+    detail: String(detail || "").trim(),
+    referenceIds: referenceIds.map((id) => String(id || "").trim()).filter(Boolean)
+  };
+}
+
+function typedLength(value) {
+  return Number.isFinite(Number(value?.length)) ? Number(value.length) : 0;
+}
+
+function pointFromProxyPosition(positions, pointIndex) {
+  const offset = Number(pointIndex) * 3;
+  if (!Number.isInteger(offset) || offset < 0 || offset + 2 >= typedLength(positions)) {
+    return null;
+  }
+  return point3([positions[offset], positions[offset + 1], positions[offset + 2]]);
+}
+
+function edgeProxyPoints(reference, selectorRuntime) {
+  const proxy = selectorRuntime?.proxy || {};
+  const positions = proxy.edgePositions;
+  const indices = proxy.edgeIndices;
+  const edgeIds = proxy.edgeIds;
+  if (!positions || !indices) {
+    return [];
+  }
+
+  const pickData = reference?.pickData || {};
+  const segmentStart = Math.max(0, Number(pickData.segmentStart || 0));
+  const segmentCount = Math.max(0, Number(pickData.segmentCount || 0));
+  const rowIndex = finiteNumber(pickData.rowIndex);
+  const points = [];
+
+  const appendPoint = (point) => {
+    if (!point) {
+      return;
+    }
+    const previous = points[points.length - 1];
+    if (!previous || !samePoint(previous, point)) {
+      points.push(point);
+    }
+  };
+
+  const appendSegment = (segmentIndex) => {
+    const firstPointIndex = indices[segmentIndex * 2];
+    const secondPointIndex = indices[(segmentIndex * 2) + 1];
+    appendPoint(pointFromProxyPosition(positions, firstPointIndex));
+    appendPoint(pointFromProxyPosition(positions, secondPointIndex));
+  };
+
+  if (segmentCount > 0 && Number.isFinite(segmentStart)) {
+    const end = Math.min(segmentStart + segmentCount, Math.floor(typedLength(indices) / 2));
+    for (let segmentIndex = segmentStart; segmentIndex < end; segmentIndex += 1) {
+      appendSegment(segmentIndex);
+    }
+    return points;
+  }
+
+  if (rowIndex !== null && edgeIds) {
+    for (let segmentIndex = 0; segmentIndex < typedLength(edgeIds); segmentIndex += 1) {
+      if (Number(edgeIds[segmentIndex]) === rowIndex) {
+        appendSegment(segmentIndex);
+      }
+    }
+  }
+
+  return points;
+}
+
+function midpointFromPoints(points) {
+  if (!Array.isArray(points) || !points.length) {
+    return null;
+  }
+  const first = points[0];
+  const last = points[points.length - 1];
+  if (!first || !last) {
+    return null;
+  }
+  return [
+    (first[0] + last[0]) / 2,
+    (first[1] + last[1]) / 2,
+    (first[2] + last[2]) / 2
+  ];
+}
+
+function edgeEndpoints(reference, selectorRuntime) {
+  const points = edgeProxyPoints(reference, selectorRuntime);
+  if (points.length < 2) {
+    return null;
+  }
+  return [points[0], points[points.length - 1]];
+}
+
+function inferredPoint(reference, selectorRuntime) {
+  const selectorType = lower(reference?.selectorType);
+  if (selectorType === "edge") {
+    return point3(reference?.pickData?.center) || midpointFromPoints(edgeProxyPoints(reference, selectorRuntime));
+  }
+  if (selectorType === "face" || selectorType === "shape") {
+    return point3(reference?.pickData?.center);
+  }
+  return point3(reference?.pickData?.center);
+}
+
+function lineDirection(reference, selectorRuntime) {
+  if (lower(reference?.selectorType) !== "edge") {
+    return null;
+  }
+  const curveType = lower(reference?.pickData?.curveType);
+  if (curveType && curveType !== "line") {
+    return null;
+  }
+  const paramDirection = vector3(reference?.pickData?.params?.direction);
+  if (paramDirection) {
+    return paramDirection;
+  }
+  const endpoints = edgeEndpoints(reference, selectorRuntime);
+  if (!endpoints) {
+    return null;
+  }
+  return vector3([
+    endpoints[1][0] - endpoints[0][0],
+    endpoints[1][1] - endpoints[0][1],
+    endpoints[1][2] - endpoints[0][2]
+  ]);
+}
+
+function faceNormal(reference) {
+  if (lower(reference?.selectorType) !== "face") {
+    return null;
+  }
+  const surfaceType = lower(reference?.pickData?.surfaceType);
+  if (surfaceType && surfaceType !== "plane") {
+    return null;
+  }
+  return vector3(reference?.pickData?.normal) || vector3(reference?.pickData?.params?.axis);
+}
+
+function acuteAngleBetweenVectors(a, b) {
+  if (!a || !b) {
+    return null;
+  }
+  const cosine = Math.min(Math.max(Math.abs((a[0] * b[0]) + (a[1] * b[1]) + (a[2] * b[2])), -1), 1);
+  return (Math.acos(cosine) * 180) / Math.PI;
+}
+
+function angleBetweenLineEdges(a, b, selectorRuntime) {
+  return acuteAngleBetweenVectors(
+    lineDirection(a, selectorRuntime),
+    lineDirection(b, selectorRuntime)
+  );
+}
+
+function angleBetweenPlanarFaces(a, b) {
+  return acuteAngleBetweenVectors(faceNormal(a), faceNormal(b));
+}
+
+function referenceRadius(reference) {
+  const params = reference?.pickData?.params || {};
+  return finiteNumber(params.radius);
+}
+
+function measurementsForSingleReference(reference, selectorRuntime) {
+  const selectorType = lower(reference?.selectorType);
+  const pickData = reference?.pickData || {};
+  const referenceIds = [reference?.id];
+  const results = [];
+
+  if (selectorType === "edge") {
+    const length = finiteNumber(pickData.length);
+    const radius = referenceRadius(reference);
+    const center = inferredPoint(reference, selectorRuntime);
+    const curveType = lower(pickData.curveType);
+    const centerDetail = center ? `Center ${formatPoint(center)}` : "";
+    const midpointDetail = center ? `Midpoint ${formatPoint(center)}` : "";
+
+    if (radius !== null && (curveType.includes("circle") || curveType.includes("arc"))) {
+      results.push(measurementResult({
+        kind: "radius",
+        title: "Radius",
+        value: radius,
+        detail: [`Diameter ${formatMeasurementValue(radius * 2)}`, centerDetail].filter(Boolean).join(" | "),
+        referenceIds
+      }));
+    }
+
+    if (length !== null) {
+      results.push(measurementResult({
+        kind: "length",
+        title: "Edge length",
+        value: length,
+        detail: midpointDetail,
+        referenceIds
+      }));
+    }
+  }
+
+  if (selectorType === "face") {
+    const radius = referenceRadius(reference);
+    const area = finiteNumber(pickData.area);
+    const surfaceType = lower(pickData.surfaceType);
+
+    if (radius !== null && (surfaceType.includes("cylinder") || surfaceType.includes("sphere"))) {
+      results.push(measurementResult({
+        kind: "radius",
+        title: "Radius",
+        value: radius,
+        detail: `Diameter ${formatMeasurementValue(radius * 2)}`,
+        referenceIds
+      }));
+    }
+
+    if (area !== null) {
+      results.push(measurementResult({
+        kind: "area",
+        title: "Surface area",
+        value: area,
+        unit: "mm2",
+        referenceIds
+      }));
+    }
+  }
+
+  if (selectorType === "shape") {
+    const volume = finiteNumber(pickData.volume);
+    const area = finiteNumber(pickData.area);
+    if (volume !== null) {
+      results.push(measurementResult({
+        kind: "volume",
+        title: "Volume",
+        value: volume,
+        unit: "mm3",
+        referenceIds
+      }));
+    }
+    if (area !== null) {
+      results.push(measurementResult({
+        kind: "area",
+        title: "Surface area",
+        value: area,
+        unit: "mm2",
+        referenceIds
+      }));
+    }
+  }
+
+  return results.filter(Boolean);
+}
+
+function measurementsForTwoReferences(references, selectorRuntime) {
+  const [first, second] = references;
+  const firstType = lower(first?.selectorType);
+  const secondType = lower(second?.selectorType);
+  const referenceIds = references.map((reference) => reference?.id);
+  const results = [];
+
+  if (firstType === "edge" && secondType === "edge") {
+    const angle = angleBetweenLineEdges(first, second, selectorRuntime);
+    if (angle !== null) {
+      results.push(measurementResult({
+        kind: "angle",
+        title: "Edge angle",
+        value: angle,
+        unit: "deg",
+        referenceIds
+      }));
+    }
+  }
+
+  if (firstType === "face" && secondType === "face") {
+    const angle = angleBetweenPlanarFaces(first, second);
+    if (angle !== null) {
+      results.push(measurementResult({
+        kind: "face-angle",
+        title: "Face angle",
+        value: angle,
+        unit: "deg",
+        referenceIds
+      }));
+    }
+  }
+
+  const firstPoint = inferredPoint(first, selectorRuntime);
+  const secondPoint = inferredPoint(second, selectorRuntime);
+  if (firstPoint && secondPoint) {
+    results.push(measurementResult({
+      kind: "point-distance",
+      title: firstType === "edge" && secondType === "edge" ? "Midpoint distance" : "Point distance",
+      value: distanceBetweenPoints(firstPoint, secondPoint),
+      detail: `${formatPoint(firstPoint)} to ${formatPoint(secondPoint)}`,
+      referenceIds
+    }));
+  }
+
+  return results.filter(Boolean);
+}
+
+export function measurementsForReferences(references, selectorRuntime = null) {
+  const normalizedReferences = (Array.isArray(references) ? references : []).filter(Boolean);
+  if (normalizedReferences.length === 1) {
+    return measurementsForSingleReference(normalizedReferences[0], selectorRuntime);
+  }
+  if (normalizedReferences.length === 2) {
+    return measurementsForTwoReferences(normalizedReferences, selectorRuntime);
+  }
+  return [];
+}
+
+export function measurementForReferences(references, selectorRuntime = null) {
+  return measurementsForReferences(references, selectorRuntime)[0] || null;
+}
+
+export function measurementKey(result) {
+  const numericValue = finiteNumber(result?.value);
+  if (numericValue === null) {
+    return "";
+  }
+  return [
+    result.kind || "",
+    result.unit || "mm",
+    formatNumber(numericValue),
+    ...(Array.isArray(result.referenceIds) ? result.referenceIds : [])
+  ].join("|");
+}

--- a/.agents/skills/cad/explorer/lib/measurements/measureTopology.test.js
+++ b/.agents/skills/cad/explorer/lib/measurements/measureTopology.test.js
@@ -146,6 +146,25 @@ test("reports midpoint distance for two selected edges without vertex selectors"
   assert.equal(distance.value, 13);
 });
 
+test("measures distance between client-side measure points", () => {
+  const result = measurementForReferences([
+    {
+      id: "p1",
+      selectorType: "vertex",
+      pickData: { kind: "measure-point", center: [0, 0, 0] }
+    },
+    {
+      id: "p2",
+      selectorType: "vertex",
+      pickData: { kind: "measure-point", center: [6, 8, 0] }
+    }
+  ]);
+
+  assert.equal(result.title, "Point distance");
+  assert.equal(result.value, 10);
+  assert.equal(result.detail, "0, 0, 0 to 6, 8, 0");
+});
+
 test("measures the acute angle between two planar faces", () => {
   const result = measurementForReferences([
     {

--- a/.agents/skills/cad/explorer/lib/measurements/measureTopology.test.js
+++ b/.agents/skills/cad/explorer/lib/measurements/measureTopology.test.js
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  measurementForReferences,
+  measurementsForReferences
+} from "./measureTopology.js";
+
+test("measures exact edge length from topology metadata", () => {
+  const result = measurementForReferences([{
+    id: "edge-1",
+    selectorType: "edge",
+    pickData: {
+      curveType: "line",
+      length: 12.5,
+      center: [1, 2, 3],
+      params: {}
+    }
+  }]);
+
+  assert.equal(result.title, "Edge length");
+  assert.equal(result.value, 12.5);
+  assert.equal(result.detail, "Midpoint 1, 2, 3");
+});
+
+test("measures radius from circular edge metadata", () => {
+  const results = measurementsForReferences([{
+    id: "edge-arc",
+    selectorType: "edge",
+    pickData: {
+      curveType: "circle",
+      length: 18.85,
+      center: [0, 0, 0],
+      params: { radius: 3 }
+    }
+  }]);
+
+  assert.equal(results[0].title, "Radius");
+  assert.equal(results[0].value, 3);
+  assert.equal(results[0].detail, "Diameter 6 mm | Center 0, 0, 0");
+  assert.equal(results[1].title, "Edge length");
+});
+
+test("measures radius from cylindrical face metadata", () => {
+  const result = measurementForReferences([{
+    id: "face-1",
+    selectorType: "face",
+    pickData: {
+      surfaceType: "cylinder",
+      params: { radius: 3 }
+    }
+  }]);
+
+  assert.equal(result.title, "Radius");
+  assert.equal(result.value, 3);
+  assert.equal(result.detail, "Diameter 6 mm");
+});
+
+test("measures surface area from face metadata", () => {
+  const result = measurementForReferences([{
+    id: "face-2",
+    selectorType: "face",
+    pickData: {
+      surfaceType: "plane",
+      area: 42.125,
+      params: {}
+    }
+  }]);
+
+  assert.equal(result.title, "Surface area");
+  assert.equal(result.value, 42.125);
+  assert.equal(result.unit, "mm2");
+});
+
+test("measures the acute angle between two line edges", () => {
+  const result = measurementForReferences([
+    {
+      id: "e1",
+      selectorType: "edge",
+      pickData: {
+        curveType: "line",
+        params: { direction: [1, 0, 0] }
+      }
+    },
+    {
+      id: "e2",
+      selectorType: "edge",
+      pickData: {
+        curveType: "line",
+        params: { direction: [0, 1, 0] }
+      }
+    }
+  ]);
+
+  assert.equal(result.title, "Edge angle");
+  assert.equal(result.unit, "deg");
+  assert.equal(result.value, 90);
+});
+
+test("measures line edge angle from proxy endpoints when vertices are absent", () => {
+  const selectorRuntime = {
+    proxy: {
+      edgePositions: new Float32Array([
+        0, 0, 0,
+        4, 0, 0,
+        0, 0, 0,
+        0, 3, 0
+      ]),
+      edgeIndices: new Uint32Array([0, 1, 2, 3]),
+      edgeIds: new Uint32Array([0, 1])
+    }
+  };
+  const result = measurementForReferences([
+    {
+      id: "e1",
+      selectorType: "edge",
+      pickData: { curveType: "line", rowIndex: 0, segmentStart: 0, segmentCount: 1, params: {} }
+    },
+    {
+      id: "e2",
+      selectorType: "edge",
+      pickData: { curveType: "line", rowIndex: 1, segmentStart: 1, segmentCount: 1, params: {} }
+    }
+  ], selectorRuntime);
+
+  assert.equal(result.title, "Edge angle");
+  assert.equal(result.value, 90);
+});
+
+test("reports midpoint distance for two selected edges without vertex selectors", () => {
+  const results = measurementsForReferences([
+    {
+      id: "e1",
+      selectorType: "edge",
+      pickData: { curveType: "line", center: [0, 0, 0], params: { direction: [1, 0, 0] } }
+    },
+    {
+      id: "e2",
+      selectorType: "edge",
+      pickData: { curveType: "line", center: [3, 4, 12], params: { direction: [1, 0, 0] } }
+    }
+  ]);
+
+  const distance = results.find((result) => result.kind === "point-distance");
+  assert.equal(distance.title, "Midpoint distance");
+  assert.equal(distance.value, 13);
+});
+
+test("measures the acute angle between two planar faces", () => {
+  const result = measurementForReferences([
+    {
+      id: "f1",
+      selectorType: "face",
+      pickData: {
+        surfaceType: "plane",
+        normal: [1, 0, 0]
+      }
+    },
+    {
+      id: "f2",
+      selectorType: "face",
+      pickData: {
+        surfaceType: "plane",
+        normal: [0, 0, 1]
+      }
+    }
+  ]);
+
+  assert.equal(result.title, "Face angle");
+  assert.equal(result.unit, "deg");
+  assert.equal(result.value, 90);
+});

--- a/.agents/skills/cad/explorer/lib/selectors/runtime.js
+++ b/.agents/skills/cad/explorer/lib/selectors/runtime.js
@@ -313,6 +313,12 @@ function buildReference({
     pickData: {
       selectorType,
       rowIndex,
+      kind: row.kind || "",
+      surfaceType: row.surfaceType || "",
+      curveType: row.curveType || "",
+      length: row.length ?? null,
+      area: row.area ?? null,
+      volume: row.volume ?? null,
       bbox: row.bbox || null,
       center: row.center || null,
       normal: row.normal || null,

--- a/.agents/skills/cad/explorer/lib/selectors/runtime.test.js
+++ b/.agents/skills/cad/explorer/lib/selectors/runtime.test.js
@@ -40,6 +40,8 @@ test("buildSelectorRuntime remaps source part rows onto an assembly occurrence",
 
   assert.deepEqual(faces.map((reference) => reference.displaySelector), ["o1.5.f1", "o1.5.f2"]);
   assert.equal(faces[1].copyText, "@cad[parts/root#o1.5.f2] plane area=1");
+  assert.equal(faces[1].pickData.surfaceType, "plane");
+  assert.equal(faces[1].pickData.area, 1);
 });
 
 test("buildSelectorRuntime remaps native occurrence prefixes onto assembly descendants", () => {

--- a/.agents/skills/cad/explorer/lib/workbench/constants.js
+++ b/.agents/skills/cad/explorer/lib/workbench/constants.js
@@ -23,6 +23,7 @@ export const RENDER_FORMAT = {
 
 export const TAB_TOOL_MODE = {
   REFERENCES: "references",
+  MEASURE: "measure",
   DRAW: "draw"
 };
 

--- a/.agents/skills/cad/explorer/lib/workbench/persistence.js
+++ b/.agents/skills/cad/explorer/lib/workbench/persistence.js
@@ -122,7 +122,13 @@ function normalizeDrawingTool(value) {
 
 function normalizeTabToolMode(value) {
   const normalized = normalizeString(value || TAB_TOOL_MODE.REFERENCES);
-  return normalized === TAB_TOOL_MODE.DRAW ? TAB_TOOL_MODE.DRAW : TAB_TOOL_MODE.REFERENCES;
+  if (normalized === TAB_TOOL_MODE.DRAW) {
+    return TAB_TOOL_MODE.DRAW;
+  }
+  if (normalized === TAB_TOOL_MODE.MEASURE) {
+    return TAB_TOOL_MODE.MEASURE;
+  }
+  return TAB_TOOL_MODE.REFERENCES;
 }
 
 function pointsEqualN(a, b, length) {

--- a/.agents/skills/cad/explorer/package.json
+++ b/.agents/skills/cad/explorer/package.json
@@ -6,7 +6,7 @@
     "dev": "vite dev",
     "dev:ensure": "node scripts/ensure-dev.mjs",
     "build": "vite build",
-    "test": "node --test --experimental-default-type=module lib/perspective.test.js lib/lookSettings.test.js lib/renderAssetClient.test.js lib/render/threeMfMeshData.test.js lib/render/glbMeshData.test.js lib/urdf/parseUrdf.test.js lib/urdf/kinematics.test.js lib/urdf/motion.test.js lib/urdf/jointAnimation.test.js lib/urdf/motionServerClient.test.js lib/dxf/parseDxf.test.js lib/workbench/sidebar.test.js lib/cadDirectoryScanner.test.mjs lib/explorer/sceneScale.test.js lib/explorerConfig.test.mjs lib/explorerServerInfo.test.mjs components/explorer/hooks/useExplorerPicking.test.js lib/assembly/meshData.test.js lib/selectors/runtime.test.js lib/measurements/measureTopology.test.js lib/async/concurrency.test.js lib/clipboard.test.js scripts/ensure-dev.test.mjs"
+    "test": "node --test --experimental-default-type=module lib/perspective.test.js lib/lookSettings.test.js lib/renderAssetClient.test.js lib/render/threeMfMeshData.test.js lib/render/glbMeshData.test.js lib/urdf/parseUrdf.test.js lib/urdf/kinematics.test.js lib/urdf/motion.test.js lib/urdf/jointAnimation.test.js lib/urdf/motionServerClient.test.js lib/dxf/parseDxf.test.js lib/workbench/sidebar.test.js lib/cadDirectoryScanner.test.mjs lib/explorer/sceneScale.test.js lib/explorerConfig.test.mjs lib/explorerServerInfo.test.mjs components/explorer/hooks/useExplorerPicking.test.js lib/assembly/meshData.test.js lib/selectors/runtime.test.js lib/measurements/measurePoints.test.js lib/measurements/measureTopology.test.js lib/async/concurrency.test.js lib/clipboard.test.js scripts/ensure-dev.test.mjs"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",

--- a/.agents/skills/cad/explorer/package.json
+++ b/.agents/skills/cad/explorer/package.json
@@ -6,7 +6,7 @@
     "dev": "vite dev",
     "dev:ensure": "node scripts/ensure-dev.mjs",
     "build": "vite build",
-    "test": "node --test --experimental-default-type=module lib/perspective.test.js lib/lookSettings.test.js lib/renderAssetClient.test.js lib/render/threeMfMeshData.test.js lib/render/glbMeshData.test.js lib/urdf/parseUrdf.test.js lib/urdf/kinematics.test.js lib/urdf/motion.test.js lib/urdf/jointAnimation.test.js lib/urdf/motionServerClient.test.js lib/dxf/parseDxf.test.js lib/workbench/sidebar.test.js lib/cadDirectoryScanner.test.mjs lib/explorer/sceneScale.test.js lib/explorerConfig.test.mjs lib/explorerServerInfo.test.mjs components/explorer/hooks/useExplorerPicking.test.js lib/assembly/meshData.test.js lib/selectors/runtime.test.js lib/async/concurrency.test.js lib/clipboard.test.js scripts/ensure-dev.test.mjs"
+    "test": "node --test --experimental-default-type=module lib/perspective.test.js lib/lookSettings.test.js lib/renderAssetClient.test.js lib/render/threeMfMeshData.test.js lib/render/glbMeshData.test.js lib/urdf/parseUrdf.test.js lib/urdf/kinematics.test.js lib/urdf/motion.test.js lib/urdf/jointAnimation.test.js lib/urdf/motionServerClient.test.js lib/dxf/parseDxf.test.js lib/workbench/sidebar.test.js lib/cadDirectoryScanner.test.mjs lib/explorer/sceneScale.test.js lib/explorerConfig.test.mjs lib/explorerServerInfo.test.mjs components/explorer/hooks/useExplorerPicking.test.js lib/assembly/meshData.test.js lib/selectors/runtime.test.js lib/measurements/measureTopology.test.js lib/async/concurrency.test.js lib/clipboard.test.js scripts/ensure-dev.test.mjs"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
While using the viewer, I found it a bit difficult to quickly double check dimensions and part properties. This measurement tool makes it easier to inspect files, debug generated CAD, and planning for 3D printing.

This adds a STEP measurement workflow to the CAD viewer.

Additions :
- A Measure toolbar mode for STEP files
- Topology based measurements for edge length, point-to-point distance, radius/diameter, face area, edge angle, and planar face angle
- A draggable in-view measurement callout anchored near the selected reference
- A Measure side sheet showing bounding box, volume, surface area, estimated mass, density presets, and measurement history
- Highlight rendering for active measurement references
- Node tests for the new measurement topology helpers

Notes:
- Measurement values are derived from available STEP selector/topology metadata.
- Angle measurements use the acute angle between line directions or planar face normals.
<img width="332" height="185" alt="image" src="https://github.com/user-attachments/assets/cb3d5b9e-d210-40af-9264-978143b73974" />
<img width="1771" height="1180" alt="image" src="https://github.com/user-attachments/assets/31648fab-b57c-4081-a16c-c00788f55ca9" />
<img width="609" height="288" alt="image" src="https://github.com/user-attachments/assets/7ede85cf-2bcf-4f99-a551-4ecbb5f90731" />
<img width="1002" height="480" alt="image" src="https://github.com/user-attachments/assets/62e47827-4150-4f52-a83e-2429ca71e7ea" />
<img width="405" height="1142" alt="image" src="https://github.com/user-attachments/assets/b114bf67-acd2-4004-9bf9-4943f470f874" />
<img width="2559" height="1184" alt="image" src="https://github.com/user-attachments/assets/8c94f232-88eb-4c62-bc42-8d56e31888a6" />
