### PR TITLE
Add OttoAuth buy parts integration

### DIFF
--- a/.agents/skills/cad/explorer/README.md
+++ b/.agents/skills/cad/explorer/README.md
@@ -59,11 +59,14 @@ Do not hand-edit package-local generated CAD assets during normal CAD or CAD Exp
 - `npm run dev` starts `vite dev`, scans `EXPLORER_ROOT_DIR` relative to the Vite process's current working directory, and updates the workspace when matching CAD files or per-STEP CAD Explorer assets are added, changed, or removed.
 - `EXPLORER_DEFAULT_FILE` can be set to a scan-root-relative file path, including extension, to open that entry by default when the URL has no `?file=`.
 - `EXPLORER_GITHUB_URL` sets the top-bar GitHub button target and defaults to `https://github.com/earthtojake/text-to-cad`.
+- `EXPLORER_OTTOAUTH_BASE_URL` sets the OttoAuth server used by the top-bar Buy Parts Now action and defaults to the local OttoAuth app on port `3000`. In Vite dev, CAD Explorer uses the simplified OttoAuth SDK flow: `/api/sdk/connect`, `/api/sdk/me`, `/api/sdk/local-agent`, `/api/sdk/files`, and `/api/sdk/checkout`.
+- The Buy Parts Now action checks OttoAuth login state through `/__ottoauth/me`. If the human is not signed in, the cart opens a **Connect OttoAuth Account** state. Pressing **Connect OttoAuth** goes through OttoAuth Connect and returns to CAD Explorer with the cart reopened. Local OttoAuth login works without Google in development; Google can be added later with OAuth credentials.
+- After connect, CAD Explorer asks OttoAuth for the signed-in human's `cad-explorer` linked agent credential and saves it to `.agents/ottoauth.local.json` plus `.agents/.env.ottoauth.local`. Before checkout, CAD Explorer uploads the current project CAD files to OttoAuth and submits the final order through the linked agent. The checkout payload uses OttoAuth signed file URLs, not CAD Explorer localhost URLs, so OttoAuth can provide the STEP/STL/etc. files to the supplier flow. OttoAuth deletes those uploaded CAD blobs after the order completes. The browser never receives the private key on order submission; the local Vite server reads it and submits the API order as the linked agent.
 - URDF CAD Explorer defaults and poses load from `.<urdf>/explorer.json`. In local Vite dev only, IK and path-planning controls load from optional `.<urdf>/robot-motion/explorer.json` and use a separately started local motion websocket server. Vite never starts Python or ROS.
 - In local Vite dev, the browser connects to `EXPLORER_ROBOT_MOTION_WS_URL` when set, otherwise `ws://127.0.0.1:8765/ws`; `?motionWs=` can override the websocket URL for a single browser session. Production builds disable motion server connections.
 - Start the motion server with `.agents/skills/robot-motion/scripts/run-motion-server.sh`. Plain URDF entries never contact the motion server.
 - `npm run build` scans `EXPLORER_ROOT_DIR`, defaulting to the Vite process's current working directory when unset or empty, and bakes that scan into the static app.
-- Production builds read `EXPLORER_DEFAULT_FILE`, `EXPLORER_GITHUB_URL`, `EXPLORER_ROOT_DIR`, and `EXPLORER_WORKSPACE_ROOT` at build time. If the build command runs from `.agents/skills/cad/explorer`, CAD Explorer falls back to the containing workspace root; set `EXPLORER_WORKSPACE_ROOT=/path/to/workspace` explicitly when your deployment builds from a different directory layout.
+- Production builds read `EXPLORER_DEFAULT_FILE`, `EXPLORER_GITHUB_URL`, `EXPLORER_OTTOAUTH_BASE_URL`, `EXPLORER_ROOT_DIR`, and `EXPLORER_WORKSPACE_ROOT` at build time. If the build command runs from `.agents/skills/cad/explorer`, CAD Explorer falls back to the containing workspace root; set `EXPLORER_WORKSPACE_ROOT=/path/to/workspace` explicitly when your deployment builds from a different directory layout.
 - `npm run build:app` runs an isolated verification build for CAD Explorer-only changes.
 - Regenerate CAD assets outside the CAD Explorer package before these commands when CAD assets need to change.
 
@@ -102,3 +105,21 @@ npm --prefix .agents/skills/cad/explorer run dev:ensure
 Then open:
 
 - `http://localhost:4178`
+
+## OttoAuth CLI
+
+Coding agents can generate the same CAD-aware OttoAuth payload from the command line:
+
+```bash
+npm --prefix .agents/skills/cad/explorer run ottoauth:buy-parts -- --asset-base-url http://127.0.0.1:4178 --file path/to/model.step
+```
+
+After the first OttoAuth Connect through the Buy Parts Now button, CAD Explorer saves
+the linked agent credential locally. The CLI uses that file automatically, or
+falls back to explicit `OTTOAUTH_AGENT_USERNAME` and `OTTOAUTH_PRIVATE_KEY` env
+vars:
+
+```bash
+OTTOAUTH_BASE_URL=http://127.0.0.1:3000 \
+npm --prefix .agents/skills/cad/explorer run ottoauth:buy-parts -- --submit --asset-base-url http://127.0.0.1:4178 --file path/to/model.step --supplier Xometry --supplier-url https://www.xometry.com/
+```

--- a/.agents/skills/cad/explorer/components/CadWorkspace.js
+++ b/.agents/skills/cad/explorer/components/CadWorkspace.js
@@ -7,6 +7,7 @@ import CadRenderPane from "./workbench/CadRenderPane";
 import DxfFileSheet from "./workbench/DxfFileSheet";
 import FileExplorerSidebar from "./workbench/FileExplorerSidebar";
 import LookSettingsPopover from "./workbench/LookSettingsPopover";
+import OttoAuthOrderDialog from "./workbench/OttoAuthOrderDialog";
 import StepAssemblyFileSheet from "./workbench/StepAssemblyFileSheet";
 import StatusToast from "./workbench/StatusToast";
 import UrdfFileSheet from "./workbench/UrdfFileSheet";
@@ -1172,6 +1173,7 @@ export default function CadWorkspace({
   const [hoveredListPartId, setHoveredListPartId] = useState("");
   const [hoveredModelPartId, setHoveredModelPartId] = useState("");
   const [copyStatus, setCopyStatus] = useState("");
+  const [ottoAuthStatus, setOttoAuthStatus] = useState("");
   const [stepUpdateInProgress, setStepUpdateInProgress] = useState(false);
   const [screenshotStatus, setScreenshotStatus] = useState("");
   const [persistenceStatus, setPersistenceStatus] = useState("");
@@ -1186,6 +1188,7 @@ export default function CadWorkspace({
   const [mobileFileSheetOpen, setMobileFileSheetOpen] = useState(false);
   const [desktopLookMenuOpen, setDesktopLookMenuOpen] = useState(false);
   const [mobileLookMenuOpen, setMobileLookMenuOpen] = useState(false);
+  const [ottoAuthDialogOpen, setOttoAuthDialogOpen] = useState(false);
   const [explorerAlertOpen, setExplorerAlertOpen] = useState(false);
   const [explorerRuntimeAlert, setExplorerRuntimeAlert] = useState(null);
   const [lookSettings, setLookSettings] = useState(readLookSettings);
@@ -4358,6 +4361,20 @@ export default function CadWorkspace({
     explorerLoading
   ]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const url = new URL(window.location.href);
+    if (url.searchParams.get("ottoauthCart") !== "1") {
+      return;
+    }
+    url.searchParams.delete("ottoauthCart");
+    window.history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+    setOttoAuthStatus("");
+    setOttoAuthDialogOpen(true);
+  }, []);
+
   const toggleDirectory = (directoryId) => {
     setExpandedDirectoryIds((current) => {
       const next = new Set(current);
@@ -4509,6 +4526,10 @@ export default function CadWorkspace({
           fileSheetKind={selectedFileSheetKind}
           fileSheetOpen={fileSheetOpen}
           onToggleFileSheet={handleToggleFileSheet}
+          onOpenOttoAuth={() => {
+            setOttoAuthStatus("");
+            setOttoAuthDialogOpen(true);
+          }}
         />
 
         <div className="pointer-events-none relative min-h-0 flex-1 overflow-hidden">
@@ -4659,17 +4680,30 @@ export default function CadWorkspace({
 
         <StatusToast
           copyStatus={copyStatus}
+          ottoAuthStatus={ottoAuthStatus}
           screenshotStatus={screenshotStatus}
           persistenceStatus={persistenceStatus}
           motionErrorStatus={motionErrorStatus}
           previewMode={previewMode}
           onClear={() => {
             setCopyStatus("");
+            setOttoAuthStatus("");
             setScreenshotStatus("");
             setPersistenceStatus("");
             setMotionErrorStatus("");
             lastPersistenceFailureKeyRef.current = "";
           }}
+        />
+
+        <OttoAuthOrderDialog
+          open={ottoAuthDialogOpen}
+          onOpenChange={setOttoAuthDialogOpen}
+          selectedEntry={selectedEntry}
+          catalogEntries={catalogEntries}
+          assemblyParts={isAssemblyView ? assemblyLeafParts : EMPTY_LIST}
+          selectedPartIds={selectedPartIds}
+          catalogRootDir={catalogRootDir}
+          onStatus={setOttoAuthStatus}
         />
 
         <ExplorerAlertDialog

--- a/.agents/skills/cad/explorer/components/ui/alert-dialog.jsx
+++ b/.agents/skills/cad/explorer/components/ui/alert-dialog.jsx
@@ -24,12 +24,13 @@ function AlertDialogPortal({
   return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
 }
 
-function AlertDialogOverlay({
+const AlertDialogOverlay = React.forwardRef(function AlertDialogOverlay({
   className,
   ...props
-}) {
+}, ref) {
   return (
     <AlertDialogPrimitive.Overlay
+      ref={ref}
       data-slot="alert-dialog-overlay"
       className={cn(
         "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
@@ -37,16 +38,17 @@ function AlertDialogOverlay({
       )}
       {...props} />
   );
-}
+})
 
-function AlertDialogContent({
+const AlertDialogContent = React.forwardRef(function AlertDialogContent({
   className,
   ...props
-}) {
+}, ref) {
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
       <AlertDialogPrimitive.Content
+        ref={ref}
         data-slot="alert-dialog-content"
         className={cn(
           "cad-glass-popover fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-md border p-6 text-foreground shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
@@ -55,7 +57,7 @@ function AlertDialogContent({
         {...props} />
     </AlertDialogPortal>
   );
-}
+})
 
 function AlertDialogHeader({
   className,
@@ -81,51 +83,55 @@ function AlertDialogFooter({
   );
 }
 
-function AlertDialogTitle({
+const AlertDialogTitle = React.forwardRef(function AlertDialogTitle({
   className,
   ...props
-}) {
+}, ref) {
   return (
     <AlertDialogPrimitive.Title
+      ref={ref}
       data-slot="alert-dialog-title"
       className={cn("text-lg font-semibold", className)}
       {...props} />
   );
-}
+})
 
-function AlertDialogDescription({
+const AlertDialogDescription = React.forwardRef(function AlertDialogDescription({
   className,
   ...props
-}) {
+}, ref) {
   return (
     <AlertDialogPrimitive.Description
+      ref={ref}
       data-slot="alert-dialog-description"
       className={cn("text-sm text-muted-foreground", className)}
       {...props} />
   );
-}
+})
 
-function AlertDialogAction({
+const AlertDialogAction = React.forwardRef(function AlertDialogAction({
   className,
   ...props
-}) {
+}, ref) {
   return (
     <AlertDialogPrimitive.Action
+      ref={ref}
       className={cn(buttonVariants(), className)}
       {...props} />
   );
-}
+})
 
-function AlertDialogCancel({
+const AlertDialogCancel = React.forwardRef(function AlertDialogCancel({
   className,
   ...props
-}) {
+}, ref) {
   return (
     <AlertDialogPrimitive.Cancel
+      ref={ref}
       className={cn(buttonVariants({ variant: "outline" }), className)}
       {...props} />
   );
-}
+})
 
 export {
   AlertDialog,

--- a/.agents/skills/cad/explorer/components/ui/button.jsx
+++ b/.agents/skills/cad/explorer/components/ui/button.jsx
@@ -38,23 +38,24 @@ const buttonVariants = cva(
   }
 )
 
-function Button({
+const Button = React.forwardRef(function Button({
   className,
   variant = "default",
   size = "default",
   asChild = false,
   ...props
-}) {
+}, ref) {
   const Comp = asChild ? Slot.Root : "button"
 
   return (
     <Comp
+      ref={ref}
       data-slot="button"
       data-variant={variant}
       data-size={size}
       className={cn(buttonVariants({ variant, size, className }))}
       {...props} />
   );
-}
+});
 
 export { Button, buttonVariants }

--- a/.agents/skills/cad/explorer/components/workbench/CadWorkspaceTopBar.js
+++ b/.agents/skills/cad/explorer/components/workbench/CadWorkspaceTopBar.js
@@ -1,5 +1,5 @@
 import { Fragment } from "react";
-import { LoaderCircle, Palette, SlidersHorizontal } from "lucide-react";
+import { LoaderCircle, Palette, ShoppingCart, SlidersHorizontal } from "lucide-react";
 import { normalizeExplorerGithubUrl } from "../../lib/explorerConfig.mjs";
 import {
   Breadcrumb,
@@ -135,7 +135,8 @@ export default function CadWorkspaceTopBar({
   filenameLoadActivity = null,
   fileSheetKind = "",
   fileSheetOpen = false,
-  onToggleFileSheet
+  onToggleFileSheet,
+  onOpenOttoAuth
 }) {
   const { isMobile, state: sidebarState } = useSidebar();
 
@@ -212,6 +213,18 @@ export default function CadWorkspaceTopBar({
           <a href={githubUrl} target="_blank" rel="noreferrer">
             <GitHubMark className={topBarIconClasses} />
           </a>
+        </Button>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Buy parts now"
+          title="Buy parts now"
+          onClick={onOpenOttoAuth}
+          className={topBarIconButtonClasses}
+        >
+          <ShoppingCart className={topBarIconClasses} strokeWidth={2} aria-hidden="true" />
         </Button>
 
         <Button

--- a/.agents/skills/cad/explorer/components/workbench/OttoAuthOrderDialog.js
+++ b/.agents/skills/cad/explorer/components/workbench/OttoAuthOrderDialog.js
@@ -1,0 +1,602 @@
+import { useEffect, useMemo, useState } from "react";
+import { ExternalLink, LoaderCircle } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "../ui/alert-dialog";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Textarea } from "../ui/textarea";
+import {
+  buildCadProjectPackage,
+  buildCadProjectPackageSummary,
+  buildEntryDownloadUrl,
+  buildOttoAuthCartReturnUrl,
+  buildOttoAuthConnectUrl,
+  buildOttoAuthOrderUrl,
+  buildOttoAuthTaskPayload,
+  entryDisplayLabel,
+  entryFormatLabel,
+  normalizeOttoAuthBaseUrl,
+  OTTOAUTH_AGENT_TASK_PROXY_ENDPOINT,
+  OTTOAUTH_FILE_UPLOAD_PROXY_ENDPOINT,
+  OTTOAUTH_LOCAL_AGENT_PROXY_ENDPOINT,
+  OTTOAUTH_ME_PROXY_ENDPOINT,
+} from "../../lib/ottoAuth";
+
+const fieldLabelClasses = "block text-xs font-medium text-muted-foreground";
+const compactInputClasses = "h-8 text-xs font-medium";
+const selectClasses =
+  "border-input bg-transparent text-foreground h-8 w-full rounded-md border px-2 text-xs font-medium shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50";
+
+const SUPPLIER_OPTIONS = [
+  { id: "auto", label: "Auto select", name: "", url: "" },
+  { id: "craftcloud", label: "Craftcloud", name: "Craftcloud", url: "https://craftcloud3d.com/upload" },
+  { id: "xometry", label: "Xometry", name: "Xometry", url: "https://www.xometry.com/" },
+  { id: "protolabs", label: "Protolabs", name: "Protolabs", url: "https://www.protolabs.com/" },
+  { id: "sendcutsend", label: "SendCutSend", name: "SendCutSend", url: "https://sendcutsend.com/" },
+  { id: "pcbway", label: "PCBWay", name: "PCBWay", url: "https://www.pcbway.com/" },
+  { id: "jlcpcb", label: "JLCPCB", name: "JLCPCB", url: "https://jlcpcb.com/" },
+  { id: "mcmaster", label: "McMaster-Carr", name: "McMaster-Carr", url: "https://www.mcmaster.com/" },
+  { id: "misumi", label: "MISUMI", name: "MISUMI", url: "https://us.misumi-ec.com/" },
+  { id: "digikey", label: "Digi-Key", name: "Digi-Key", url: "https://www.digikey.com/" },
+  { id: "mouser", label: "Mouser", name: "Mouser", url: "https://www.mouser.com/" },
+  { id: "custom", label: "Custom supplier", name: "", url: "" }
+];
+
+function emptyForm() {
+  return {
+    quantity: "1",
+    material: "",
+    supplierId: "auto",
+    supplierName: "",
+    supplierUrl: "",
+    maxSpendUsd: "",
+    packageSummary: "",
+    notes: ""
+  };
+}
+
+function selectedEntryKey(entry) {
+  return String(entry?.file || entry?.name || entry?.source?.path || entry?.step?.path || "");
+}
+
+function errorMessageForResponse(payload, statusCode, ottoAuthBaseUrl) {
+  const upstreamMessage = String(payload?.error || payload?.message || "").trim();
+  if (statusCode === 401) {
+    return `Sign in to OttoAuth at ${ottoAuthBaseUrl}/login, then retry.`;
+  }
+  if (statusCode === 404) {
+    return "OttoAuth submission is available from the local CAD Explorer dev server.";
+  }
+  return upstreamMessage || `OttoAuth request failed with status ${statusCode}.`;
+}
+
+function formatUsd(cents) {
+  const value = Number(cents);
+  if (!Number.isFinite(value)) {
+    return "$0.00";
+  }
+  return `$${(value / 100).toFixed(2)}`;
+}
+
+async function readJsonResponse(response) {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+}
+
+function fileNameFromCadFile(file, index) {
+  const label = String(file?.label || file?.key || `cad-file-${index + 1}`).trim();
+  return label.split(/[\\/]/).filter(Boolean).pop() || `cad-file-${index + 1}`;
+}
+
+async function uploadCadProjectPackage(cadPackage) {
+  const cadFiles = Array.isArray(cadPackage?.cadFiles) ? cadPackage.cadFiles : [];
+  const uploadTargets = cadFiles.filter((file) => String(file?.url || "").trim()).slice(0, 20);
+  if (!uploadTargets.length) {
+    return cadPackage;
+  }
+
+  const formData = new FormData();
+  const metadata = [];
+  for (let index = 0; index < uploadTargets.length; index += 1) {
+    const file = uploadTargets[index];
+    const response = await fetch(file.url, { credentials: "same-origin" });
+    if (!response.ok) {
+      throw new Error(`Could not read ${file.label || file.url} for OttoAuth upload.`);
+    }
+    const blob = await response.blob();
+    formData.append("file", blob, fileNameFromCadFile(file, index));
+    metadata.push({
+      source: "cad-explorer",
+      original_url: file.url,
+      label: file.label,
+      key: file.key,
+      format: file.format,
+      selected: Boolean(file.selected)
+    });
+  }
+  formData.append("metadata", JSON.stringify({ app_id: "cad-explorer", files: metadata }));
+
+  const response = await fetch(OTTOAUTH_FILE_UPLOAD_PROXY_ENDPOINT, {
+    method: "POST",
+    credentials: "include",
+    body: formData
+  });
+  const payload = await readJsonResponse(response);
+  if (!response.ok) {
+    throw new Error(payload?.error || `OttoAuth file upload failed with status ${response.status}.`);
+  }
+
+  const uploadedFiles = Array.isArray(payload?.files) ? payload.files : [];
+  let uploadIndex = 0;
+  const uploadedCadFiles = cadFiles.map((file) => {
+    if (!String(file?.url || "").trim() || uploadIndex >= uploadedFiles.length) {
+      return file;
+    }
+    const uploaded = uploadedFiles[uploadIndex];
+    uploadIndex += 1;
+    return {
+      ...file,
+      local_url: file.url,
+      url: uploaded?.url || file.url,
+      ottoauth_file_id: uploaded?.id || "",
+      ottoauth_sha256: uploaded?.sha256 || "",
+      size: uploaded?.size ?? file.size
+    };
+  });
+  const selectedFile = uploadedCadFiles.find((file) => file.selected) || uploadedCadFiles[0] || null;
+
+  return {
+    ...cadPackage,
+    selectedFile,
+    cadFiles: uploadedCadFiles,
+    primarySourceUrl: selectedFile?.url || uploadedCadFiles.find((file) => file.url)?.url || cadPackage.primarySourceUrl || ""
+  };
+}
+
+export default function OttoAuthOrderDialog({
+  open,
+  onOpenChange,
+  selectedEntry,
+  catalogEntries = [],
+  assemblyParts = [],
+  selectedPartIds = [],
+  catalogRootDir = "",
+  onStatus
+}) {
+  const [form, setForm] = useState(emptyForm);
+  const [error, setError] = useState("");
+  const [account, setAccount] = useState(null);
+  const [localAgent, setLocalAgent] = useState(null);
+  const [accountLoading, setAccountLoading] = useState(false);
+  const [agentLoading, setAgentLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const entryKey = selectedEntryKey(selectedEntry);
+  const entryLabel = entryDisplayLabel(selectedEntry);
+  const entryFormat = selectedEntry ? entryFormatLabel(selectedEntry) : "";
+  const ottoAuthBaseUrl = normalizeOttoAuthBaseUrl(import.meta.env?.EXPLORER_OTTOAUTH_BASE_URL);
+  const cadProjectPackage = useMemo(() => {
+    const origin = typeof window === "undefined" ? "" : window.location.origin;
+    return buildCadProjectPackage({
+      entries: catalogEntries,
+      selectedEntry,
+      assemblyParts,
+      selectedPartIds,
+      origin,
+      catalogRootDir
+    });
+  }, [assemblyParts, catalogEntries, catalogRootDir, selectedEntry, selectedPartIds]);
+  const sourceUrl = useMemo(() => {
+    return cadProjectPackage.primarySourceUrl || buildEntryDownloadUrl(selectedEntry, {
+      origin: typeof window === "undefined" ? "" : window.location.origin,
+      catalogRootDir
+    });
+  }, [cadProjectPackage.primarySourceUrl, catalogRootDir, selectedEntry]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setForm({
+      ...emptyForm(),
+      packageSummary: buildCadProjectPackageSummary(cadProjectPackage)
+    });
+    setError("");
+    setAccount(null);
+    setLocalAgent(null);
+    setSubmitting(false);
+  }, [cadProjectPackage, entryKey, open]);
+
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    async function loadAccount() {
+      setAccountLoading(true);
+      setError("");
+      try {
+        const response = await fetch(OTTOAUTH_ME_PROXY_ENDPOINT, {
+          method: "GET",
+          headers: {
+            "Accept": "application/json"
+          },
+          credentials: "include",
+          signal: controller.signal
+        });
+        const payload = await readJsonResponse(response);
+        if (response.status === 401) {
+          setAccount(null);
+          return;
+        }
+        if (!response.ok) {
+          setError(errorMessageForResponse(payload, response.status, ottoAuthBaseUrl));
+          return;
+        }
+        setAccount(payload);
+
+        setAccountLoading(false);
+        setAgentLoading(true);
+        const agentResponse = await fetch(OTTOAUTH_LOCAL_AGENT_PROXY_ENDPOINT, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+          },
+          credentials: "include",
+          body: JSON.stringify({
+            app_id: "cad-explorer",
+            app_name: "CAD Explorer",
+            agent_name: "CAD Explorer local coding agent"
+          }),
+          signal: controller.signal
+        });
+        const agentPayload = await readJsonResponse(agentResponse);
+        if (!agentResponse.ok) {
+          setError(errorMessageForResponse(agentPayload, agentResponse.status, ottoAuthBaseUrl));
+          return;
+        }
+        setLocalAgent(agentPayload);
+      } catch (requestError) {
+        if (requestError instanceof DOMException && requestError.name === "AbortError") {
+          return;
+        }
+        setError(requestError instanceof Error ? requestError.message : "Could not reach OttoAuth.");
+      } finally {
+        setAccountLoading(false);
+        setAgentLoading(false);
+      }
+    }
+
+    void loadAccount();
+    return () => {
+      controller.abort();
+    };
+  }, [open, ottoAuthBaseUrl]);
+
+  const updateForm = (key, value) => {
+    setForm((current) => ({
+      ...current,
+      [key]: value
+    }));
+  };
+
+  const connectToOttoAuth = () => {
+    const currentUrl = typeof window === "undefined"
+      ? ""
+      : buildOttoAuthCartReturnUrl(window.location.href);
+    if (typeof window !== "undefined") {
+      window.location.href = buildOttoAuthConnectUrl(ottoAuthBaseUrl, currentUrl);
+    }
+  };
+
+  const handleSupplierChange = (supplierId) => {
+    const supplier = SUPPLIER_OPTIONS.find((option) => option.id === supplierId) || SUPPLIER_OPTIONS[0];
+    setForm((current) => ({
+      ...current,
+      supplierId: supplier.id,
+      supplierName: supplier.name,
+      supplierUrl: supplier.url
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError("");
+
+    if (!account?.user) {
+      connectToOttoAuth();
+      return;
+    }
+
+    if (!localAgent?.agent?.username) {
+      setError("OttoAuth is still preparing linked agent credentials. Try again in a moment.");
+      return;
+    }
+
+    if (!selectedEntry && !String(form.notes || "").trim()) {
+      setError("Enter request details when no CAD file is selected.");
+      return;
+    }
+
+    setSubmitting(true);
+    let uploadedPackage;
+    try {
+      uploadedPackage = await uploadCadProjectPackage(cadProjectPackage);
+    } catch (uploadError) {
+      setError(uploadError instanceof Error ? uploadError.message : "Could not upload CAD files to OttoAuth.");
+      setSubmitting(false);
+      return;
+    }
+
+    const payload = buildOttoAuthTaskPayload({
+      entry: selectedEntry,
+      sourceUrl: uploadedPackage.primarySourceUrl || sourceUrl,
+      form: {
+        ...form,
+        packageSummary: buildCadProjectPackageSummary(uploadedPackage),
+        cadFiles: uploadedPackage.cadFiles,
+        cadParts: uploadedPackage.parts
+      }
+    });
+
+    try {
+      const response = await fetch(OTTOAUTH_AGENT_TASK_PROXY_ENDPOINT, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json"
+        },
+        credentials: "include",
+        body: JSON.stringify(payload)
+      });
+      const responsePayload = await readJsonResponse(response);
+      if (!response.ok) {
+        setError(errorMessageForResponse(responsePayload, response.status, ottoAuthBaseUrl));
+        return;
+      }
+
+      const taskId = String(responsePayload?.task?.id || "").trim();
+      onStatus?.(taskId ? "OttoAuth order queued" : "OttoAuth request submitted");
+      onOpenChange?.(false);
+      if (taskId && typeof window !== "undefined") {
+        window.location.href = buildOttoAuthOrderUrl(ottoAuthBaseUrl, taskId);
+      }
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : "Could not reach OttoAuth.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const user = account?.user || null;
+  const displayName = String(user?.display_name || user?.email || "OttoAuth").trim();
+  const connectedEmail = String(user?.email || "").trim();
+  const balanceLabel = formatUsd(account?.balance_cents);
+  const agentUsername = String(localAgent?.agent?.username || "").trim();
+  const credentialPath = String(localAgent?.credential_path || "").trim();
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="max-h-[min(42rem,calc(100vh-2rem))] max-w-xl overflow-y-auto">
+        <form className="grid gap-4" onSubmit={handleSubmit}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {user ? "Buy Parts Now" : "Connect OttoAuth Account"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {user
+                ? "Review the auto-filled CAD package, choose a supplier, then send it to OttoAuth."
+                : "Create or sign in to OttoAuth, then register this local coding agent for one-click orders."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-xs">
+            <div className="flex min-w-0 items-center justify-between gap-3">
+              <div className="min-w-0">
+                <div className="font-medium text-foreground">
+                  {entryLabel || "Current CAD project"}
+                </div>
+                <div className="mt-0.5 text-muted-foreground">
+                  {selectedEntry ? `${entryFormat} from ${cadProjectPackage.cadFiles.length} project file${cadProjectPackage.cadFiles.length === 1 ? "" : "s"}` : `${cadProjectPackage.cadFiles.length} project file${cadProjectPackage.cadFiles.length === 1 ? "" : "s"}`}
+                </div>
+              </div>
+              {sourceUrl ? (
+                <a
+                  href={sourceUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-foreground hover:bg-accent hover:text-accent-foreground"
+                >
+                  <ExternalLink className="size-3" aria-hidden="true" />
+                  Source
+                </a>
+              ) : null}
+            </div>
+          </div>
+
+          {error ? (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs font-medium text-destructive">
+              {error}
+            </div>
+          ) : null}
+
+          <div className="rounded-md border border-border/70 bg-muted/20 px-3 py-2 text-xs">
+            {accountLoading ? (
+              <div className="flex items-center gap-2 font-medium text-muted-foreground">
+                <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
+                Checking OttoAuth connection...
+              </div>
+            ) : user ? (
+              <div className="grid gap-2">
+                <div className="flex min-w-0 flex-wrap items-center justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="font-medium text-foreground">Logged in as {displayName}</div>
+                    {connectedEmail && connectedEmail !== displayName ? (
+                      <div className="mt-0.5 text-muted-foreground">{connectedEmail}</div>
+                    ) : null}
+                  </div>
+                  <div className="rounded-md bg-accent px-2 py-1 font-medium text-accent-foreground">
+                    {balanceLabel} credits
+                  </div>
+                </div>
+                {agentLoading ? (
+                  <div className="flex items-center gap-2 font-medium text-muted-foreground">
+                    <LoaderCircle className="size-3.5 animate-spin" aria-hidden="true" />
+                    Linking local coding agent...
+                  </div>
+                ) : agentUsername ? (
+                  <div className="rounded-md border border-border/70 bg-background px-2 py-1.5 text-muted-foreground">
+                    Agent @{agentUsername} linked to this OttoAuth account
+                    {credentialPath ? `; saved to ${credentialPath}` : ""}.
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <div className="grid gap-2">
+                <div className="font-medium text-foreground">
+                  Connect your OttoAuth account
+                </div>
+                <div className="text-muted-foreground">
+                  OttoAuth will create or find your account, then register this computer's local coding agent so future orders can be submitted through the agent API.
+                </div>
+                <Button type="button" size="sm" onClick={connectToOttoAuth} className="justify-self-start">
+                  Connect OttoAuth
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {user ? (
+            <>
+          <div className="grid gap-3 sm:grid-cols-[5.5rem_minmax(0,1fr)]">
+            <label className="block">
+              <span className={fieldLabelClasses}>Quantity</span>
+              <Input
+                type="number"
+                min="1"
+                step="1"
+                inputMode="numeric"
+                value={form.quantity}
+                onChange={(event) => updateForm("quantity", event.target.value)}
+                className={`${compactInputClasses} mt-1.5`}
+              />
+            </label>
+            <label className="block min-w-0">
+              <span className={fieldLabelClasses}>Material or finish</span>
+              <Input
+                value={form.material}
+                onChange={(event) => updateForm("material", event.target.value)}
+                placeholder="6061 aluminum, PETG, black oxide, M3 stainless"
+                className={`${compactInputClasses} mt-1.5`}
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="block min-w-0">
+              <span className={fieldLabelClasses}>Supplier</span>
+              <select
+                value={form.supplierId}
+                onChange={(event) => handleSupplierChange(event.target.value)}
+                className={`${selectClasses} mt-1.5`}
+              >
+                {SUPPLIER_OPTIONS.map((supplier) => (
+                  <option key={supplier.id} value={supplier.id}>
+                    {supplier.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block min-w-0">
+              <span className={fieldLabelClasses}>Supplier URL</span>
+              <Input
+                value={form.supplierUrl}
+                onChange={(event) => updateForm("supplierUrl", event.target.value)}
+                placeholder="Optional supplier link"
+                className={`${compactInputClasses} mt-1.5`}
+              />
+            </label>
+          </div>
+
+          {form.supplierId === "custom" ? (
+            <label className="block min-w-0">
+              <span className={fieldLabelClasses}>Custom supplier name</span>
+              <Input
+                value={form.supplierName}
+                onChange={(event) => updateForm("supplierName", event.target.value)}
+                placeholder="Supplier or fabrication service name"
+                className={`${compactInputClasses} mt-1.5`}
+              />
+            </label>
+          ) : null}
+
+          <label className="block">
+            <span className={fieldLabelClasses}>CAD package sent to OttoAuth</span>
+            <Textarea
+              value={form.packageSummary}
+              onChange={(event) => updateForm("packageSummary", event.target.value)}
+              className="mt-1.5 min-h-48 font-mono text-[11px] leading-4"
+            />
+          </label>
+
+          <label className="block max-w-xs min-w-0">
+            <span className={fieldLabelClasses}>Spend cap</span>
+            <Input
+              value={form.maxSpendUsd}
+              onChange={(event) => updateForm("maxSpendUsd", event.target.value)}
+              placeholder="Optional USD"
+              inputMode="decimal"
+              className={`${compactInputClasses} mt-1.5`}
+            />
+          </label>
+
+          <label className="block">
+            <span className={fieldLabelClasses}>Request details</span>
+            <Textarea
+              value={form.notes}
+              onChange={(event) => updateForm("notes", event.target.value)}
+              placeholder="Tolerances, substitute parts, shipping preferences, or exact vendor instructions."
+              className="mt-1.5 min-h-24 text-xs"
+            />
+          </label>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel type="button" disabled={submitting}>
+              Cancel
+            </AlertDialogCancel>
+            <Button type="submit" disabled={submitting || accountLoading || agentLoading}>
+              {submitting ? (
+                <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
+              ) : null}
+              {submitting ? "Sending..." : "One-click buy"}
+            </Button>
+          </AlertDialogFooter>
+            </>
+          ) : (
+            <AlertDialogFooter>
+              <AlertDialogCancel type="button">Cancel</AlertDialogCancel>
+              <Button type="button" onClick={connectToOttoAuth} disabled={accountLoading}>
+                Connect OttoAuth
+              </Button>
+            </AlertDialogFooter>
+          )}
+        </form>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/.agents/skills/cad/explorer/components/workbench/StatusToast.js
+++ b/.agents/skills/cad/explorer/components/workbench/StatusToast.js
@@ -5,8 +5,8 @@ import {
   ToastViewport
 } from "../ui/toast";
 
-export default function StatusToast({ copyStatus, screenshotStatus, persistenceStatus, motionErrorStatus, previewMode, onClear }) {
-  const message = motionErrorStatus || copyStatus || screenshotStatus || persistenceStatus;
+export default function StatusToast({ copyStatus, ottoAuthStatus, screenshotStatus, persistenceStatus, motionErrorStatus, previewMode, onClear }) {
+  const message = motionErrorStatus || copyStatus || ottoAuthStatus || screenshotStatus || persistenceStatus;
   const isError = Boolean(motionErrorStatus);
   if (!message || previewMode) {
     return null;

--- a/.agents/skills/cad/explorer/lib/ottoAuth.js
+++ b/.agents/skills/cad/explorer/lib/ottoAuth.js
@@ -1,0 +1,418 @@
+export const DEFAULT_OTTOAUTH_BASE_URL = "http://localhost:3000";
+export const OTTOAUTH_ME_PROXY_ENDPOINT = "/__ottoauth/me";
+export const OTTOAUTH_LOCAL_AGENT_PROXY_ENDPOINT = "/__ottoauth/local-agent";
+export const OTTOAUTH_AGENT_TASK_PROXY_ENDPOINT = "/__ottoauth/agent-task";
+export const OTTOAUTH_FILE_UPLOAD_PROXY_ENDPOINT = "/__ottoauth/files";
+
+const FILE_EXTENSION_FORMATS = new Map([
+  ["step", "STEP"],
+  ["stp", "STEP"],
+  ["stl", "STL"],
+  ["3mf", "3MF"],
+  ["dxf", "DXF"],
+  ["urdf", "URDF"]
+]);
+
+function normalizeRelativePath(value) {
+  const rawValue = String(value || "").trim();
+  if (!rawValue) {
+    return "";
+  }
+  return rawValue
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "");
+}
+
+function normalizeCatalogRootDir(value) {
+  const normalized = normalizeRelativePath(value);
+  if (!normalized || normalized === ".") {
+    return "";
+  }
+  return normalized;
+}
+
+function joinRelativePath(...parts) {
+  return parts
+    .map(normalizeRelativePath)
+    .filter(Boolean)
+    .join("/");
+}
+
+function encodeUrlPath(relativePath) {
+  const normalized = normalizeRelativePath(relativePath);
+  if (!normalized) {
+    return "";
+  }
+  return `/${normalized.split("/").map((part) => encodeURIComponent(part)).join("/")}`;
+}
+
+function stripQueryAndHash(value) {
+  return String(value || "").split(/[?#]/)[0];
+}
+
+function defaultBaseUrlForBrowser() {
+  if (typeof window === "undefined" || !window.location?.hostname) {
+    return DEFAULT_OTTOAUTH_BASE_URL;
+  }
+  const protocol = window.location.protocol === "https:" ? "https:" : "http:";
+  return `${protocol}//${window.location.hostname}:3000`;
+}
+
+export function normalizeOttoAuthBaseUrl(value, fallback = defaultBaseUrlForBrowser()) {
+  const rawValue = String(value || "").trim();
+  const candidate = rawValue || fallback || DEFAULT_OTTOAUTH_BASE_URL;
+  try {
+    const url = new URL(candidate);
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return DEFAULT_OTTOAUTH_BASE_URL;
+  }
+}
+
+export function parseUsdToCents(value) {
+  const normalized = String(value || "").trim().replace(/[^0-9.]/g, "");
+  if (!normalized) {
+    return null;
+  }
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return Math.round(parsed * 100);
+}
+
+export function entrySourceFormat(entry) {
+  const kind = String(entry?.kind || "").trim().toLowerCase();
+  if (kind === "part" || kind === "assembly") {
+    return "step";
+  }
+  if (kind === "stp") {
+    return "step";
+  }
+  if (FILE_EXTENSION_FORMATS.has(kind)) {
+    return kind;
+  }
+  const path = String(entry?.source?.path || entry?.step?.path || entry?.file || "").trim();
+  const extension = stripQueryAndHash(path).split(".").pop()?.toLowerCase() || "";
+  if (extension === "stp") {
+    return "step";
+  }
+  return FILE_EXTENSION_FORMATS.has(extension) ? extension : "";
+}
+
+export function entryFormatLabel(entry) {
+  const format = entrySourceFormat(entry);
+  return FILE_EXTENSION_FORMATS.get(format) || "CAD";
+}
+
+export function entryDisplayLabel(entry) {
+  return String(entry?.name || entry?.file || entry?.source?.path || entry?.step?.path || "").trim();
+}
+
+function entrySourcePath(entry, catalogRootDir = "") {
+  if (!entry) {
+    return "";
+  }
+  const format = entrySourceFormat(entry);
+  if (format === "step") {
+    const rootDir = normalizeCatalogRootDir(catalogRootDir);
+    const sourcePath = normalizeRelativePath(entry?.step?.path || entry?.source?.path || entry?.file);
+    if (!sourcePath) {
+      return "";
+    }
+    if (rootDir && (sourcePath === rootDir || sourcePath.startsWith(`${rootDir}/`))) {
+      return sourcePath;
+    }
+    return joinRelativePath(rootDir, sourcePath);
+  }
+  return normalizeRelativePath(entry?.source?.path || entry?.file);
+}
+
+export function buildEntryDownloadUrl(entry, { origin = "", catalogRootDir = "" } = {}) {
+  const safeOrigin = String(origin || "").trim();
+  if (!entry || !safeOrigin) {
+    return "";
+  }
+
+  const format = entrySourceFormat(entry);
+  const assetUrl = String(entry?.assets?.[format]?.url || "").trim();
+  const sourceUrl = assetUrl || encodeUrlPath(entrySourcePath(entry, catalogRootDir));
+  if (!sourceUrl) {
+    return "";
+  }
+
+  try {
+    return new URL(sourceUrl, safeOrigin).href;
+  } catch {
+    return "";
+  }
+}
+
+function uniqueBy(items, keyForItem) {
+  const seen = new Set();
+  const result = [];
+  for (const item of Array.isArray(items) ? items : []) {
+    const key = String(keyForItem(item) || "").trim();
+    if (!key || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(item);
+  }
+  return result;
+}
+
+function normalizePartLabel(part) {
+  return String(part?.name || part?.displayName || part?.label || part?.sourcePath || part?.id || "").trim();
+}
+
+function normalizePartRecord(part) {
+  const id = String(part?.id || "").trim();
+  const label = normalizePartLabel(part);
+  if (!id && !label) {
+    return null;
+  }
+  return {
+    id,
+    label: label || id,
+    sourcePath: String(part?.sourcePath || "").trim(),
+    occurrenceId: String(part?.occurrenceId || "").trim()
+  };
+}
+
+export function buildCadProjectPackage({
+  entries = [],
+  selectedEntry = null,
+  assemblyParts = [],
+  selectedPartIds = [],
+  origin = "",
+  catalogRootDir = ""
+} = {}) {
+  const selectedKey = String(selectedEntry?.file || selectedEntry?.name || selectedEntry?.source?.path || selectedEntry?.step?.path || "").trim();
+  const projectEntries = uniqueBy(
+    [
+      selectedEntry,
+      ...entries
+    ].filter(Boolean),
+    (entry) => entry?.file || entry?.name || entry?.source?.path || entry?.step?.path
+  );
+  const selectedPartIdSet = new Set(
+    (Array.isArray(selectedPartIds) ? selectedPartIds : [])
+      .map((id) => String(id || "").trim())
+      .filter(Boolean)
+  );
+  const normalizedParts = uniqueBy(
+    (Array.isArray(assemblyParts) ? assemblyParts : [])
+      .filter((part) => !selectedPartIdSet.size || selectedPartIdSet.has(String(part?.id || "").trim()))
+      .map(normalizePartRecord)
+      .filter(Boolean),
+    (part) => part.id || part.label
+  );
+  const fallbackParts = normalizedParts.length
+    ? normalizedParts
+    : uniqueBy(
+      (Array.isArray(assemblyParts) ? assemblyParts : [])
+        .map(normalizePartRecord)
+        .filter(Boolean),
+      (part) => part.id || part.label
+    );
+  const cadFiles = projectEntries.map((entry) => {
+    const key = String(entry?.file || entry?.name || entry?.source?.path || entry?.step?.path || "").trim();
+    return {
+      key,
+      label: entryDisplayLabel(entry) || key,
+      format: entryFormatLabel(entry),
+      selected: Boolean(selectedKey && key === selectedKey),
+      url: buildEntryDownloadUrl(entry, { origin, catalogRootDir })
+    };
+  });
+  const selectedFile = cadFiles.find((file) => file.selected) || cadFiles[0] || null;
+
+  return {
+    selectedFile,
+    cadFiles,
+    parts: fallbackParts,
+    selectedPartCount: normalizedParts.length,
+    primarySourceUrl: selectedFile?.url || cadFiles.find((file) => file.url)?.url || ""
+  };
+}
+
+export function buildCadProjectPackageSummary(cadPackage = {}) {
+  const selectedFile = cadPackage?.selectedFile || null;
+  const cadFiles = Array.isArray(cadPackage?.cadFiles) ? cadPackage.cadFiles : [];
+  const parts = Array.isArray(cadPackage?.parts) ? cadPackage.parts : [];
+  const selectedPartCount = Number(cadPackage?.selectedPartCount || 0);
+  const cadFileLines = cadFiles
+    .slice(0, 24)
+    .map((file, index) => `${index + 1}. ${file.label}${file.format ? ` (${file.format})` : ""}${file.url ? ` - ${file.url}` : ""}`);
+  const partLines = parts
+    .slice(0, 40)
+    .map((part, index) => {
+      const sourceSuffix = part.sourcePath ? ` - source ${part.sourcePath}` : "";
+      return `${index + 1}. ${part.label}${sourceSuffix}`;
+    });
+
+  return [
+    "CAD project package:",
+    selectedFile ? `Selected CAD file: ${selectedFile.label}${selectedFile.format ? ` (${selectedFile.format})` : ""}` : "Selected CAD file: none",
+    selectedFile?.url ? `Selected CAD URL: ${selectedFile.url}` : "",
+    cadFileLines.length ? `Project CAD files (${cadFiles.length}${cadFiles.length > cadFileLines.length ? `, first ${cadFileLines.length} shown` : ""}):\n${cadFileLines.join("\n")}` : "Project CAD files: none discovered",
+    partLines.length ? `Assembly parts (${parts.length}${selectedPartCount ? `, ${selectedPartCount} selected` : ""}${parts.length > partLines.length ? `, first ${partLines.length} shown` : ""}):\n${partLines.join("\n")}` : "Assembly parts: none discovered"
+  ].filter(Boolean).join("\n");
+}
+
+export function buildOttoAuthOrderUrl(baseUrl, taskId = "") {
+  const normalizedBaseUrl = normalizeOttoAuthBaseUrl(baseUrl);
+  const normalizedTaskId = String(taskId || "").trim();
+  if (normalizedTaskId) {
+    return `${normalizedBaseUrl}/orders/${encodeURIComponent(normalizedTaskId)}`;
+  }
+  return `${normalizedBaseUrl}/orders/new`;
+}
+
+export function buildOttoAuthConnectUrl(baseUrl, returnUrl = "", {
+  appId = "cad-explorer",
+  appName = "CAD Explorer"
+} = {}) {
+  const normalizedBaseUrl = normalizeOttoAuthBaseUrl(baseUrl);
+  const targetUrl = new URL("/api/sdk/connect", `${normalizedBaseUrl}/`);
+  targetUrl.searchParams.set("app_id", appId);
+  targetUrl.searchParams.set("app_name", appName);
+  if (returnUrl) {
+    targetUrl.searchParams.set("return_to", returnUrl);
+  }
+  return targetUrl.href;
+}
+
+export function buildOttoAuthLoginUrl(baseUrl, returnUrl = "") {
+  return buildOttoAuthConnectUrl(baseUrl, returnUrl);
+}
+
+export function buildOttoAuthCartReturnUrl(currentUrl) {
+  try {
+    const url = new URL(String(currentUrl || ""));
+    url.searchParams.set("ottoauthCart", "1");
+    return url.href;
+  } catch {
+    return "";
+  }
+}
+
+function normalizeQuantity(value) {
+  const parsed = Number.parseInt(String(value || "").trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function normalizeText(value, limit = 1000) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, limit);
+}
+
+function normalizeMultilineText(value, limit = 8000) {
+  return String(value || "")
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+    .slice(0, limit);
+}
+
+function normalizeUrl(value) {
+  const rawValue = String(value || "").trim();
+  if (!rawValue) {
+    return "";
+  }
+  try {
+    return new URL(rawValue).href;
+  } catch {
+    if (/^[a-z][a-z0-9+.-]*:/i.test(rawValue)) {
+      return rawValue;
+    }
+    try {
+      return new URL(`https://${rawValue}`).href;
+    } catch {
+      return rawValue;
+    }
+  }
+}
+
+export function buildOttoAuthTaskPrompt({
+  entry = null,
+  sourceUrl = "",
+  form = {}
+} = {}) {
+  const entryLabel = entryDisplayLabel(entry);
+  const quantity = normalizeQuantity(form.quantity);
+  const formatLabel = entry ? entryFormatLabel(entry) : "";
+  const material = normalizeText(form.material, 300);
+  const supplierName = normalizeText(form.supplierName, 160);
+  const supplierUrl = normalizeUrl(form.supplierUrl);
+  const packageSummary = normalizeMultilineText(form.packageSummary, 8000);
+  const notes = normalizeText(form.notes, 1800);
+  const sourceLine = sourceUrl ? `CAD source URL: ${sourceUrl}` : "";
+  const selectedLine = entryLabel
+    ? `Selected CAD file: ${entryLabel}${formatLabel ? ` (${formatLabel})` : ""}`
+    : "Selected CAD file: none";
+  const targetLine = supplierName || supplierUrl
+    ? `Preferred supplier or manufacturing service: ${[supplierName, supplierUrl].filter(Boolean).join(" ")}`
+    : "Find a suitable supplier, fabrication service, or manufacturing quote flow.";
+
+  return [
+    `Please buy or source ${quantity} physical part${quantity === 1 ? "" : "s"} for this CAD project.`,
+    selectedLine,
+    sourceLine,
+    targetLine,
+    material ? `Material, process, or finish preference: ${material}` : "",
+    packageSummary,
+    "If this is a custom geometry, use the CAD source URL when a supplier or manufacturing service asks for the model. If it appears to be off-the-shelf hardware, find the closest purchasable matching part.",
+    "Use the linked OttoAuth human account's saved shipping and payment context. Do not ask for card numbers or CVV in chat; if checkout needs new payment credentials or missing address/contact details, request clarification through OttoAuth instead of guessing.",
+    notes ? `Additional request details: ${notes}` : ""
+  ].filter(Boolean).join("\n");
+}
+
+export function buildOttoAuthTaskPayload({
+  entry = null,
+  sourceUrl = "",
+  form = {}
+} = {}) {
+  const supplierUrl = normalizeUrl(form.supplierUrl);
+  const supplierName = normalizeText(form.supplierName, 160);
+  const maxChargeCents = parseUsdToCents(form.maxSpendUsd);
+  const entryLabel = entryDisplayLabel(entry) || "CAD project";
+  const cadFiles = Array.isArray(form.cadFiles) ? form.cadFiles : [];
+  const cadParts = Array.isArray(form.cadParts) ? form.cadParts : [];
+  const payload = {
+    app_id: "cad-explorer",
+    kind: "buy_parts",
+    task: buildOttoAuthTaskPrompt({ entry, sourceUrl, form }),
+    task_title: `Buy parts: ${entryLabel}`.slice(0, 120),
+    platform_hint: "parts supplier or manufacturing service",
+    confirmation_mode: "auto_purchase_under_cap",
+    url_policy: supplierUrl ? "preferred" : "discover",
+    request_source: "cad-explorer",
+    cad_file: entryLabel,
+    files: cadFiles,
+    ottoauth_files: cadFiles,
+    cad_files: cadFiles,
+    cad_parts: cadParts,
+    cad_source_url: sourceUrl || null,
+    quantity: normalizeQuantity(form.quantity)
+  };
+
+  if (supplierName) {
+    payload.merchant_name = supplierName;
+  }
+  if (supplierUrl) {
+    payload.url = supplierUrl;
+  }
+  if (maxChargeCents != null) {
+    payload.max_charge_cents = maxChargeCents;
+  }
+  return payload;
+}

--- a/.agents/skills/cad/explorer/lib/ottoAuth.test.js
+++ b/.agents/skills/cad/explorer/lib/ottoAuth.test.js
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildCadProjectPackage,
+  buildCadProjectPackageSummary,
+  buildEntryDownloadUrl,
+  buildOttoAuthCartReturnUrl,
+  buildOttoAuthConnectUrl,
+  buildOttoAuthLoginUrl,
+  buildOttoAuthOrderUrl,
+  buildOttoAuthTaskPayload,
+  entryFormatLabel,
+  parseUsdToCents
+} from "./ottoAuth.js";
+
+test("buildEntryDownloadUrl resolves STEP sources relative to the explorer root", () => {
+  const entry = {
+    kind: "part",
+    name: "mount.step",
+    step: { path: "parts/mount.step" }
+  };
+
+  assert.equal(
+    buildEntryDownloadUrl(entry, {
+      origin: "http://127.0.0.1:4178",
+      catalogRootDir: "fixtures"
+    }),
+    "http://127.0.0.1:4178/fixtures/parts/mount.step"
+  );
+});
+
+test("buildEntryDownloadUrl prefers served asset URLs for mesh formats", () => {
+  const entry = {
+    kind: "stl",
+    name: "clip.stl",
+    assets: {
+      stl: {
+        url: "/exports/clip.stl?v=abc"
+      }
+    }
+  };
+
+  assert.equal(
+    buildEntryDownloadUrl(entry, { origin: "http://localhost:4178" }),
+    "http://localhost:4178/exports/clip.stl?v=abc"
+  );
+  assert.equal(entryFormatLabel(entry), "STL");
+});
+
+test("buildOttoAuthTaskPayload includes CAD context and optional spend cap", () => {
+  const payload = buildOttoAuthTaskPayload({
+    entry: {
+      kind: "assembly",
+      name: "gantry.step"
+    },
+    sourceUrl: "http://localhost:4178/gantry.step",
+    form: {
+      quantity: "2",
+      material: "6061 aluminum, black anodized",
+      packageSummary: "CAD project package:\nSelected CAD file: gantry.step",
+      supplierName: "Xometry",
+      supplierUrl: "https://www.xometry.com/",
+      maxSpendUsd: "$125.50"
+    }
+  });
+
+  assert.equal(payload.task_title, "Buy parts: gantry.step");
+  assert.equal(payload.app_id, "cad-explorer");
+  assert.equal(payload.kind, "buy_parts");
+  assert.equal(payload.merchant_name, "Xometry");
+  assert.equal(payload.url_policy, "preferred");
+  assert.equal(payload.url, "https://www.xometry.com/");
+  assert.equal(payload.max_charge_cents, 12550);
+  assert.equal(payload.fulfillment_mode, undefined);
+  assert.match(payload.task, /Selected CAD file: gantry\.step \(STEP\)/);
+  assert.match(payload.task, /CAD project package:\nSelected CAD file: gantry\.step/);
+  assert.match(payload.task, /CAD source URL: http:\/\/localhost:4178\/gantry\.step/);
+});
+
+test("buildCadProjectPackage summarizes project CAD files and selected assembly parts", () => {
+  const selectedEntry = {
+    file: "assembly/fixture.step",
+    kind: "assembly",
+    name: "fixture.step",
+    step: { path: "assembly/fixture.step" }
+  };
+  const cadPackage = buildCadProjectPackage({
+    selectedEntry,
+    entries: [
+      selectedEntry,
+      {
+        file: "parts/bracket.stl",
+        kind: "stl",
+        name: "bracket.stl",
+        assets: { stl: { url: "/parts/bracket.stl?v=abc" } }
+      }
+    ],
+    assemblyParts: [
+      { id: "a", name: "left bracket", sourcePath: "parts/left.step" },
+      { id: "b", name: "right bracket", sourcePath: "parts/right.step" }
+    ],
+    selectedPartIds: ["b"],
+    origin: "http://127.0.0.1:4178",
+    catalogRootDir: "project"
+  });
+  const summary = buildCadProjectPackageSummary(cadPackage);
+
+  assert.equal(cadPackage.cadFiles.length, 2);
+  assert.equal(cadPackage.parts.length, 1);
+  assert.equal(cadPackage.parts[0].label, "right bracket");
+  assert.equal(cadPackage.primarySourceUrl, "http://127.0.0.1:4178/project/assembly/fixture.step");
+  assert.match(summary, /Project CAD files \(2\):/);
+  assert.match(summary, /Assembly parts \(1, 1 selected\):/);
+  assert.match(summary, /right bracket/);
+});
+
+test("parseUsdToCents accepts formatted dollars", () => {
+  assert.equal(parseUsdToCents("19.99"), 1999);
+  assert.equal(parseUsdToCents("$1,250.45"), 125045);
+  assert.equal(parseUsdToCents(""), null);
+  assert.equal(parseUsdToCents("free"), null);
+});
+
+test("buildOttoAuthOrderUrl points to a task when one is available", () => {
+  assert.equal(
+    buildOttoAuthOrderUrl("http://localhost:3000/", "task 42"),
+    "http://localhost:3000/orders/task%2042"
+  );
+  assert.equal(
+    buildOttoAuthOrderUrl("http://localhost:3000/"),
+    "http://localhost:3000/orders/new"
+  );
+});
+
+test("buildOttoAuthConnectUrl points at the OttoAuth SDK connect route", () => {
+  const loginUrl = new URL(buildOttoAuthConnectUrl(
+    "http://127.0.0.1:3000/",
+    "http://127.0.0.1:4178/?ottoauthCart=1"
+  ));
+  assert.equal(loginUrl.origin, "http://127.0.0.1:3000");
+  assert.equal(loginUrl.pathname, "/api/sdk/connect");
+  assert.equal(loginUrl.searchParams.get("app_id"), "cad-explorer");
+  assert.equal(loginUrl.searchParams.get("app_name"), "CAD Explorer");
+  assert.equal(
+    loginUrl.searchParams.get("return_to"),
+    "http://127.0.0.1:4178/?ottoauthCart=1"
+  );
+  assert.equal(buildOttoAuthLoginUrl(
+    "http://127.0.0.1:3000/",
+    "http://127.0.0.1:4178/?ottoauthCart=1"
+  ), loginUrl.href);
+});
+
+test("buildOttoAuthCartReturnUrl marks the explorer URL to reopen the cart", () => {
+  assert.equal(
+    buildOttoAuthCartReturnUrl("http://127.0.0.1:4178/?file=parts%2Fbracket.step"),
+    "http://127.0.0.1:4178/?file=parts%2Fbracket.step&ottoauthCart=1"
+  );
+});

--- a/.agents/skills/cad/explorer/lib/ottoAuthLocalCredentials.mjs
+++ b/.agents/skills/cad/explorer/lib/ottoAuthLocalCredentials.mjs
@@ -1,0 +1,157 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const OTTOAUTH_LOCAL_AGENT_JSON = ".agents/ottoauth.local.json";
+export const OTTOAUTH_LOCAL_AGENT_ENV = ".agents/.env.ottoauth.local";
+
+function normalizeText(value) {
+  return String(value || "").trim();
+}
+
+function maybeRelative(workspaceRoot, targetPath) {
+  const relative = path.relative(workspaceRoot, targetPath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return targetPath;
+  }
+  return relative;
+}
+
+export function resolveOttoAuthLocalCredentialPaths(workspaceRoot, env = process.env) {
+  const root = path.resolve(workspaceRoot || process.cwd());
+  return {
+    jsonPath: path.resolve(
+      root,
+      normalizeText(env.OTTOAUTH_LOCAL_AGENT_FILE) || OTTOAUTH_LOCAL_AGENT_JSON
+    ),
+    envPath: path.resolve(
+      root,
+      normalizeText(env.OTTOAUTH_LOCAL_AGENT_ENV_FILE) || OTTOAUTH_LOCAL_AGENT_ENV
+    ),
+  };
+}
+
+function extractCredential(payload = {}) {
+  const agent = payload.agent && typeof payload.agent === "object" ? payload.agent : {};
+  const username =
+    normalizeText(payload.username) ||
+    normalizeText(agent.username) ||
+    normalizeText(agent.username_display) ||
+    normalizeText(agent.username_lower);
+  const privateKey =
+    normalizeText(payload.private_key) ||
+    normalizeText(payload.privateKey) ||
+    normalizeText(payload.credentials?.private_key) ||
+    normalizeText(payload.credentials?.privateKey);
+  if (!username || !privateKey) {
+    return null;
+  }
+  return {
+    username,
+    privateKey,
+    agent: {
+      id: agent.id ?? null,
+      username,
+      username_lower: normalizeText(agent.username_lower) || username.toLowerCase(),
+      description: normalizeText(agent.description),
+    },
+  };
+}
+
+function quoteEnv(value) {
+  return JSON.stringify(String(value || ""));
+}
+
+export function writeOttoAuthLocalAgentCredential({
+  workspaceRoot,
+  payload,
+  baseUrl,
+  env = process.env,
+}) {
+  const root = path.resolve(workspaceRoot || process.cwd());
+  const credential = extractCredential(payload);
+  if (!credential) {
+    throw new Error("OttoAuth did not return a usable linked agent credential.");
+  }
+
+  const paths = resolveOttoAuthLocalCredentialPaths(root, env);
+  fs.mkdirSync(path.dirname(paths.jsonPath), { recursive: true });
+  fs.mkdirSync(path.dirname(paths.envPath), { recursive: true });
+
+  const record = {
+    schema_version: 1,
+    ottoauth_base_url: normalizeText(baseUrl),
+    tool_name: normalizeText(payload.tool_name) || "cad-explorer",
+    created: Boolean(payload.created),
+    saved_at: new Date().toISOString(),
+    human: payload.human && typeof payload.human === "object"
+      ? {
+          id: payload.human.id ?? null,
+          email: normalizeText(payload.human.email),
+          display_name: normalizeText(payload.human.display_name),
+          handle: normalizeText(payload.human.handle),
+        }
+      : null,
+    agent: credential.agent,
+    credentials: {
+      username: credential.username,
+      private_key: credential.privateKey,
+    },
+  };
+
+  fs.writeFileSync(paths.jsonPath, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+  fs.writeFileSync(
+    paths.envPath,
+    [
+      `OTTOAUTH_BASE_URL=${quoteEnv(record.ottoauth_base_url)}`,
+      `OTTOAUTH_AGENT_USERNAME=${quoteEnv(credential.username)}`,
+      `OTTOAUTH_PRIVATE_KEY=${quoteEnv(credential.privateKey)}`,
+      "",
+    ].join("\n"),
+    { mode: 0o600 }
+  );
+
+  return {
+    ok: true,
+    created: Boolean(payload.created),
+    tool_name: record.tool_name,
+    human: record.human,
+    agent: record.agent,
+    credential_path: maybeRelative(root, paths.jsonPath),
+    env_path: maybeRelative(root, paths.envPath),
+  };
+}
+
+export function readOttoAuthLocalAgentCredential({
+  workspaceRoot,
+  env = process.env,
+} = {}) {
+  const username =
+    normalizeText(env.OTTOAUTH_AGENT_USERNAME) ||
+    normalizeText(env.OTTOAUTH_USERNAME);
+  const privateKey = normalizeText(env.OTTOAUTH_PRIVATE_KEY);
+  if (username && privateKey) {
+    return {
+      source: "env",
+      username,
+      privateKey,
+    };
+  }
+
+  const root = path.resolve(workspaceRoot || process.cwd());
+  const paths = resolveOttoAuthLocalCredentialPaths(root, env);
+  if (!fs.existsSync(paths.jsonPath)) {
+    return null;
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(paths.jsonPath, "utf8"));
+  const credential = extractCredential(parsed);
+  if (!credential) {
+    return null;
+  }
+
+  return {
+    source: paths.jsonPath,
+    username: credential.username,
+    privateKey: credential.privateKey,
+  };
+}

--- a/.agents/skills/cad/explorer/lib/ottoAuthLocalCredentials.test.mjs
+++ b/.agents/skills/cad/explorer/lib/ottoAuthLocalCredentials.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  readOttoAuthLocalAgentCredential,
+  writeOttoAuthLocalAgentCredential,
+} from "./ottoAuthLocalCredentials.mjs";
+
+test("writes and reads local OttoAuth linked agent credentials", () => {
+  const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ottoauth-local-agent-"));
+  const stored = writeOttoAuthLocalAgentCredential({
+    workspaceRoot,
+    baseUrl: "http://127.0.0.1:3000",
+    env: {},
+    payload: {
+      ok: true,
+      tool_name: "cad-explorer",
+      created: true,
+      human: {
+        id: 7,
+        email: "human@example.com",
+        display_name: "Human",
+        handle: "human",
+      },
+      agent: {
+        id: 12,
+        username: "cad_explorer_abc123",
+        username_lower: "cad_explorer_abc123",
+        description: "CAD Explorer local coding agent",
+      },
+      private_key: "oa_private_test",
+    },
+  });
+
+  assert.equal(stored.agent.username, "cad_explorer_abc123");
+  assert.equal(stored.credential_path, ".agents/ottoauth.local.json");
+  assert.equal(stored.env_path, ".agents/.env.ottoauth.local");
+
+  const credential = readOttoAuthLocalAgentCredential({
+    workspaceRoot,
+    env: {},
+  });
+  assert.equal(credential.username, "cad_explorer_abc123");
+  assert.equal(credential.privateKey, "oa_private_test");
+  assert.match(credential.source, /ottoauth\.local\.json$/);
+});
+
+test("prefers explicit OttoAuth agent env credentials", () => {
+  const credential = readOttoAuthLocalAgentCredential({
+    workspaceRoot: "/does/not/matter",
+    env: {
+      OTTOAUTH_AGENT_USERNAME: "from_env",
+      OTTOAUTH_PRIVATE_KEY: "env_private",
+    },
+  });
+
+  assert.deepEqual(credential, {
+    source: "env",
+    username: "from_env",
+    privateKey: "env_private",
+  });
+});

--- a/.agents/skills/cad/explorer/package.json
+++ b/.agents/skills/cad/explorer/package.json
@@ -2,13 +2,15 @@
   "name": "cad-explorer",
   "private": true,
   "version": "0.1.0",
+  "type": "module",
   "scripts": {
     "dev": "vite dev",
     "dev:ensure": "node scripts/ensure-dev-server.mjs",
     "dev:stop": "node scripts/stop-dev-server.mjs",
     "build": "vite build",
     "build:app": "vite build --outDir dist-verify --emptyOutDir",
-    "test:node": "node --test --experimental-default-type=module lib/perspective.test.js lib/lookSettings.test.js lib/renderAssetClient.test.js lib/render/threeMfMeshData.test.js lib/urdf/parseUrdf.test.js lib/urdf/kinematics.test.js lib/urdf/motion.test.js lib/urdf/jointAnimation.test.js lib/urdf/motionServerClient.test.js lib/dxf/parseDxf.test.js lib/workbench/sidebar.test.js lib/cadDirectoryScanner.test.mjs lib/explorer/sceneScale.test.js lib/explorerConfig.test.mjs components/explorer/hooks/useExplorerPicking.test.js lib/assembly/meshData.test.js lib/selectors/runtime.test.js lib/async/concurrency.test.js lib/clipboard.test.js",
+    "test:node": "node --test lib/perspective.test.js lib/lookSettings.test.js lib/renderAssetClient.test.js lib/render/threeMfMeshData.test.js lib/urdf/parseUrdf.test.js lib/urdf/kinematics.test.js lib/urdf/motion.test.js lib/urdf/jointAnimation.test.js lib/urdf/motionServerClient.test.js lib/dxf/parseDxf.test.js lib/workbench/sidebar.test.js lib/cadDirectoryScanner.test.mjs lib/explorer/sceneScale.test.js lib/explorerConfig.test.mjs components/explorer/hooks/useExplorerPicking.test.js lib/assembly/meshData.test.js lib/selectors/runtime.test.js lib/async/concurrency.test.js lib/clipboard.test.js lib/ottoAuth.test.js lib/ottoAuthLocalCredentials.test.mjs",
+    "ottoauth:buy-parts": "node scripts/ottoauth-buy-parts.mjs",
     "start": "vite preview"
   },
   "dependencies": {

--- a/.agents/skills/cad/explorer/scripts/ottoauth-buy-parts.mjs
+++ b/.agents/skills/cad/explorer/scripts/ottoauth-buy-parts.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+import path from "node:path";
+import process from "node:process";
+import fs from "node:fs/promises";
+import {
+  buildCadProjectPackage,
+  buildCadProjectPackageSummary,
+  buildOttoAuthTaskPayload,
+  normalizeOttoAuthBaseUrl,
+} from "../lib/ottoAuth.js";
+import {
+  DEFAULT_EXPLORER_ROOT_DIR,
+  scanCadDirectory,
+} from "../lib/cadDirectoryScanner.mjs";
+import {
+  readOttoAuthLocalAgentCredential,
+} from "../lib/ottoAuthLocalCredentials.mjs";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      continue;
+    }
+    const [rawKey, inlineValue] = token.slice(2).split("=", 2);
+    const key = rawKey.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+    if (inlineValue != null) {
+      args[key] = inlineValue;
+      continue;
+    }
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    index += 1;
+  }
+  return args;
+}
+
+function usage() {
+  return `Usage:
+  npm --prefix .agents/skills/cad/explorer run ottoauth:buy-parts -- [options]
+
+Options:
+  --file <path>              Scan-root-relative CAD file to package.
+  --root-dir <path>          CAD scan root, defaults to the current workspace.
+  --asset-base-url <url>     Explorer URL that can serve CAD files, e.g. http://127.0.0.1:4178.
+  --supplier <name>          Preferred supplier name.
+  --supplier-url <url>       Preferred supplier URL.
+  --material <text>          Material, process, or finish preference.
+  --quantity <n>             Quantity, defaults to 1.
+  --max-spend <usd>          Optional USD spend cap.
+  --notes <text>             Extra instructions.
+  --submit                   Submit to OttoAuth with a linked local agent credential.
+  --base-url <url>           OttoAuth base URL, defaults to OTTOAUTH_BASE_URL or http://localhost:3000.
+                             Credentials come from env or .agents/ottoauth.local.json.
+`;
+}
+
+function findEntry(entries, file) {
+  const normalized = String(file || "").replace(/\\/g, "/").replace(/^\/+/, "");
+  if (!normalized) {
+    return entries[0] || null;
+  }
+  return entries.find((entry) => (
+    entry.file === normalized ||
+    entry.source?.path === normalized ||
+    entry.step?.path === normalized ||
+    entry.name === normalized
+  )) || null;
+}
+
+function contentTypeForCadFile(filePath) {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === ".step" || extension === ".stp") return "model/step";
+  if (extension === ".stl") return "model/stl";
+  if (extension === ".3mf") return "model/3mf";
+  if (extension === ".dxf") return "application/dxf";
+  if (extension === ".urdf") return "application/xml";
+  return "application/octet-stream";
+}
+
+function resolveCadFilePath(repoRoot, catalogRootDir, file) {
+  const key = String(file?.key || "").replace(/\\/g, "/").replace(/^\/+/, "");
+  if (!key) return "";
+  return path.resolve(repoRoot, catalogRootDir || "", key);
+}
+
+async function uploadCadFilesToOttoAuth(baseUrl, cadPackage, workspaceRoot, credential, catalogRootDir) {
+  const cadFiles = Array.isArray(cadPackage?.cadFiles) ? cadPackage.cadFiles : [];
+  const uploadable = cadFiles
+    .map((file) => ({
+      file,
+      filePath: resolveCadFilePath(workspaceRoot, catalogRootDir, file),
+    }))
+    .filter((item) => item.filePath);
+  if (!uploadable.length) {
+    return cadPackage;
+  }
+
+  const files = [];
+  for (const item of uploadable) {
+    const bytes = await fs.readFile(item.filePath);
+    files.push({
+      name: path.basename(item.filePath),
+      content_type: contentTypeForCadFile(item.filePath),
+      content_base64: bytes.toString("base64"),
+      metadata: {
+        source: "cad-explorer-cli",
+        local_path: path.relative(workspaceRoot, item.filePath),
+        label: item.file.label,
+        key: item.file.key,
+        format: item.file.format,
+        selected: Boolean(item.file.selected),
+      },
+    });
+  }
+
+  const response = await fetch(`${baseUrl}/api/sdk/files`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Accept": "application/json",
+    },
+    body: JSON.stringify({
+      username: credential.username,
+      private_key: credential.privateKey,
+      files,
+    }),
+  });
+  const text = await response.text();
+  let responsePayload = null;
+  try {
+    responsePayload = text ? JSON.parse(text) : null;
+  } catch {
+    responsePayload = { error: text };
+  }
+  if (!response.ok) {
+    throw new Error(responsePayload?.error || `OttoAuth file upload failed with status ${response.status}.`);
+  }
+
+  const uploadedFiles = Array.isArray(responsePayload?.files) ? responsePayload.files : [];
+  let uploadedIndex = 0;
+  const uploadedCadFiles = cadFiles.map((file) => {
+    const matched = uploadable.find((item) => item.file === file);
+    if (!matched || uploadedIndex >= uploadedFiles.length) {
+      return file;
+    }
+    const uploaded = uploadedFiles[uploadedIndex];
+    uploadedIndex += 1;
+    return {
+      ...file,
+      local_url: file.url,
+      url: uploaded?.url || file.url,
+      ottoauth_file_id: uploaded?.id || "",
+      ottoauth_sha256: uploaded?.sha256 || "",
+      size: uploaded?.size ?? file.size,
+    };
+  });
+  const selectedFile = uploadedCadFiles.find((file) => file.selected) || uploadedCadFiles[0] || null;
+  return {
+    ...cadPackage,
+    selectedFile,
+    cadFiles: uploadedCadFiles,
+    primarySourceUrl: selectedFile?.url || uploadedCadFiles.find((file) => file.url)?.url || cadPackage.primarySourceUrl || "",
+  };
+}
+
+function readCredentialOrThrow(workspaceRoot) {
+  const credential = readOttoAuthLocalAgentCredential({ workspaceRoot });
+  if (!credential) {
+    throw new Error(
+      "No linked OttoAuth agent credential found. Sign in with Google from CAD Explorer Buy Parts Now first, or set OTTOAUTH_AGENT_USERNAME and OTTOAUTH_PRIVATE_KEY."
+    );
+  }
+  return credential;
+}
+
+async function submitToOttoAuth(baseUrl, payload, workspaceRoot, credential) {
+  const response = await fetch(`${baseUrl}/api/sdk/checkout`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Accept": "application/json",
+    },
+    body: JSON.stringify({
+      ...payload,
+      username: credential.username,
+      private_key: credential.privateKey,
+    }),
+  });
+  const text = await response.text();
+  let responsePayload = null;
+  try {
+    responsePayload = text ? JSON.parse(text) : null;
+  } catch {
+    responsePayload = { error: text };
+  }
+  if (!response.ok) {
+    throw new Error(responsePayload?.error || `OttoAuth submit failed with status ${response.status}.`);
+  }
+  return responsePayload;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || args.h) {
+    console.log(usage());
+    return;
+  }
+
+  const repoRoot = path.resolve(process.env.EXPLORER_WORKSPACE_ROOT || process.env.INIT_CWD || process.cwd());
+  const rootDir = args.rootDir == null ? DEFAULT_EXPLORER_ROOT_DIR : String(args.rootDir);
+  const catalog = scanCadDirectory({ repoRoot, rootDir });
+  const selectedEntry = findEntry(catalog.entries, args.file);
+  if (!selectedEntry) {
+    throw new Error(args.file ? `No CAD entry matched ${args.file}.` : "No CAD entries found.");
+  }
+
+  const cadPackage = buildCadProjectPackage({
+    entries: catalog.entries,
+    selectedEntry,
+    origin: args.assetBaseUrl || "",
+    catalogRootDir: catalog.root?.dir || "",
+  });
+  const payload = buildOttoAuthTaskPayload({
+    entry: selectedEntry,
+    sourceUrl: cadPackage.primarySourceUrl,
+    form: {
+      quantity: args.quantity || "1",
+      material: args.material || "",
+      supplierName: args.supplier || "",
+      supplierUrl: args.supplierUrl || "",
+      maxSpendUsd: args.maxSpend || "",
+      packageSummary: buildCadProjectPackageSummary(cadPackage),
+      notes: args.notes || "",
+      cadFiles: cadPackage.cadFiles,
+      cadParts: cadPackage.parts,
+    },
+  });
+
+  if (!args.submit) {
+    console.log(JSON.stringify({
+      ok: true,
+      mode: "dry_run",
+      payload,
+    }, null, 2));
+    return;
+  }
+
+  const baseUrl = normalizeOttoAuthBaseUrl(
+    args.baseUrl || process.env.OTTOAUTH_BASE_URL || "http://localhost:3000"
+  );
+  const credential = readCredentialOrThrow(repoRoot);
+  const uploadedPackage = await uploadCadFilesToOttoAuth(
+    baseUrl,
+    cadPackage,
+    repoRoot,
+    credential,
+    catalog.root?.dir || ""
+  );
+  const uploadedPayload = buildOttoAuthTaskPayload({
+    entry: selectedEntry,
+    sourceUrl: uploadedPackage.primarySourceUrl,
+    form: {
+      quantity: args.quantity || "1",
+      material: args.material || "",
+      supplierName: args.supplier || "",
+      supplierUrl: args.supplierUrl || "",
+      maxSpendUsd: args.maxSpend || "",
+      packageSummary: buildCadProjectPackageSummary(uploadedPackage),
+      notes: args.notes || "",
+      cadFiles: uploadedPackage.cadFiles,
+      cadParts: uploadedPackage.parts,
+    },
+  });
+  const result = await submitToOttoAuth(baseUrl, uploadedPayload, repoRoot, credential);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/.agents/skills/cad/explorer/vite.config.mjs
+++ b/.agents/skills/cad/explorer/vite.config.mjs
@@ -17,6 +17,10 @@ import {
   normalizeExplorerDefaultFile,
   normalizeExplorerGithubUrl,
 } from "./lib/explorerConfig.mjs";
+import {
+  readOttoAuthLocalAgentCredential,
+  writeOttoAuthLocalAgentCredential,
+} from "./lib/ottoAuthLocalCredentials.mjs";
 
 const DEFAULT_EXPLORER_PORT = 4178;
 const resolvedPort = Number.parseInt(process.env.EXPLORER_PORT || "", 10);
@@ -28,6 +32,7 @@ const repoRoot = workspaceRoot;
 const buildExplorerRootDir = normalizeExplorerRootDir(process.env.EXPLORER_ROOT_DIR ?? DEFAULT_EXPLORER_ROOT_DIR);
 const buildExplorerDefaultFile = normalizeExplorerDefaultFile(process.env.EXPLORER_DEFAULT_FILE ?? "");
 const buildExplorerGithubUrl = normalizeExplorerGithubUrl(process.env.EXPLORER_GITHUB_URL ?? "");
+const buildOttoAuthBaseUrl = normalizeOttoAuthBaseUrl(process.env.EXPLORER_OTTOAUTH_BASE_URL ?? "http://127.0.0.1:3000");
 
 function resolveWorkspaceRoot() {
   if (process.env.EXPLORER_WORKSPACE_ROOT) {
@@ -163,6 +168,192 @@ function sendJson(res, statusCode, payload) {
   res.end(JSON.stringify(payload));
 }
 
+function normalizeOttoAuthBaseUrl(value) {
+  try {
+    const url = new URL(String(value || "").trim() || "http://127.0.0.1:3000");
+    url.pathname = url.pathname.replace(/\/+$/, "");
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return "http://127.0.0.1:3000";
+  }
+}
+
+function readRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function forwardCookieHeader(req) {
+  return req.headers.cookie ? { "cookie": req.headers.cookie } : {};
+}
+
+async function proxyOttoAuthJson(req, res, {
+  path: upstreamPath,
+  method = req.method,
+  body = null,
+  headers = {},
+} = {}) {
+  try {
+    const upstreamResponse = await fetch(`${buildOttoAuthBaseUrl}${upstreamPath}`, {
+      method,
+      headers: {
+        "accept": "application/json",
+        ...forwardCookieHeader(req),
+        ...headers,
+      },
+      ...(body == null ? {} : { body }),
+      redirect: "manual",
+    });
+    const responseBody = await upstreamResponse.text();
+    res.statusCode = upstreamResponse.status;
+    res.setHeader(
+      "content-type",
+      upstreamResponse.headers.get("content-type") || "application/json; charset=utf-8"
+    );
+    res.setHeader("cache-control", "no-store");
+    res.end(responseBody);
+  } catch (error) {
+    sendJson(res, 502, {
+      error: `Could not reach OttoAuth at ${buildOttoAuthBaseUrl}.`,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function proxyOttoAuthRaw(req, res, {
+  path: upstreamPath,
+  method = req.method,
+  body = null,
+  headers = {},
+} = {}) {
+  try {
+    const upstreamResponse = await fetch(`${buildOttoAuthBaseUrl}${upstreamPath}`, {
+      method,
+      headers: {
+        "accept": "application/json",
+        ...forwardCookieHeader(req),
+        ...headers,
+      },
+      ...(body == null ? {} : { body }),
+      redirect: "manual",
+    });
+    const responseBody = await upstreamResponse.text();
+    res.statusCode = upstreamResponse.status;
+    res.setHeader(
+      "content-type",
+      upstreamResponse.headers.get("content-type") || "application/json; charset=utf-8"
+    );
+    res.setHeader("cache-control", "no-store");
+    res.end(responseBody);
+  } catch (error) {
+    sendJson(res, 502, {
+      error: `Could not reach OttoAuth at ${buildOttoAuthBaseUrl}.`,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function provisionLocalOttoAuthAgent(req, res, body = null) {
+  try {
+    const upstreamResponse = await fetch(`${buildOttoAuthBaseUrl}/api/sdk/local-agent`, {
+      method: "POST",
+      headers: {
+        "accept": "application/json",
+        "content-type": "application/json",
+        ...forwardCookieHeader(req),
+      },
+      body: body && body.length
+        ? body
+        : JSON.stringify({
+            tool_name: "cad-explorer",
+            app_id: "cad-explorer",
+            app_name: "CAD Explorer",
+            agent_name: "CAD Explorer local coding agent",
+          }),
+      redirect: "manual",
+    });
+    const responseText = await upstreamResponse.text();
+    let payload = null;
+    try {
+      payload = responseText ? JSON.parse(responseText) : null;
+    } catch {
+      payload = { error: responseText };
+    }
+
+    if (!upstreamResponse.ok) {
+      sendJson(res, upstreamResponse.status, payload || {
+        error: `OttoAuth request failed with status ${upstreamResponse.status}.`,
+      });
+      return;
+    }
+
+    const stored = writeOttoAuthLocalAgentCredential({
+      workspaceRoot,
+      payload,
+      baseUrl: buildOttoAuthBaseUrl,
+    });
+    sendJson(res, 200, stored);
+  } catch (error) {
+    sendJson(res, 502, {
+      error: `Could not provision local OttoAuth agent credentials from ${buildOttoAuthBaseUrl}.`,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function submitOttoAuthAgentTask(res, body) {
+  const credential = readOttoAuthLocalAgentCredential({ workspaceRoot });
+  if (!credential) {
+    sendJson(res, 409, {
+      error:
+        "No local OttoAuth linked agent credentials are available. Sign in with Google through OttoAuth, then reopen Buy Parts Now.",
+    });
+    return;
+  }
+
+  let payload = null;
+  try {
+    payload = body && body.length ? JSON.parse(body.toString("utf8")) : {};
+  } catch {
+    sendJson(res, 400, { error: "Invalid JSON body." });
+    return;
+  }
+
+  try {
+    const upstreamResponse = await fetch(`${buildOttoAuthBaseUrl}/api/sdk/checkout`, {
+      method: "POST",
+      headers: {
+        "accept": "application/json",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        ...payload,
+        username: credential.username,
+        private_key: credential.privateKey,
+      }),
+    });
+    const responseBody = await upstreamResponse.text();
+    res.statusCode = upstreamResponse.status;
+    res.setHeader(
+      "content-type",
+      upstreamResponse.headers.get("content-type") || "application/json; charset=utf-8"
+    );
+    res.setHeader("cache-control", "no-store");
+    res.end(responseBody);
+  } catch (error) {
+    sendJson(res, 502, {
+      error: `Could not submit OttoAuth agent task to ${buildOttoAuthBaseUrl}.`,
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 function cadCatalogPlugin() {
   const virtualId = "virtual:cad-catalog";
   const resolvedVirtualId = `\0${virtualId}`;
@@ -230,6 +421,134 @@ function cadCatalogPlugin() {
     },
     configureServer(server) {
       const servedExplorerRoot = activateDirectory(server, buildExplorerRootDir);
+      server.middlewares.use(async (req, res, next) => {
+        const requestUrl = new URL(req.url || "/", "http://localhost");
+        if (requestUrl.pathname !== "/__ottoauth/me") {
+          next();
+          return;
+        }
+        if (req.method !== "GET") {
+          res.setHeader("allow", "GET");
+          sendJson(res, 405, { error: "Method not allowed." });
+          return;
+        }
+        await proxyOttoAuthJson(req, res, {
+          path: "/api/sdk/me?app_id=cad-explorer&app_name=CAD%20Explorer",
+          method: "GET",
+        });
+      });
+      server.middlewares.use(async (req, res, next) => {
+        const requestUrl = new URL(req.url || "/", "http://localhost");
+        if (requestUrl.pathname !== "/__ottoauth/local-agent") {
+          next();
+          return;
+        }
+        if (req.method !== "POST" && req.method !== "GET") {
+          res.setHeader("allow", "GET, POST");
+          sendJson(res, 405, { error: "Method not allowed." });
+          return;
+        }
+
+        let body = null;
+        if (req.method === "POST") {
+          try {
+            body = await readRequestBody(req);
+          } catch (error) {
+            sendJson(res, 400, {
+              error: error instanceof Error ? error.message : "Could not read request body.",
+            });
+            return;
+          }
+        }
+
+        await provisionLocalOttoAuthAgent(req, res, body);
+      });
+      server.middlewares.use(async (req, res, next) => {
+        const requestUrl = new URL(req.url || "/", "http://localhost");
+        if (requestUrl.pathname !== "/__ottoauth/files") {
+          next();
+          return;
+        }
+        if (req.method !== "POST") {
+          res.setHeader("allow", "POST");
+          sendJson(res, 405, { error: "Method not allowed." });
+          return;
+        }
+
+        let body;
+        try {
+          body = await readRequestBody(req);
+        } catch (error) {
+          sendJson(res, 400, {
+            error: error instanceof Error ? error.message : "Could not read request body.",
+          });
+          return;
+        }
+
+        await proxyOttoAuthRaw(req, res, {
+          path: "/api/sdk/files",
+          method: "POST",
+          body,
+          headers: {
+            "content-type": req.headers["content-type"] || "application/octet-stream",
+          },
+        });
+      });
+      server.middlewares.use(async (req, res, next) => {
+        const requestUrl = new URL(req.url || "/", "http://localhost");
+        if (requestUrl.pathname !== "/__ottoauth/human-task") {
+          next();
+          return;
+        }
+        if (req.method !== "POST") {
+          res.setHeader("allow", "POST");
+          sendJson(res, 405, { error: "Method not allowed." });
+          return;
+        }
+
+        let body;
+        try {
+          body = await readRequestBody(req);
+        } catch (error) {
+          sendJson(res, 400, {
+            error: error instanceof Error ? error.message : "Could not read request body.",
+          });
+          return;
+        }
+
+        await proxyOttoAuthJson(req, res, {
+          path: "/api/sdk/checkout",
+          method: "POST",
+          body,
+          headers: {
+            "content-type": req.headers["content-type"] || "application/json",
+          },
+        });
+      });
+      server.middlewares.use(async (req, res, next) => {
+        const requestUrl = new URL(req.url || "/", "http://localhost");
+        if (requestUrl.pathname !== "/__ottoauth/agent-task") {
+          next();
+          return;
+        }
+        if (req.method !== "POST") {
+          res.setHeader("allow", "POST");
+          sendJson(res, 405, { error: "Method not allowed." });
+          return;
+        }
+
+        let body;
+        try {
+          body = await readRequestBody(req);
+        } catch (error) {
+          sendJson(res, 400, {
+            error: error instanceof Error ? error.message : "Could not read request body.",
+          });
+          return;
+        }
+
+        await submitOttoAuthAgentTask(res, body);
+      });
       server.middlewares.use((req, res, next) => {
         const requestUrl = new URL(req.url || "/", "http://localhost");
         if (requestUrl.pathname !== "/__cad/catalog") {

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ node_modules
 dist
 dist-verify
 coverage
+.agents/ottoauth.local.json
+.agents/.env.ottoauth.local
 
 # Temporary files
 *.tmp

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ An open source harness for generating 3D models with your favorite coding agent
 - **Generate** - Create source-controlled CAD models with coding agents like Codex and Claude Code.
 - **Export** - Produce STEP, STL, 3MF, DXF, GLB, topology data, and URDF robot descriptions.
 - **Browse** - Inspect generated geometry in CAD Explorer.
+- **Buy** - Connect OttoAuth, upload the current CAD project and assembly parts, choose a supplier, and submit a one-click parts-sourcing or manufacturing request.
 - **Reference** - Copy stable `@cad[...]` references so agents can make precise follow-up edits.
 - **Review** - Render quick snapshots for fast checks during an iteration loop.
 - **Reproduce** - Edit source files first, then regenerate explicit targets.


### PR DESCRIPTION
## Summary
- add a CAD Explorer Buy Parts Now action with OttoAuth connect/login flow
- upload CAD files to OttoAuth and submit checkout through a linked local agent credential
- add a CLI path for coding agents to submit the same CAD-aware buy-parts request

## Verification
- npm --prefix .agents/skills/cad/explorer run test:node
- npm --prefix .agents/skills/cad/explorer run build:app
- BASE_URL=http://127.0.0.1:3000 TEXT_TO_CAD_ROOT=/Users/mark/Desktop/projects/oneclickstack/text-to-cad npm run verify:cad-e2e (in OttoAuth repo)