### PR TITLE
fix(cad): assembly displayName uses instance.name; absolute EXPLORER_ROOT_DIR works

### DIFF
--- a/.agents/skills/cad/explorer/lib/cadDirectoryScanner.mjs
+++ b/.agents/skills/cad/explorer/lib/cadDirectoryScanner.mjs
@@ -32,7 +32,7 @@ function encodeUrlPath(repoRelativePath) {
 
 export function normalizeExplorerRootDir(value = DEFAULT_EXPLORER_ROOT_DIR) {
   const rawValue = String(value ?? "").trim();
-  const slashNormalized = rawValue.replace(/\\/g, "/").replace(/^\/+/, "");
+  const slashNormalized = rawValue.replace(/\\/g, "/");
   const normalized = path.posix.normalize(slashNormalized);
   if (!normalized || normalized === ".") {
     return DEFAULT_EXPLORER_ROOT_DIR;
@@ -40,12 +40,19 @@ export function normalizeExplorerRootDir(value = DEFAULT_EXPLORER_ROOT_DIR) {
   if (normalized === ".." || normalized.startsWith("../")) {
     throw new Error(`Explorer root directory must stay inside the workspace: ${rawValue}`);
   }
-  return normalized.replace(/\/+$/, "");
+  // Preserve a leading slash so absolute paths flow through to
+  // resolveExplorerRoot intact; previously we stripped it, which made an
+  // absolute EXPLORER_ROOT_DIR silently resolve as a workspace-relative
+  // join onto a nonsensical location.
+  return normalized.replace(/(?!^\/)\/+$/, "");
 }
 
 export function resolveExplorerRoot(repoRoot, rootDir = DEFAULT_EXPLORER_ROOT_DIR) {
   const normalizedDir = normalizeExplorerRootDir(rootDir);
   const resolvedRepoRoot = path.resolve(repoRoot);
+  // path.resolve accepts absolute later arguments and uses them verbatim,
+  // so an absolute normalizedDir overrides resolvedRepoRoot here. The
+  // workspace-containment check below still rejects paths outside repoRoot.
   const rootPath = normalizedDir
     ? path.resolve(resolvedRepoRoot, normalizedDir)
     : resolvedRepoRoot;

--- a/.agents/skills/cad/explorer/lib/cadDirectoryScanner.test.mjs
+++ b/.agents/skills/cad/explorer/lib/cadDirectoryScanner.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   isServedCadAsset,
   normalizeExplorerRootDir,
+  resolveExplorerRoot,
   scanCadDirectory,
 } from "./cadDirectoryScanner.mjs";
 
@@ -104,6 +105,39 @@ test("normalizeExplorerRootDir rejects traversal", () => {
   assert.equal(normalizeExplorerRootDir(""), "");
   assert.equal(normalizeExplorerRootDir("workspace/samples"), "workspace/samples");
   assert.throws(() => normalizeExplorerRootDir("../workspace"), /inside the workspace/);
+});
+
+test("normalizeExplorerRootDir preserves absolute paths", () => {
+  // Previously the leading slash was stripped, which silently turned an
+  // absolute EXPLORER_ROOT_DIR into a workspace-relative join onto a
+  // nonsense path. Now the leading slash flows through to resolveExplorerRoot.
+  assert.equal(normalizeExplorerRootDir("/abs/path/exports"), "/abs/path/exports");
+  assert.equal(normalizeExplorerRootDir("/abs/path/exports/"), "/abs/path/exports");
+});
+
+test("resolveExplorerRoot accepts an absolute path inside the workspace", () => {
+  const repo = makeTempRepo();
+  try {
+    const absoluteDir = path.join(repo, "exports");
+    fs.mkdirSync(absoluteDir, { recursive: true });
+    const resolved = resolveExplorerRoot(repo, absoluteDir);
+    assert.equal(resolved.rootPath, path.resolve(absoluteDir));
+    assert.equal(resolved.rootName, "exports");
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("resolveExplorerRoot rejects an absolute path outside the workspace", () => {
+  const repo = makeTempRepo();
+  try {
+    assert.throws(
+      () => resolveExplorerRoot(repo, "/elsewhere/outside"),
+      /inside the workspace/,
+    );
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
 });
 
 test("isServedCadAsset allows only explorer.json inside URDF sidecar directories", () => {

--- a/.agents/skills/cad/scripts/common/assembly_composition.py
+++ b/.agents/skills/cad/scripts/common/assembly_composition.py
@@ -160,13 +160,17 @@ def _linked_instance_node(
     world_transform = multiply_transforms(parent_world_transform, instance_transform)
     source_step_path = getattr(source_spec, "step_path", None) if source_spec is not None else None
     source_path = _relative_to_topology(topology_path, Path(source_step_path)) if source_step_path is not None else (instance.path or "")
+    # Prefer the user-supplied instance name (it is required by the generator
+    # contract and intentionally chosen for display); fall back to the source
+    # STEP filename stem only when no instance name is set, then to the
+    # instance-path component as a last resort.
     display_name = str(
-        (
+        instance.name
+        or (
             Path(source_step_path).stem
             if source_step_path is not None
             else Path(instance.path or "").stem
         )
-        or instance.name
         or instance_path[-1]
     ).strip()
     use_source_colors = parent_use_source_colors and bool(instance.use_source_colors)

--- a/.agents/skills/cad/scripts/common/tests/test_assembly_composition.py
+++ b/.agents/skills/cad/scripts/common/tests/test_assembly_composition.py
@@ -280,7 +280,7 @@ class NativeAssemblyCompositionTests(unittest.TestCase):
             child["topologyCounts"],
         )
 
-    def test_linked_assembly_prefers_source_step_stem_over_custom_instance_name(self) -> None:
+    def test_linked_assembly_prefers_instance_name_over_source_step_stem(self) -> None:
         leaf_step_path = self._write_catalog_step("parts/leaf")
         self._write_source_topology(leaf_step_path)
         topology_path = self._write_topology(
@@ -330,7 +330,7 @@ class NativeAssemblyCompositionTests(unittest.TestCase):
         )
 
         child = payload["root"]["children"][0]
-        self.assertEqual("leaf", child["displayName"])
+        self.assertEqual("custom_leaf_instance", child["displayName"])
 
     def test_linked_generated_subassembly_expands_to_descendant_leaf_nodes(self) -> None:
         module_step_path = self._write_catalog_step("assemblies/module")


### PR DESCRIPTION
## Summary

Two independent CAD skill bug fixes that surfaced while wiring a real downstream project (a quadruped robot whose 7 fab parts × 4 leg variants land under `exports/parts/<name>/<leg>.{step,stl}` and are then composed by `assembly/leg_module/<leg>.py` instances).

### `scripts/common/assembly_composition.py` — assembly displayName precedence

`_linked_instance_node` previously took `displayName` from the source STEP filename stem first and only fell back to `instance.name`. The generator contract makes `name` a **required**, intentionally-chosen, per-instance string; treating the filename stem as authoritative collapsed every component of a per-leg assembly to the leg label — every child in the explorer tree showed `bl` instead of `haa_shell_BL`, `thigh_BL`, etc.

This PR flips the precedence (`instance.name` → stem → instance-path component). The filename-stem fallback is retained for the path where `instance.name` happens to be empty.

The existing `test_linked_assembly_prefers_source_step_stem_over_custom_instance_name` codified the old behaviour; it is renamed to `test_linked_assembly_prefers_instance_name_over_source_step_stem` and its assertion flipped accordingly.

### `explorer/lib/cadDirectoryScanner.mjs` — absolute EXPLORER_ROOT_DIR

`normalizeExplorerRootDir()` unconditionally stripped the leading slash from `EXPLORER_ROOT_DIR` before normalization, so an absolute path like `/abs/path/exports` silently became `abs/path/exports` and was resolved as a workspace-relative join onto a nonsense location — the scan returned zero entries with no error.

This PR drops the leading-slash strip so `resolveExplorerRoot` (which already validates workspace containment via `path.relative` + `startsWith("..")`) accepts absolute inputs verbatim. The trailing-slash strip is also tightened so a bare `/` does not collapse to empty.

Adds three tests:
- `normalizeExplorerRootDir preserves absolute paths`
- `resolveExplorerRoot accepts an absolute path inside the workspace`
- `resolveExplorerRoot rejects an absolute path outside the workspace`

## Test Plan

- [x] `python -m unittest common.tests.test_assembly_composition -v` from `scripts/` — 9/9 pass
- [x] `node --test lib/cadDirectoryScanner.test.mjs` from `explorer/` — 10/10 pass
- [x] downstream end-to-end: regenerated a 10-instance per-leg assembly STEP and confirmed each child node in `topology.json`'s `assembly.root.children[].displayName` is now the per-instance name, and the dev server with absolute `EXPLORER_ROOT_DIR=/<workspace>/exports` lists the entries (previously zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)