### PR TITLE
feat: add right-click context menu with Download option to file explorer

### DIFF
--- a/.agents/skills/cad/explorer/components/ui/context-menu.jsx
+++ b/.agents/skills/cad/explorer/components/ui/context-menu.jsx
@@ -1,0 +1,77 @@
+"use client";
+
+import * as React from "react";
+import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function ContextMenu({
+  ...props
+}) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
+}
+
+function ContextMenuTrigger({
+  ...props
+}) {
+  return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />;
+}
+
+function ContextMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "cad-glass-popover z-50 min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  ...props
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 focus:bg-accent focus:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+};

--- a/.agents/skills/cad/explorer/components/workbench/FileExplorerSidebar.js
+++ b/.agents/skills/cad/explorer/components/workbench/FileExplorerSidebar.js
@@ -2,6 +2,7 @@ import {
   Bot,
   Boxes,
   ChevronRight,
+  Download,
   DraftingCompass,
   LoaderCircle,
   Package,
@@ -13,6 +14,12 @@ import {
   CollapsibleTrigger
 } from "@/components/ui/collapsible";
 import { Button } from "@/components/ui/button";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from "@/components/ui/context-menu";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sidebar,
@@ -94,26 +101,48 @@ function FileEntryButton({
     String(entry?.source?.path || entry?.step?.path || "")
   ].filter(Boolean).join(" | ");
 
+  const handleDownload = () => {
+    const sourcePath = entry?.source?.path || entry?.step?.path;
+    if (!sourcePath) return;
+    const url = `/${sourcePath}`;
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = sourcePath.split("/").pop() || sourcePath;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+  };
+
   return (
-    <SidebarMenuButton
-      type="button"
-      isActive={active}
-      size="sm"
-      title={title}
-      className={cn(
-        "min-w-0 w-full justify-start"
-      )}
-      onClick={() => {
-        onSelectEntry(key);
-        if (isMobile) {
-          setOpenMobile(false);
-        }
-      }}
-      tooltip={label}
-    >
-      <EntryIcon className={cn(pending && !missingArtifacts && "animate-spin")} aria-hidden="true" />
-      <span className="block min-w-0 flex-1 max-w-full overflow-hidden text-ellipsis whitespace-nowrap">{label}</span>
-    </SidebarMenuButton>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <SidebarMenuButton
+          type="button"
+          isActive={active}
+          size="sm"
+          title={title}
+          className={cn(
+            "min-w-0 w-full justify-start"
+          )}
+          onClick={() => {
+            onSelectEntry(key);
+            if (isMobile) {
+              setOpenMobile(false);
+            }
+          }}
+          tooltip={label}
+        >
+          <EntryIcon className={cn(pending && !missingArtifacts && "animate-spin")} aria-hidden="true" />
+          <span className="block min-w-0 flex-1 max-w-full overflow-hidden text-ellipsis whitespace-nowrap">{label}</span>
+        </SidebarMenuButton>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem onSelect={handleDownload}>
+          <Download className="size-4" aria-hidden="true" />
+          Download
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 

--- a/.agents/skills/cad/explorer/components/workbench/FloatingToolBar.js
+++ b/.agents/skills/cad/explorer/components/workbench/FloatingToolBar.js
@@ -2,6 +2,7 @@ import {
   Copy,
   Crosshair,
   Download,
+  FileDown,
   MousePointer2,
   Play,
   PenTool
@@ -29,6 +30,7 @@ function DesktopFloatingToolBar({
   explorerLoading,
   selectedMeshData,
   selectedDxfData,
+  selectedEntry,
   drawingToolOptions,
   drawingTool,
   handleSelectDrawingTool,
@@ -129,6 +131,24 @@ function DesktopFloatingToolBar({
           >
             <Download className="size-3.5" strokeWidth={2} aria-hidden="true" />
           </ToolbarButton>
+
+          <ToolbarButton
+            label="Download file"
+            disabled={!selectedEntry}
+            onClick={() => {
+              const sourcePath = selectedEntry?.source?.path || selectedEntry?.step?.path;
+              if (!sourcePath) return;
+              const url = `/${sourcePath}`;
+              const anchor = document.createElement("a");
+              anchor.href = url;
+              anchor.download = sourcePath.split("/").pop() || sourcePath;
+              document.body.appendChild(anchor);
+              anchor.click();
+              document.body.removeChild(anchor);
+            }}
+          >
+            <FileDown className="size-3.5" strokeWidth={2} aria-hidden="true" />
+          </ToolbarButton>
         </div>
       </TooltipProvider>
 
@@ -159,5 +179,5 @@ export default function FloatingToolBar({
     return null;
   }
 
-  return <DesktopFloatingToolBar {...toolbarProps} />;
+  return <DesktopFloatingToolBar selectedEntry={selectedEntry} {...toolbarProps} />;
 }


### PR DESCRIPTION
## Summary

Adds file download capabilities to CAD Explorer through two access points:

### 1. Right-click context menu on sidebar entries
Right-click any file in the explorer sidebar and select "Download" to save the source file.

**New:** `components/ui/context-menu.jsx` wraps `@radix-ui/react-context-menu` (already installed as peer dep of `radix-ui`), following the existing `dropdown-menu.jsx` pattern.

### 2. Floating toolbar button
A `FileDown` icon button sits next to "Download screenshot" in the floating CAD toolbar. Visible whenever a model is selected, it downloads the source file with one click.

**Modified:** `components/workbench/FloatingToolBar.js` passes `selectedEntry` through to `DesktopFloatingToolBar` and adds the download button.

## How it works
Both access points read `source.path` from the selected catalog entry, construct a URL served by the existing Vite CAD asset middleware, and trigger a browser download with the original filename.

## Files changed
- **New:** `components/ui/context-menu.jsx`
- **Modified:** `components/workbench/FileExplorerSidebar.js`
- **Modified:** `components/workbench/FloatingToolBar.js`

## Testing
- Downloaded `trophy.step` (126KB) and `trophy.stl` (440KB) via both access points
- Context menu only appears on file entries (not directories)
- Toolbar button disabled when no file is selected