### PR TITLE
WIP: feat(viewer): copy CAD review state URL

### DIFF
--- a/viewer/docs/cad-review-state-url.md
+++ b/viewer/docs/cad-review-state-url.md
@@ -1,0 +1,103 @@
+# CAD Review State URL Payload
+
+This document defines the state that should be shared when a CAD Explorer user copies a review URL. The goal is to reproduce the reviewed model context without copying raw browser session storage.
+
+## Goal
+
+A copied review URL should allow another viewer session to open the same CAD file and restore the review-relevant 3D context: camera, selected entities, visibility, active assembly context, and clipping.
+
+The URL payload is not intended to mirror every transient UI state. Local persistence such as sessionStorage remains responsible for private, transparent restoration on the same browser.
+
+## Priority model
+
+- **P0 required**: missing this breaks review-state reproduction.
+- **P1 recommended**: improves semantic fidelity and diagnostics, but the core 3D review can still open without it.
+- **P2 optional**: useful for polish or format-specific workflows, but should not dominate the URL payload by default.
+- **Do not share**: transient or local-only state.
+
+## State inventory
+
+| Area | Parameters | Priority | Why it matters | URL placement |
+| --- | --- | --- | --- | --- |
+| File identity | `file.key`, `file.cadPath` | P0 | Selects the model the review state applies to. All camera, selection, and visibility IDs are meaningless on the wrong file. | Keep `file` readable in the URL; include both values in `view`. |
+| File metadata | `file.renderFormat` | P1 | Helps interpret format-specific state and validate restore behavior. | `view.file.renderFormat` |
+| File validation | content/topology/render signatures | P1 | Detects stale links or same-name/different-content models before applying IDs incorrectly. | Future `view.file.signatures` |
+| Camera | `position`, `target`, `up` | P0 | The minimum 3D viewpoint. | `view.camera.perspective` |
+| Camera metadata | `modelKey`, `sceneScaleMode`, `coordinateSystem` | P0 | The same numeric camera can render differently if model binding, scale mode, or coordinate system differ. | `view.camera.perspective` |
+| Projection | projection type, zoom/FOV | P1/future P0 | Needed once the viewer supports orthographic/perspective switching or explicit projection settings. | Future `view.camera.projection` |
+| Scene mode | `explorerMode` | P2/future | The 0.2 workspace does not expose a durable scene-mode state yet. Add this only when the viewer has a concrete mode to read and restore. | Future `view.scene.explorerMode` |
+| Scene mapping | `selectedRenderPartIdByAssemblyPartId` | P0 | Restores the render mesh that backs an assembly-part selection. | `view.scene.selectedRenderPartIdByAssemblyPartId` |
+| Scene path | active assembly path / expanded assembly context | P0/P1 | Required when assembly expansion also represents the active review context; otherwise it is sidebar context. | `view.assembly.expandedAssemblyPartIds` |
+| Selection | `selectedPartIds`, `selectedReferenceIds` | P0 | Defines what the review is pointing at. | `view.selection` |
+| Stable selection fallback | `cadRefs` | P1 | Internal IDs are fast, but cadRef tokens are better fallbacks across minor topology/ID changes. | `view.selection.cadRefs` |
+| Whole-model selection | selected whole-entry cadRef token | P1 | Distinguishes whole-model selection from no entity selection. | Future `view.selection.selectedWholeEntryCadRefToken` |
+| Visibility | `hiddenPartIds` | P0 | Hidden geometry changes the actual reviewed view. | `view.visibility.hiddenPartIds` (currently normalized from legacy `assembly.hiddenPartIds`) |
+| Visibility focus/isolate | focused/isolated part IDs and mode | P0/P1 | If the viewer is showing an isolated subset, the copied state must reproduce that subset. | Future `view.visibility` |
+| Clip | complete clip settings object | P0 | Clipping changes the visible geometry and review target. Avoid reducing it to `axis,plane` only. | `view.clip` (currently normalized from legacy `view.clipSettings`) |
+| Tree context | expanded STEP tree nodes | P1 | Helps recipients understand where the selected entity lives in the sidebar. | `view.assembly.expandedTreeNodeIds` |
+| Review workspace | active tool/tab, selected sheet | P1 | Opens the recipient near the same review affordance, e.g. References. | Future `view.workspace` |
+| Appearance | display mode, edges/wireframe | P1 if present | Can affect whether CAD review details are visible. | Future `view.appearance` |
+| Theme | theme preset/settings | P2 | Affects visual appearance, but is user preference and currently localStorage-oriented. | Do not force by default. |
+| Panel layout | sidebar/tool open, widths | P2 | Mostly device/user preference; widths are especially screen-dependent. | Avoid or keep minimal. |
+| STEP parametric state | parameters, module enabled, animation pose | Format-specific P0/P1 | A parametric STEP file can represent a different model if parameters differ. | Future `view.format.stepModule` |
+| URDF state | joint values | Format-specific P0 | Robot posture is part of the reviewed model. | Future `view.format.urdf` |
+| DXF state | thickness and bend settings | Format-specific P0 | Sheet-metal geometry depends on these settings. | Future `view.format.dxf` |
+| Hover | hovered part/ref | Do not share | Hover is transient and should not be part of a durable review link. | Exclude |
+| Runtime state | loading/error/status | Do not share | Not review state. | Exclude |
+| Browser persistence | raw sessionStorage/localStorage keys | Do not share | Local restore mechanism, not cross-user share state. | Exclude |
+
+## P0 URL payload implemented now
+
+The P0 payload should be a compact review-state document encoded into the `view` query parameter:
+
+```text
+?file=<fileKey>&view=<encoded-review-state>
+```
+
+The P0 document shape is:
+
+```js
+{
+  schema: "cad-review-state",
+  version: 1,
+  file: {
+    key: string,
+    cadPath: string,
+    renderFormat: string
+  },
+  camera: {
+    perspective: {
+      position: [number, number, number],
+      target: [number, number, number],
+      up: [number, number, number],
+      modelKey: string,
+      sceneScaleMode: string,
+      coordinateSystem: string
+    }
+  },
+  scene: {
+    selectedRenderPartIdByAssemblyPartId: Record<string, string>
+  },
+  selection: {
+    selectedPartIds: string[],
+    selectedReferenceIds: string[],
+    cadRefs: string[]
+  },
+  visibility: {
+    hiddenPartIds: string[]
+  },
+  clip: object | null,
+  assembly: {
+    expandedAssemblyPartIds: string[]
+  }
+}
+```
+
+Legacy URL payloads using `cad-explorer-view-state` remain accepted for URL compatibility, but copied URLs should prefer the explicit `cad-review-state` P0 schema.
+
+## Non-goals for the P0 pass
+
+- Do not encode raw sessionStorage.
+- Do not restore hover/tooltips/loading/error state.
+- Do not force the recipient's theme or pixel layout.
+- Do not solve format-specific STEP/URDF/DXF pose state yet; those belong to follow-up passes.

--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -299,6 +299,12 @@ import {
   normalizeParameterValues
 } from "implicitjs/common/parameters.js";
 import { copyTextToClipboard, readTextFromClipboard } from "@/ui/clipboard";
+import {
+  buildCadViewState,
+  buildCadViewStateFromParams,
+  buildCadViewStateQueryString,
+  normalizeCadViewStateForApply
+} from "@/workbench/viewState";
 import { triggerUrlDownload } from "@/ui/download";
 import {
   copyTargetsForFileAccessAsset,
@@ -1090,6 +1096,47 @@ function normalizeViewerDirectoryOptions(viewerServerInfo) {
   return options;
 }
 
+function readCurrentExplorerPerspective({ explorerRef, activePerspectiveRef, fallbackPerspective } = {}) {
+  return clonePerspectiveSnapshot(
+    explorerRef?.current?.getPerspective?.() ||
+    activePerspectiveRef?.current ||
+    fallbackPerspective
+  );
+}
+
+function buildWorkspaceLayoutViewState({
+  sidebarOpen,
+  selectedFileSheetKind,
+  tabToolsOpen,
+  workspaceLayoutMode
+} = {}) {
+  return {
+    sidebarOpen,
+    selectedFileSheetKind,
+    tabToolsOpen,
+    workspaceLayoutMode
+  };
+}
+
+function applyRestoredExplorerPerspective(explorerRef, perspective) {
+  const restoredPerspective = clonePerspectiveSnapshot(perspective);
+  if (!restoredPerspective) {
+    return false;
+  }
+
+  const apply = () => explorerRef.current?.setPerspective?.(restoredPerspective, { animate: false }) === true;
+  const applied = apply();
+  if (typeof window !== "undefined") {
+    window.requestAnimationFrame?.(() => {
+      apply();
+    });
+    window.setTimeout(() => {
+      apply();
+    }, 120);
+  }
+  return applied;
+}
+
 export default function CadWorkspace({
   manifestEntries: manifestEntriesProp = [],
   generationStatus = null,
@@ -1258,6 +1305,20 @@ export default function CadWorkspace({
   const implicitParameterInteractionTimerRef = useRef(0);
   const [urdfPosePickerState, setUrdfPosePickerState] = useState(emptyUrdfPosePickerState);
   const [pendingCadRefQueryParams, setPendingCadRefQueryParams] = useState(() => readCadRefQueryParams());
+  const pendingViewStateErrorRef = useRef("");
+  const pendingViewStateRef = useRef(null);
+  const pendingViewStateParsedRef = useRef(false);
+  if (!pendingViewStateParsedRef.current && typeof window !== "undefined") {
+    pendingViewStateParsedRef.current = true;
+    try {
+      pendingViewStateRef.current = buildCadViewStateFromParams(
+        new URLSearchParams(window.location.search),
+        { cadPath: readCadParam() || "" }
+      );
+    } catch (error) {
+      pendingViewStateErrorRef.current = error instanceof Error ? error.message : "Invalid CAD review state URL";
+    }
+  }
   const lastPersistenceFailureKeyRef = useRef("");
   const urdfTrajectoryPlaybackRef = useRef({
     frameId: 0,
@@ -6639,6 +6700,166 @@ export default function CadWorkspace({
     cadDirectorySessionBootstrappedRef
   ]);
 
+  // Apply view state from URL query params on initial page load.
+  const viewStateFromUrlAppliedRef = useRef(false);
+  useEffect(() => {
+    if (viewStateFromUrlAppliedRef.current) return;
+    if (pendingViewStateErrorRef.current) {
+      setCopyStatus(pendingViewStateErrorRef.current);
+      viewStateFromUrlAppliedRef.current = true;
+      return;
+    }
+    const viewState = pendingViewStateRef.current;
+    if (!viewState) {
+      viewStateFromUrlAppliedRef.current = true;
+      return;
+    }
+    if (!selectedEntry) return;
+    const viewStateCadPath = String(viewState.file?.cadPath || "").trim();
+    const viewStateFileKey = String(viewState.file?.key || viewState.file?.entry?.file || "").trim();
+    const selectedEntryFileKey = fileKey(selectedEntry);
+    const selectedEntryCadPath = cadPathForEntry(selectedEntry);
+    if (
+      (viewStateFileKey || viewStateCadPath) &&
+      selectedEntryFileKey !== viewStateFileKey &&
+      selectedEntryFileKey !== viewStateCadPath &&
+      selectedEntryCadPath !== viewStateFileKey &&
+      selectedEntryCadPath !== viewStateCadPath
+    ) {
+      viewStateFromUrlAppliedRef.current = true;
+      pendingViewStateRef.current = null;
+      return;
+    }
+    if (!selectedMeshMatches) return;
+    if (typeof viewerRef.current?.setPerspective !== "function") return;
+
+    const normalized = normalizeCadViewStateForApply(viewState);
+
+    // Camera
+    const perspective = normalized.camera?.perspective;
+    if (perspective) {
+      applyRestoredExplorerPerspective(viewerRef, perspective);
+      setViewerPerspective(perspective);
+      activePerspectiveRef.current = perspective;
+    }
+
+    // Selection
+    selectedPartIdsRef.current = normalized.selection.selectedPartIds;
+    setSelectedPartIds(normalized.selection.selectedPartIds);
+    selectedReferenceIdsRef.current = normalized.selection.selectedReferenceIds;
+    setSelectedReferenceIds(normalized.selection.selectedReferenceIds);
+
+    // Assembly / scene
+    setHiddenPartIds(normalized.assembly.hiddenPartIds);
+    setExpandedStepTreeNodeIds(normalized.assembly.expandedTreeNodeIds);
+    setIsolatedAssemblyNodeIds(
+      isAssemblyView
+        ? normalized.assembly.expandedAssemblyPartIds.filter((id) => id && id !== assemblyRootNodeId)
+        : []
+    );
+    setSelectedRenderPartIdByAssemblyPartId(normalized.scene.selectedRenderPartIdByAssemblyPartId);
+
+    // Clip
+    if (isStepView && normalized.view.clipSettings) {
+      updateDisplaySettings((current) => ({
+        ...current,
+        clip: normalized.view.clipSettings
+      }));
+    }
+
+    pendingViewStateRef.current = null;
+    viewStateFromUrlAppliedRef.current = true;
+  }, [assemblyRootNodeId, isAssemblyView, isStepView, selectedEntry, selectedMeshMatches]);
+
+  const handleCopyViewState = useCallback(async () => {
+    if (!selectedEntry) {
+      setCopyStatus("No file selected");
+      return;
+    }
+
+    try {
+      const selectedPartIds = selectedPartIdsRef.current;
+      const selectedReferenceIds = selectedReferenceIdsRef.current;
+      const currentPerspective = readCurrentExplorerPerspective({
+        explorerRef: viewerRef,
+        activePerspectiveRef,
+        fallbackPerspective: viewerPerspective
+      });
+      const layout = buildWorkspaceLayoutViewState({
+        sidebarOpen,
+        selectedFileSheetKind,
+        tabToolsOpen,
+        workspaceLayoutMode
+      });
+      const copiedExpandedAssemblyPartIds = isAssemblyView ? focusedAssemblyNodeIds : [];
+      const state = buildCadViewState({
+        entry: selectedEntry,
+        cadPath: cadPathForEntry(selectedEntry),
+        renderFormat: effectiveRenderFormat,
+        perspective: currentPerspective,
+        selectedPartIds,
+        selectedReferenceIds,
+        selectedCadRefs: copySelectionPayload.lines,
+        hoveredPartId,
+        hoveredReferenceId,
+        hiddenPartIds,
+        expandedTreeNodeIds: expandedStepTreeNodeIds,
+        expandedAssemblyPartIds: copiedExpandedAssemblyPartIds,
+        selectedRenderPartIdByAssemblyPartId,
+        clipSettings: isStepView ? displaySettings.clip : null,
+        themeSettings,
+        layout,
+        url: typeof window !== "undefined" ? window.location.href : "",
+        notes: "Open this copied review URL to restore the reviewed CAD context."
+      });
+      const queryString = buildCadViewStateQueryString(state);
+      const url = new URL(typeof window !== "undefined" ? window.location.href : "about:blank");
+      if (!url.searchParams.get("dir") && catalogRootDir) {
+        url.searchParams.set("dir", catalogRootDir);
+      }
+      if (!url.searchParams.get("file")) {
+        url.searchParams.set("file", fileKey(selectedEntry));
+      }
+      // Remove any existing view-state params before setting the full review-state payload.
+      for (const key of ["view", "v", "sr", "sp", "hp", "cp"]) {
+        url.searchParams.delete(key);
+      }
+      if (queryString) {
+        const viewParams = new URLSearchParams(queryString);
+        for (const [key, value] of viewParams.entries()) {
+          url.searchParams.set(key, value);
+        }
+      }
+      await copyTextToClipboard(url.href);
+      setScreenshotStatus("");
+      setCopyStatus("Copied view state URL");
+    } catch (error) {
+      setScreenshotStatus("");
+      setCopyStatus(error instanceof Error ? error.message : "Clipboard write failed");
+    }
+  }, [
+    catalogRootDir,
+    effectiveRenderFormat,
+    displaySettings,
+    expandedStepTreeNodeIds,
+    copySelectionPayload,
+    focusedAssemblyNodeIds,
+    selectedRenderPartIdByAssemblyPartId,
+    hiddenPartIds,
+    hoveredPartId,
+    hoveredReferenceId,
+    isAssemblyView,
+    isStepView,
+    selectedEntry,
+    selectedFileSheetKind,
+    sidebarOpen,
+    supportsPartSelection,
+    tabToolsOpen,
+    themeSettings,
+    viewerPerspective,
+    workspaceLayoutMode
+  ]);
+
   const expandStepTreeAroundNode = useCallback((nodeId, {
     expandSelf = false,
     includeVisualOnlyAncestors = true
@@ -8589,6 +8810,7 @@ export default function CadWorkspace({
                 canRedoDrawing={canRedoDrawing}
                 drawingStrokes={drawingStrokes}
                 handleEnterPreviewMode={handleEnterPreviewMode}
+                handleCopyViewState={handleCopyViewState}
                 handleScreenshotCopy={handleScreenshotCopy}
               />
 

--- a/viewer/src/client/components/workbench/FloatingToolBar.js
+++ b/viewer/src/client/components/workbench/FloatingToolBar.js
@@ -1,4 +1,5 @@
 import {
+  ClipboardList,
   Crosshair,
   Focus,
   MousePointer2,
@@ -44,6 +45,7 @@ function DesktopFloatingToolBar({
   canRedoDrawing,
   drawingStrokes,
   handleEnterPreviewMode,
+  handleCopyViewState,
   handleScreenshotCopy
 }) {
   const dxfMode = renderFormat === RENDER_FORMAT.DXF;
@@ -113,6 +115,16 @@ function DesktopFloatingToolBar({
               <Orbit className="size-3.5" strokeWidth={2} aria-hidden="true" />
             </ToolbarButton>
           ) : null}
+
+          <ToolbarButton
+            label="Copy view URL"
+            onClick={() => {
+              void handleCopyViewState();
+            }}
+            disabled={viewerLoading || !selectedMeshData}
+          >
+            <ClipboardList className="size-3.5" strokeWidth={2} aria-hidden="true" />
+          </ToolbarButton>
 
           <ToolbarButton
             label="Copy screenshot to clipboard"

--- a/viewer/src/client/workbench/viewState.js
+++ b/viewer/src/client/workbench/viewState.js
@@ -1,0 +1,529 @@
+export const CAD_EXPLORER_VIEW_STATE_SCHEMA = "cad-explorer-view-state";
+export const CAD_EXPLORER_VIEW_STATE_VERSION = 1;
+export const CAD_REVIEW_STATE_SCHEMA = "cad-review-state";
+export const CAD_REVIEW_STATE_VERSION = 1;
+
+/**
+ * Clipboard-safe snapshot of the CAD Explorer context needed to reproduce a reviewed view.
+ *
+ * @typedef {Object} CadExplorerViewState
+ * @property {"cad-explorer-view-state"} schema
+ * @property {number} version
+ * @property {string} createdAt
+ * @property {{key: string, cadPath: string, renderFormat: string, entry: Object|null}} file
+ * @property {{perspective: Object|null}} camera
+ * @property {{
+ *   selectedPartIds: string[],
+ *   selectedParts: Object[],
+ *   selectedReferenceIds: string[],
+ *   selectedReferences: Object[],
+ *   cadRefs: string[]
+ * }} selection
+ * @property {{partId: string, referenceId: string}} hover
+ * @property {{hiddenPartIds: string[], expandedTreeNodeIds: string[], expandedAssemblyPartIds: string[]}} assembly
+ * @property {{clipSettings: Object|null, themeSettings: Object|null, layout: Object|null}} view
+ * @property {{url: string}} browser
+ * @property {string} notes
+ */
+
+function normalizeString(value) {
+  return String(value || "").trim();
+}
+
+function uniqueStrings(values) {
+  const seen = new Set();
+  const result = [];
+  for (const value of Array.isArray(values) ? values : []) {
+    const normalized = normalizeString(value);
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function cloneJson(value) {
+  if (value === null || typeof value === "undefined") {
+    return null;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return null;
+  }
+}
+
+function cloneObject(value) {
+  const cloned = cloneJson(value);
+  return cloned && typeof cloned === "object" && !Array.isArray(cloned) ? cloned : {};
+}
+
+function normalizeStringMap(value) {
+  const source = value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  const result = {};
+  for (const [key, childValue] of Object.entries(source)) {
+    const normalizedKey = normalizeString(key);
+    const normalizedValue = normalizeString(childValue);
+    if (normalizedKey && normalizedValue) {
+      result[normalizedKey] = normalizedValue;
+    }
+  }
+  return result;
+}
+
+function encodeBase64Url(text) {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(String(text), "utf8").toString("base64url");
+  }
+  const bytes = new TextEncoder().encode(String(text));
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function decodeBase64Url(value) {
+  const normalized = String(value || "").replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(padded, "base64").toString("utf8");
+  }
+  const binary = atob(padded);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function clonePerspective(value) {
+  const cloned = cloneObject(value);
+  const position = Array.isArray(cloned.position) ? cloned.position.map(Number) : [];
+  const target = Array.isArray(cloned.target) ? cloned.target.map(Number) : [];
+  const up = Array.isArray(cloned.up) ? cloned.up.map(Number) : [];
+  if (
+    position.length < 3 ||
+    target.length < 3 ||
+    up.length < 3 ||
+    ![...position.slice(0, 3), ...target.slice(0, 3), ...up.slice(0, 3)].every(Number.isFinite)
+  ) {
+    return null;
+  }
+  return {
+    ...cloned,
+    position: position.slice(0, 3),
+    target: target.slice(0, 3),
+    up: up.slice(0, 3)
+  };
+}
+
+/**
+ * Normalize a POSIX-style path, resolving "." and ".." segments.
+ * Backslashes are treated as separators.
+ */
+export function normalizePosixPath(path) {
+  const parts = [];
+  for (const part of String(path || "").replace(/\\/g, "/").split("/")) {
+    if (!part || part === ".") {
+      continue;
+    }
+    if (part === "..") {
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return parts.join("/");
+}
+
+function entrySummary(entry) {
+  if (!entry) {
+    return null;
+  }
+  return {
+    key: normalizeString(entry.key),
+    kind: normalizeString(entry.kind),
+    name: normalizeString(entry.name),
+    file: normalizeString(entry.file),
+    path: normalizeString(entry.path),
+    cadPath: normalizeString(entry.cadPath),
+    sourcePath: normalizeString(entry.source?.path || entry.sourcePath),
+    stepPath: normalizeString(entry.step?.path || entry.stepPath)
+  };
+}
+
+function partSummary(part) {
+  return {
+    id: normalizeString(part?.id),
+    occurrenceId: normalizeString(part?.occurrenceId),
+    name: normalizeString(part?.name || part?.displayName || part?.label),
+    displayName: normalizeString(part?.displayName || part?.name || part?.label),
+    nodeType: normalizeString(part?.nodeType),
+    sourceKind: normalizeString(part?.sourceKind),
+    sourcePath: normalizeString(part?.sourcePath || part?.partSourcePath),
+    instancePath: normalizeString(part?.instancePath),
+    leafPartIds: uniqueStrings(part?.leafPartIds)
+  };
+}
+
+function referenceSummary(reference) {
+  return {
+    id: normalizeString(reference?.id),
+    copyText: normalizeString(reference?.copyText),
+    cadRef: normalizeString(reference?.cadRef),
+    displaySelector: normalizeString(reference?.displaySelector),
+    normalizedSelector: normalizeString(reference?.normalizedSelector),
+    selectorType: normalizeString(reference?.selectorType),
+    entityType: normalizeString(reference?.entityType),
+    partId: normalizeString(reference?.partId),
+    occurrenceId: normalizeString(reference?.occurrenceId),
+    summary: normalizeString(reference?.summary)
+  };
+}
+
+/**
+ * Build a normalized, versioned view-state document for clipboard sharing.
+ *
+ * @returns {CadExplorerViewState}
+ */
+export function buildCadViewState({
+  version = CAD_EXPLORER_VIEW_STATE_VERSION,
+  createdAt = new Date().toISOString(),
+  entry = null,
+  cadPath = "",
+  renderFormat = "",
+  perspective = null,
+  selectedPartIds = [],
+  selectedParts = [],
+  selectedReferenceIds = [],
+  selectedReferences = [],
+  selectedCadRefs = [],
+  hoveredPartId = "",
+  hoveredReferenceId = "",
+  hiddenPartIds = [],
+  expandedTreeNodeIds = [],
+  expandedAssemblyPartIds = [],
+  selectedRenderPartIdByAssemblyPartId = {},
+  explorerMode = "",
+  clipSettings = null,
+  themeSettings = null,
+  layout = null,
+  url = "",
+  notes = ""
+} = {}) {
+  const normalizedCadPath = normalizeString(cadPath);
+  const entryData = entrySummary(entry);
+  return {
+    schema: CAD_EXPLORER_VIEW_STATE_SCHEMA,
+    version,
+    createdAt,
+    file: {
+      key: entryData?.key || "",
+      cadPath: normalizedCadPath,
+      renderFormat: normalizeString(renderFormat),
+      entry: entryData
+    },
+    camera: {
+      perspective: clonePerspective(perspective)
+    },
+    selection: {
+      selectedPartIds: uniqueStrings(selectedPartIds),
+      selectedParts: (Array.isArray(selectedParts) ? selectedParts : []).map(partSummary).filter((part) => part.id),
+      selectedReferenceIds: uniqueStrings(selectedReferenceIds),
+      selectedReferences: (Array.isArray(selectedReferences) ? selectedReferences : []).map(referenceSummary).filter((reference) => reference.id),
+      cadRefs: uniqueStrings(selectedCadRefs)
+    },
+    hover: {
+      partId: normalizeString(hoveredPartId),
+      referenceId: normalizeString(hoveredReferenceId)
+    },
+    assembly: {
+      hiddenPartIds: uniqueStrings(hiddenPartIds),
+      expandedTreeNodeIds: uniqueStrings(expandedTreeNodeIds),
+      expandedAssemblyPartIds: uniqueStrings(expandedAssemblyPartIds)
+    },
+    scene: {
+      explorerMode: normalizeString(explorerMode),
+      selectedRenderPartIdByAssemblyPartId: normalizeStringMap(selectedRenderPartIdByAssemblyPartId)
+    },
+    view: {
+      clipSettings: cloneJson(clipSettings),
+      themeSettings: cloneJson(themeSettings),
+      layout: cloneJson(layout)
+    },
+    browser: {
+      url: normalizeString(url)
+    },
+    notes: normalizeString(notes)
+  };
+}
+
+export function formatCadViewStateForClipboard(viewState) {
+  const state = cloneObject(viewState);
+  const file = state.file || {};
+  const selection = state.selection || {};
+  const summary = [
+    "CAD Explorer view state",
+    file.cadPath ? `File: ${file.cadPath}` : "",
+    selection.selectedPartIds?.length ? `Parts: ${selection.selectedPartIds.join(", ")}` : "",
+    selection.cadRefs?.length ? `CAD refs: ${selection.cadRefs.join(", ")}` : "",
+  ].filter(Boolean);
+  return `${summary.join("\n")}\n\n${JSON.stringify(state, null, 2)}\n`;
+}
+
+function tryParseViewStateJson(text, startIndex, endIndex) {
+  try {
+    const value = JSON.parse(text.slice(startIndex, endIndex + 1));
+    return value && typeof value === "object" && !Array.isArray(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseCadViewStateClipboardText(text) {
+  const clipboardText = String(text || "").trim();
+  if (!clipboardText) {
+    throw new Error("Clipboard is empty");
+  }
+
+  const direct = tryParseViewStateJson(clipboardText, 0, clipboardText.length - 1);
+  if (direct?.schema === CAD_EXPLORER_VIEW_STATE_SCHEMA) {
+    return direct;
+  }
+
+  const firstBraceIndex = clipboardText.indexOf("{");
+  if (firstBraceIndex < 0) {
+    throw new Error("Clipboard does not contain CAD view state JSON");
+  }
+
+  for (let endIndex = clipboardText.lastIndexOf("}"); endIndex > firstBraceIndex; endIndex = clipboardText.lastIndexOf("}", endIndex - 1)) {
+    const parsed = tryParseViewStateJson(clipboardText, firstBraceIndex, endIndex);
+    if (parsed?.schema === CAD_EXPLORER_VIEW_STATE_SCHEMA) {
+      return parsed;
+    }
+  }
+
+  throw new Error("Clipboard does not contain a valid CAD view state");
+}
+
+// ── URL query param helpers ────────────────────────────────────────────────
+
+export const CAD_VIEW_STATE_PARAM = "view";
+export const CAD_VIEW_CAMERA_PARAM = "v";
+export const CAD_VIEW_REFS_PARAM = "sr";
+export const CAD_VIEW_PARTS_PARAM = "sp";
+export const CAD_VIEW_HIDDEN_PARAM = "hp";
+export const CAD_VIEW_CLIP_PARAM = "cp";
+
+const VIEW_STATE_QUERY_PARAMS = [
+  CAD_VIEW_STATE_PARAM,
+  CAD_VIEW_CAMERA_PARAM,
+  CAD_VIEW_REFS_PARAM,
+  CAD_VIEW_PARTS_PARAM,
+  CAD_VIEW_HIDDEN_PARAM,
+  CAD_VIEW_CLIP_PARAM
+];
+
+export function hasCadViewStateParams(params) {
+  return VIEW_STATE_QUERY_PARAMS.some((name) => params.has(name));
+}
+
+function splitCommaList(value) {
+  return String(value || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function serializeCameraParam(camera) {
+  const p = camera?.perspective || camera;
+  if (
+    !p ||
+    !Array.isArray(p.position) ||
+    p.position.length < 3 ||
+    !Array.isArray(p.target) ||
+    p.target.length < 3 ||
+    !Array.isArray(p.up) ||
+    p.up.length < 3
+  ) {
+    return null;
+  }
+  return [
+    ...p.position.slice(0, 3),
+    ...p.target.slice(0, 3),
+    ...p.up.slice(0, 3)
+  ]
+    .map((f) => Number(f))
+    .join(",");
+}
+
+function parseCameraParam(value) {
+  const parts = splitCommaList(value).map(Number);
+  if (parts.length !== 9 || !parts.every(Number.isFinite)) {
+    return null;
+  }
+  return {
+    position: parts.slice(0, 3),
+    target: parts.slice(3, 6),
+    up: parts.slice(6, 9)
+  };
+}
+
+function parseClipParam(value) {
+  if (!value) {
+    return null;
+  }
+  const parts = splitCommaList(value);
+  const axis = parts[0] || "z";
+  const plane = parseFloat(parts[1]);
+  return {
+    axis,
+    plane: Number.isFinite(plane) ? plane : 0,
+    enabled: true
+  };
+}
+
+function buildCadReviewStatePayload(viewState) {
+  const normalized = normalizeCadViewStateForApply(viewState);
+  return {
+    schema: CAD_REVIEW_STATE_SCHEMA,
+    version: CAD_REVIEW_STATE_VERSION,
+    file: {
+      key: normalized.file.key,
+      cadPath: normalized.file.cadPath,
+      renderFormat: normalized.file.renderFormat
+    },
+    camera: {
+      perspective: normalized.camera.perspective
+    },
+    scene: {
+      selectedRenderPartIdByAssemblyPartId: normalized.scene.selectedRenderPartIdByAssemblyPartId
+    },
+    selection: {
+      selectedPartIds: normalized.selection.selectedPartIds,
+      selectedReferenceIds: normalized.selection.selectedReferenceIds,
+      cadRefs: normalized.selection.cadRefs
+    },
+    visibility: {
+      hiddenPartIds: normalized.assembly.hiddenPartIds
+    },
+    clip: cloneJson(normalized.view.clipSettings),
+    assembly: {
+      expandedAssemblyPartIds: normalized.assembly.expandedAssemblyPartIds
+    }
+  };
+}
+
+function buildCadViewStateFromReviewState(reviewState) {
+  return buildCadViewState({
+    entry: {
+      key: reviewState.file?.key,
+      file: reviewState.file?.key,
+      cadPath: reviewState.file?.cadPath
+    },
+    cadPath: reviewState.file?.cadPath,
+    renderFormat: reviewState.file?.renderFormat,
+    perspective: reviewState.camera?.perspective,
+    explorerMode: reviewState.scene?.explorerMode,
+    selectedRenderPartIdByAssemblyPartId: reviewState.scene?.selectedRenderPartIdByAssemblyPartId,
+    selectedPartIds: reviewState.selection?.selectedPartIds,
+    selectedReferenceIds: reviewState.selection?.selectedReferenceIds,
+    selectedCadRefs: reviewState.selection?.cadRefs,
+    hiddenPartIds: reviewState.visibility?.hiddenPartIds,
+    expandedAssemblyPartIds: reviewState.assembly?.expandedAssemblyPartIds,
+    clipSettings: reviewState.clip
+  });
+}
+
+/**
+ * Build a compact URL query string from review-state data.
+ *
+ * Does NOT include file identity — the caller is expected to merge with the
+ * existing `?file=` param.
+ *
+ * @param {CadExplorerViewState} viewState
+ * @returns {string}
+ */
+export function buildCadViewStateQueryString(viewState) {
+  const params = new URLSearchParams();
+  params.set(CAD_VIEW_STATE_PARAM, encodeBase64Url(JSON.stringify(buildCadReviewStatePayload(viewState))));
+  return params.toString();
+}
+
+/**
+ * Parse view state from URLSearchParams and return a minimal
+ * {@link CadExplorerViewState} suitable for `normalizeCadViewStateForApply`.
+ *
+ * @param {URLSearchParams} params
+ * @param {{cadPath?: string}} [options]
+ * @returns {CadExplorerViewState|null}
+ */
+export function buildCadViewStateFromParams(params, { cadPath = "" } = {}) {
+  const encodedViewState = params.get(CAD_VIEW_STATE_PARAM);
+  if (encodedViewState) {
+    try {
+      const parsed = JSON.parse(decodeBase64Url(encodedViewState));
+      if (parsed?.schema === CAD_REVIEW_STATE_SCHEMA) {
+        return buildCadViewStateFromReviewState(parsed);
+      }
+      if (parsed?.schema === CAD_EXPLORER_VIEW_STATE_SCHEMA) {
+        return parsed;
+      }
+      throw new Error("Unsupported CAD review state URL schema");
+    } catch {
+      throw new Error("Invalid CAD review state URL");
+    }
+  }
+
+  if (!hasCadViewStateParams(params)) {
+    return null;
+  }
+  return buildCadViewState({
+    cadPath,
+    perspective: parseCameraParam(params.get(CAD_VIEW_CAMERA_PARAM)),
+    selectedReferenceIds: splitCommaList(params.get(CAD_VIEW_REFS_PARAM)),
+    selectedPartIds: splitCommaList(params.get(CAD_VIEW_PARTS_PARAM)),
+    hiddenPartIds: splitCommaList(params.get(CAD_VIEW_HIDDEN_PARAM)),
+    clipSettings: parseClipParam(params.get(CAD_VIEW_CLIP_PARAM))
+  });
+}
+
+export function normalizeCadViewStateForApply(viewState) {
+  if (!viewState || typeof viewState !== "object" || viewState.schema !== CAD_EXPLORER_VIEW_STATE_SCHEMA) {
+    throw new Error("Unsupported CAD view state");
+  }
+
+  return {
+    file: {
+      key: normalizeString(viewState.file?.key),
+      cadPath: normalizeString(viewState.file?.cadPath),
+      renderFormat: normalizeString(viewState.file?.renderFormat),
+      entry: entrySummary(viewState.file?.entry)
+    },
+    camera: {
+      perspective: clonePerspective(viewState.camera?.perspective)
+    },
+    selection: {
+      selectedPartIds: uniqueStrings(viewState.selection?.selectedPartIds),
+      selectedReferenceIds: uniqueStrings(viewState.selection?.selectedReferenceIds),
+      cadRefs: uniqueStrings(viewState.selection?.cadRefs)
+    },
+    assembly: {
+      hiddenPartIds: uniqueStrings(viewState.assembly?.hiddenPartIds),
+      expandedTreeNodeIds: uniqueStrings(viewState.assembly?.expandedTreeNodeIds),
+      expandedAssemblyPartIds: uniqueStrings(viewState.assembly?.expandedAssemblyPartIds)
+    },
+    scene: {
+      explorerMode: normalizeString(viewState.scene?.explorerMode),
+      selectedRenderPartIdByAssemblyPartId: normalizeStringMap(viewState.scene?.selectedRenderPartIdByAssemblyPartId)
+    },
+    view: {
+      clipSettings: cloneJson(viewState.view?.clipSettings),
+      themeSettings: cloneJson(viewState.view?.themeSettings),
+      layout: cloneJson(viewState.view?.layout)
+    }
+  };
+}

--- a/viewer/src/client/workbench/viewState.test.js
+++ b/viewer/src/client/workbench/viewState.test.js
@@ -1,0 +1,351 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CAD_EXPLORER_VIEW_STATE_SCHEMA,
+  CAD_EXPLORER_VIEW_STATE_VERSION,
+  CAD_REVIEW_STATE_SCHEMA,
+  buildCadViewState,
+  buildCadViewStateFromParams,
+  buildCadViewStateQueryString,
+  formatCadViewStateForClipboard,
+  hasCadViewStateParams,
+  normalizeCadViewStateForApply,
+  parseCadViewStateClipboardText
+} from "./viewState.js";
+
+test("buildCadViewState captures file, camera, selection, and view data", () => {
+  const state = buildCadViewState({
+    createdAt: "2026-05-22T00:00:00.000Z",
+    entry: {
+      key: "generated/model.step",
+      kind: "assembly",
+      name: "model.step",
+      source: { path: "generated/model.step" },
+      step: { path: "generated/model.step" }
+    },
+    cadPath: "resources/generated/model",
+    renderFormat: "step",
+    perspective: {
+      position: [1, 2, 3],
+      target: [0, 0, 0],
+      up: [0, 0, 1],
+      modelKey: "abc"
+    },
+    selectedPartIds: ["o1.2", "o1.2", ""],
+    selectedParts: [{ id: "o1.2", displayName: "gear", leafPartIds: ["o1.2"] }],
+    selectedReferenceIds: ["topology|o1.2|face|o1.2.f1"],
+    selectedReferences: [{ id: "topology|o1.2|face|o1.2.f1", displaySelector: "o1.2.f1" }],
+    selectedCadRefs: ["@cad[resources/generated/model#o1.2.f1]"],
+    hiddenPartIds: ["o1.4"],
+    expandedTreeNodeIds: ["o1"],
+    clipSettings: { enabled: true, axis: "z" },
+    themeSettings: { preset: "dark" },
+    url: "http://127.0.0.1:4178/?file=generated/model.step"
+  });
+
+  assert.equal(state.schema, CAD_EXPLORER_VIEW_STATE_SCHEMA);
+  assert.equal(state.version, CAD_EXPLORER_VIEW_STATE_VERSION);
+  assert.equal(state.file.cadPath, "resources/generated/model");
+  assert.deepEqual(state.camera.perspective.position, [1, 2, 3]);
+  assert.deepEqual(state.selection.selectedPartIds, ["o1.2"]);
+  assert.equal(state.selection.selectedParts[0].displayName, "gear");
+  assert.equal(state.selection.selectedReferences[0].displaySelector, "o1.2.f1");
+  assert.deepEqual(state.assembly.hiddenPartIds, ["o1.4"]);
+  assert.equal(state.view.clipSettings.enabled, true);
+});
+
+test("formatCadViewStateForClipboard includes a short summary and JSON payload", () => {
+  const state = buildCadViewState({
+    createdAt: "2026-05-22T00:00:00.000Z",
+    cadPath: "resources/generated/model",
+    selectedPartIds: ["o1.2"],
+    selectedCadRefs: ["@cad[resources/generated/model#o1.2]"]
+  });
+  const text = formatCadViewStateForClipboard(state);
+
+  assert.match(text, /CAD Explorer view state/);
+  assert.match(text, /File: resources\/generated\/model/);
+  assert.match(text, /Parts: o1\.2/);
+  assert.match(text, /CAD refs: @cad\[resources\/generated\/model#o1\.2\]/);
+  assert.match(text, /"schema": "cad-explorer-view-state"/);
+
+  const [summary, payload] = text.trimEnd().split("\n\n");
+  assert.equal(summary, [
+    "CAD Explorer view state",
+    "File: resources/generated/model",
+    "Parts: o1.2",
+    "CAD refs: @cad[resources/generated/model#o1.2]"
+  ].join("\n"));
+  assert.equal(JSON.parse(payload).schema, CAD_EXPLORER_VIEW_STATE_SCHEMA);
+});
+
+test("parseCadViewStateClipboardText reads summary-prefixed payloads", () => {
+  const state = buildCadViewState({
+    createdAt: "2026-05-22T00:00:00.000Z",
+    entry: { key: "generated/model.step", cadPath: "generated/model.step" },
+    cadPath: "resources/generated/model",
+    perspective: {
+      position: [1, 2, 3],
+      target: [0, 0, 0],
+      up: [0, 1, 0]
+    },
+    selectedPartIds: ["solid-1"],
+    hiddenPartIds: ["solid-2"]
+  });
+
+  const parsed = parseCadViewStateClipboardText(formatCadViewStateForClipboard(state));
+  const normalized = normalizeCadViewStateForApply(parsed);
+
+  assert.equal(normalized.file.key, "generated/model.step");
+  assert.deepEqual(normalized.camera.perspective.position, [1, 2, 3]);
+  assert.deepEqual(normalized.selection.selectedPartIds, ["solid-1"]);
+  assert.deepEqual(normalized.assembly.hiddenPartIds, ["solid-2"]);
+});
+
+test("parseCadViewStateClipboardText accepts direct JSON payloads", () => {
+  const state = buildCadViewState({
+    createdAt: "2026-05-22T00:00:00.000Z",
+    cadPath: "resources/generated/direct-model",
+    selectedReferenceIds: ["face-1"]
+  });
+
+  const parsed = parseCadViewStateClipboardText(JSON.stringify(state));
+
+  assert.equal(parsed.schema, CAD_EXPLORER_VIEW_STATE_SCHEMA);
+  assert.equal(parsed.file.cadPath, "resources/generated/direct-model");
+  assert.deepEqual(parsed.selection.selectedReferenceIds, ["face-1"]);
+});
+
+test("parseCadViewStateClipboardText extracts payloads from surrounding prose", () => {
+  const state = buildCadViewState({
+    createdAt: "2026-05-22T00:00:00.000Z",
+    cadPath: "resources/generated/prose-model",
+    hiddenPartIds: ["part-a"]
+  });
+  const clipboardText = [
+    "I reviewed this model from a low front view.",
+    "",
+    formatCadViewStateForClipboard(state),
+    "Additional issue notes after the JSON should be ignored."
+  ].join("\n");
+
+  const parsed = parseCadViewStateClipboardText(clipboardText);
+
+  assert.equal(parsed.schema, CAD_EXPLORER_VIEW_STATE_SCHEMA);
+  assert.equal(parsed.file.cadPath, "resources/generated/prose-model");
+  assert.deepEqual(parsed.assembly.hiddenPartIds, ["part-a"]);
+});
+
+test("normalizeCadViewStateForApply rejects unsupported schemas", () => {
+  assert.throws(
+    () => normalizeCadViewStateForApply({ schema: "other-view-state" }),
+    /Unsupported CAD view state/
+  );
+});
+
+test("normalizeCadViewStateForApply sanitizes duplicate ids and invalid camera snapshots", () => {
+  const normalized = normalizeCadViewStateForApply({
+    schema: CAD_EXPLORER_VIEW_STATE_SCHEMA,
+    file: { cadPath: " resources/generated/model " },
+    camera: {
+      perspective: {
+        position: [1, 2],
+        target: [0, 0, 0],
+        up: [0, 0, 1]
+      }
+    },
+    selection: {
+      selectedPartIds: [" part-a ", "part-a", ""],
+      selectedReferenceIds: ["face-1", "face-1"],
+      cadRefs: [" @cad[resources/generated/model#face-1] "]
+    },
+    assembly: {
+      hiddenPartIds: ["part-b", "part-b"],
+      expandedTreeNodeIds: ["root", ""],
+      expandedAssemblyPartIds: ["asm-1", "asm-1"]
+    },
+    view: {
+      clipSettings: { enabled: true },
+      themeSettings: undefined,
+      layout: { sidebarOpen: true }
+    }
+  });
+
+  assert.equal(normalized.file.cadPath, "resources/generated/model");
+  assert.equal(normalized.camera.perspective, null);
+  assert.deepEqual(normalized.selection.selectedPartIds, ["part-a"]);
+  assert.deepEqual(normalized.selection.selectedReferenceIds, ["face-1"]);
+  assert.deepEqual(normalized.selection.cadRefs, ["@cad[resources/generated/model#face-1]"]);
+  assert.deepEqual(normalized.assembly.hiddenPartIds, ["part-b"]);
+  assert.deepEqual(normalized.assembly.expandedTreeNodeIds, ["root"]);
+  assert.deepEqual(normalized.assembly.expandedAssemblyPartIds, ["asm-1"]);
+  assert.deepEqual(normalized.view.clipSettings, { enabled: true });
+  assert.equal(normalized.view.themeSettings, null);
+  assert.deepEqual(normalized.view.layout, { sidebarOpen: true });
+});
+
+test("buildCadViewStateQueryString stores full review state in a view query param", () => {
+  const state = buildCadViewState({
+    createdAt: "2026-05-22T00:00:00.000Z",
+    entry: {
+      key: "generated/model.step",
+      kind: "part",
+      name: "model.step",
+      file: "generated/model.step"
+    },
+    cadPath: "resources/generated/model",
+    renderFormat: "step",
+    perspective: {
+      position: [5.2, -3.1, 8.8],
+      target: [0, 0, 0],
+      up: [0, 0, 1],
+      modelKey: "generated/model.step",
+      sceneScaleMode: "normalized",
+      coordinateSystem: "z-up"
+    },
+    selectedPartIds: ["o1.2", "o1.4"],
+    selectedReferenceIds: ["topology|o1.2|face|o1.2.f1", "topology|o1.4|face|f1"],
+    selectedCadRefs: ["@cad[resources/generated/model#o1.2.f1]"],
+    hiddenPartIds: ["o1.10", "o1.12"],
+    expandedTreeNodeIds: ["root", "o1"],
+    expandedAssemblyPartIds: ["o1.2"],
+    selectedRenderPartIdByAssemblyPartId: { "o1.2": "mesh:17" },
+    explorerMode: "assembly",
+    clipSettings: { axis: "z", plane: 0.5, enabled: true, inverted: true },
+    layout: { sidebarOpen: true, tabToolsOpen: false, tabToolMode: "references" }
+  });
+  const qs = buildCadViewStateQueryString(state);
+
+  const params = new URLSearchParams(qs);
+  const encodedPayload = params.get("view");
+  assert.ok(encodedPayload);
+  assert.equal(params.has("v"), false);
+  assert.equal(params.has("sp"), false);
+  const payload = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8"));
+  assert.equal(payload.schema, CAD_REVIEW_STATE_SCHEMA);
+  assert.equal(payload.file.key, "generated/model.step");
+  assert.equal(payload.file.cadPath, "resources/generated/model");
+  assert.equal(payload.camera.perspective.modelKey, "generated/model.step");
+  assert.deepEqual(payload.selection.selectedPartIds, ["o1.2", "o1.4"]);
+  assert.deepEqual(payload.selection.cadRefs, ["@cad[resources/generated/model#o1.2.f1]"]);
+  assert.deepEqual(payload.visibility.hiddenPartIds, ["o1.10", "o1.12"]);
+  assert.deepEqual(payload.assembly.expandedAssemblyPartIds, ["o1.2"]);
+  assert.equal(payload.assembly.expandedTreeNodeIds, undefined);
+  assert.equal(payload.scene.explorerMode, undefined);
+  assert.equal(payload.view, undefined);
+  assert.deepEqual(payload.clip, { axis: "z", plane: 0.5, enabled: true, inverted: true });
+
+  const parsed = buildCadViewStateFromParams(params);
+  const normalized = normalizeCadViewStateForApply(parsed);
+  assert.equal(normalized.file.key, "generated/model.step");
+  assert.equal(normalized.file.cadPath, "resources/generated/model");
+  assert.equal(normalized.camera.perspective.modelKey, "generated/model.step");
+  assert.equal(normalized.camera.perspective.sceneScaleMode, "normalized");
+  assert.equal(normalized.camera.perspective.coordinateSystem, "z-up");
+  assert.deepEqual(normalized.selection.selectedPartIds, ["o1.2", "o1.4"]);
+  assert.deepEqual(normalized.selection.cadRefs, ["@cad[resources/generated/model#o1.2.f1]"]);
+  assert.deepEqual(normalized.assembly.expandedTreeNodeIds, []);
+  assert.deepEqual(normalized.assembly.expandedAssemblyPartIds, ["o1.2"]);
+  assert.deepEqual(normalized.scene.selectedRenderPartIdByAssemblyPartId, { "o1.2": "mesh:17" });
+  assert.equal(normalized.scene.explorerMode, "");
+  assert.deepEqual(normalized.view.clipSettings, { axis: "z", plane: 0.5, enabled: true, inverted: true });
+  assert.equal(normalized.view.layout, null);
+});
+
+test("buildCadViewStateQueryString preserves empty slices in the full view payload", () => {
+  const state = buildCadViewState({
+    createdAt: "2026-05-22T00:00:00.000Z",
+    cadPath: "resources/generated/model",
+    perspective: { position: [1, 2, 3], target: [0, 0, 0], up: [0, 1, 0] }
+  });
+  const params = new URLSearchParams(buildCadViewStateQueryString(state));
+  const parsed = normalizeCadViewStateForApply(buildCadViewStateFromParams(params));
+
+  assert.ok(params.get("view"));
+  assert.deepEqual(parsed.selection.selectedReferenceIds, []);
+  assert.deepEqual(parsed.selection.selectedPartIds, []);
+  assert.deepEqual(parsed.assembly.hiddenPartIds, []);
+  assert.equal(parsed.view.clipSettings, null);
+});
+
+test("buildCadViewStateQueryString preserves invalid camera as null without dropping other state", () => {
+  const state = buildCadViewState({
+    createdAt: "2026-05-22T00:00:00.000Z",
+    cadPath: "resources/generated/model",
+    perspective: { position: [1, 2], target: [0], up: [] },
+    selectedPartIds: ["part-1"]
+  });
+  const params = new URLSearchParams(buildCadViewStateQueryString(state));
+  const parsed = normalizeCadViewStateForApply(buildCadViewStateFromParams(params));
+
+  assert.equal(parsed.camera.perspective, null);
+  assert.deepEqual(parsed.selection.selectedPartIds, ["part-1"]);
+});
+
+test("buildCadViewStateFromParams round-trips camera, selection, and clip", () => {
+  const params = new URLSearchParams(
+    "v=1,2,3,0,0,0,0,1,0&sp=gear,shaft&sr=face-1,face-2&hp=hidden-1&cp=y,0.3"
+  );
+  const state = buildCadViewStateFromParams(params, { cadPath: "resources/generated/model" });
+
+  assert.equal(state.schema, CAD_EXPLORER_VIEW_STATE_SCHEMA);
+  assert.equal(state.file.cadPath, "resources/generated/model");
+  assert.deepEqual(state.camera.perspective.position, [1, 2, 3]);
+  assert.deepEqual(state.camera.perspective.target, [0, 0, 0]);
+  assert.deepEqual(state.camera.perspective.up, [0, 1, 0]);
+  assert.deepEqual(state.selection.selectedPartIds, ["gear", "shaft"]);
+  assert.deepEqual(state.selection.selectedReferenceIds, ["face-1", "face-2"]);
+  assert.deepEqual(state.assembly.hiddenPartIds, ["hidden-1"]);
+  assert.equal(state.view.clipSettings.axis, "y");
+  assert.equal(state.view.clipSettings.plane, 0.3);
+  assert.equal(state.view.clipSettings.enabled, true);
+});
+
+test("buildCadViewStateFromParams handles partial params", () => {
+  const params = new URLSearchParams("v=0,0,10,0,0,0,0,0,1");
+  const state = buildCadViewStateFromParams(params, { cadPath: "resources/partial" });
+
+  assert.equal(state.file.cadPath, "resources/partial");
+  assert.deepEqual(state.camera.perspective.position, [0, 0, 10]);
+  assert.deepEqual(state.selection.selectedPartIds, []);
+  assert.deepEqual(state.assembly.hiddenPartIds, []);
+  assert.equal(state.view.clipSettings, null);
+});
+
+test("buildCadViewStateFromParams ignores URLs without view-state params", () => {
+  const params = new URLSearchParams("file=generated/model.step");
+
+  assert.equal(buildCadViewStateFromParams(params, { cadPath: "generated/model.step" }), null);
+});
+
+test("buildCadViewStateFromParams rejects invalid view payloads", () => {
+  assert.throws(
+    () => buildCadViewStateFromParams(new URLSearchParams("view=not-base64-json")),
+    /Invalid CAD review state URL/
+  );
+
+  const unsupported = Buffer.from(JSON.stringify({ schema: "other-schema", version: 1 })).toString("base64url");
+  assert.throws(
+    () => buildCadViewStateFromParams(new URLSearchParams(`view=${unsupported}&sp=part-a`)),
+    /Invalid CAD review state URL/
+  );
+});
+
+test("buildCadViewStateFromParams rejects malformed camera", () => {
+  const params = new URLSearchParams("v=1,2,3&sp=part-a");
+  const state = buildCadViewStateFromParams(params);
+
+  assert.equal(state.camera.perspective, null);
+  assert.deepEqual(state.selection.selectedPartIds, ["part-a"]);
+});
+
+test("hasCadViewStateParams detects view state in URL params", () => {
+  assert.equal(hasCadViewStateParams(new URLSearchParams("v=1,2,3,0,0,0,0,0,1")), true);
+  assert.equal(hasCadViewStateParams(new URLSearchParams("sp=part-a")), true);
+  assert.equal(hasCadViewStateParams(new URLSearchParams("hp=hidden-1")), true);
+  assert.equal(hasCadViewStateParams(new URLSearchParams("cp=z,0.5")), true);
+  assert.equal(hasCadViewStateParams(new URLSearchParams("sr=face-1")), true);
+  assert.equal(hasCadViewStateParams(new URLSearchParams("file=model.step")), false);
+  assert.equal(hasCadViewStateParams(new URLSearchParams("")), false);
+});


### PR DESCRIPTION
## Summary

Adds Copy/Paste View State actions to CAD Explorer so a user can share and restore a CAD review context without relying on screenshots.

The copied clipboard text contains a short human-readable summary followed by a versioned JSON payload. Paste restores the matching file when available, camera perspective, selected parts/references, hidden/expanded assembly state, clip settings, theme settings, and layout state.

This complements existing session persistence: session storage restores a local browser session, while view state is portable across chats, issues, machines, and reviewers.

## Why

When reviewing generated CAD with another person or an agent, screenshots are often not enough: camera angle, selected topology, hidden parts, clipping, and theme settings are lost. A portable view-state payload makes review context reproducible.

## Demo

![Copy and paste CAD Explorer view state](https://github.com/tolatolatop/text-to-cad/releases/download/copy-view-state-demo-20260522/copy_state.gif)

## Scope

- Adds Copy View State and Paste View State toolbar actions.
- Adds a `CadExplorerViewState` clipboard document shape with schema/version constants.
- Keeps the payload plain text: summary first, JSON second.
- Does not add generated CAD artifacts, backend services, or external dependencies.

## Verification

- `node --test --experimental-default-type=module lib/workbench/viewState.test.js`
- `npm run test -- --runInBand`
- `npm run build`