### PR TITLE
Propagate leaf shape label to STEP product name

### DIFF
--- a/packages/cadpy/src/cadpy/assembly_export.py
+++ b/packages/cadpy/src/cadpy/assembly_export.py
@@ -965,6 +965,7 @@ class _DirectXcafAssemblyWriter:
             return definition_label
         definition_label = self.shape_tool.AddShape(_topods_shape_without_location(shape.wrapped), False)
         self.shape_definitions[key] = definition_label
+        self._set_label_name(definition_label, getattr(shape, "label", None))
         self._set_label_color(definition_label, getattr(shape, "color", None))
         return definition_label
 

--- a/skills/cad/scripts/cadpy_common/assembly_export.py
+++ b/skills/cad/scripts/cadpy_common/assembly_export.py
@@ -959,6 +959,7 @@ class _DirectXcafAssemblyWriter:
             return definition_label
         definition_label = self.shape_tool.AddShape(shape.wrapped, False)
         self.shape_definitions[key] = definition_label
+        self._set_label_name(definition_label, getattr(shape, "label", None))
         self._set_label_color(definition_label, getattr(shape, "color", None))
         return definition_label
 

--- a/skills/cad/scripts/cadpy_common/tests/test_assembly_export.py
+++ b/skills/cad/scripts/cadpy_common/tests/test_assembly_export.py
@@ -337,6 +337,36 @@ class AssemblyExportTests(unittest.TestCase):
         self.assertEqual(1, iter_cad_sources.call_count)
         self.assertEqual(["leaf_a", "leaf_b"], [child.label for child in assembly.children])
 
+    def test_direct_export_propagates_leaf_shape_label_to_step_product(self) -> None:
+        """Regression: leaf-Part definitions in the assembly STEP must carry
+        the shape label, not the generic 'SOLID' OCCT fallback. Without
+        ``_set_label_name`` on the leaf branch of ``_shape_definition_for_tree``,
+        a CAD UI such as Fusion shows every single-Part component as ``solid``.
+        """
+        leaf_label = "leaf_box_product"
+        step_path = self.cad_root / "STEP" / f"{leaf_label}.step"
+        step_path.parent.mkdir(parents=True, exist_ok=True)
+        box = build123d.Box(1, 1, 1)
+        box.label = leaf_label
+        build123d.export_step(box, step_path)
+
+        assembly_spec = self._assembly_spec(
+            AssemblyInstanceSpec(
+                instance_id="leaf",
+                source_path=step_path.resolve(),
+                path=f"{leaf_label}.step",
+                name="leaf",
+                transform=IDENTITY_TRANSFORM,
+            ),
+        )
+        output_path = assembly_spec.assembly_path.with_suffix(".step")
+
+        export_assembly_step_scene(assembly_spec, output_path)
+        contents = output_path.read_bytes()
+
+        self.assertIn(f"PRODUCT('{leaf_label}'".encode("ascii"), contents)
+        self.assertNotIn(b"PRODUCT('SOLID'", contents)
+
     def test_direct_writer_reuses_quantity_colors_for_tuple_rgba(self) -> None:
         assembly_spec = self._assembly_spec()
         writer = assembly_export_module._DirectXcafAssemblyWriter(assembly_spec, label="assembly")


### PR DESCRIPTION
## Summary

`_DirectXcafAssemblyWriter._shape_definition_for_tree` skipped `_set_label_name` in the leaf branch, so the underlying STEP product fell back to OCCT's generic `SOLID`. The with-children branch already names its definition via `_new_assembly_definition(label)`, so only single-Part shapes were affected — CAD UIs that surface the product name (e.g. Fusion's browser) showed every such component as `solid`.

## Fix

After `AddShape` returns the fresh definition label, set `getattr(shape, "label", None)` on it, mirroring the with-children naming. `_set_label_name` is a no-op when `name` is falsy, so unlabelled shapes are unchanged.

Source copies updated in lockstep; build-generated mirrors refreshed via `scripts/build/build-viewer.sh`, `scripts/build/build-cad-skill.sh`, `scripts/build/build-cad-viewer-skill.sh`, and `scripts/build/build-plugin.sh`:

- `packages/cadpy/src/cadpy/assembly_export.py`
- `skills/cad/scripts/cadpy_common/assembly_export.py`
- `viewer/packages/cadpy/...`
- `skills/cad-viewer/scripts/viewer/packages/cadpy/...`
- `skills/cad/scripts/packages/cadpy/...`
- `plugins/cad/skills/...` mirrors

## Test

`skills/cad/scripts/cadpy_common/tests/test_assembly_export.py::test_direct_export_propagates_leaf_shape_label_to_step_product` writes a labelled `Box` STEP, exports a single-instance assembly STEP referencing it, and asserts `PRODUCT('<label>'` is present and `PRODUCT('SOLID'` is not. The test fails on `main` and passes with this change.

## Checks

- `scripts/build/build-skills.sh --check` — up to date
- `scripts/build/build-plugin.sh --check` — up to date
- `scripts/check/validate-plugins.sh` — passed
- CAD-skill Python tests: 226 passed / 3 skipped