### PR TITLE
[codex] Fix hosted viewer catalog mode

### DIFF
--- a/packages/cadjs/src/lib/cadManifestStore.js
+++ b/packages/cadjs/src/lib/cadManifestStore.js
@@ -4,6 +4,15 @@ const CAD_GENERATION_STATUS_REFRESH_INTERVAL_MS = 750;
 const CAD_DIR_QUERY_PARAM = "dir";
 const CAD_FILE_QUERY_PARAM = "file";
 const CAD_DIR_SESSION_STORAGE_KEY = "__cadViewerDir";
+const HOSTED_CATALOG_BACKENDS = new Set(["vercel-blob"]);
+
+function viewerAssetBackendFromEnv() {
+  return String(import.meta.env?.VIEWER_ASSET_BACKEND || "").trim().toLowerCase();
+}
+
+export function cadViewerUsesHostedCatalog(assetBackend = viewerAssetBackendFromEnv()) {
+  return HOSTED_CATALOG_BACKENDS.has(String(assetBackend || "").trim().toLowerCase());
+}
 
 function normalizeCadManifest(manifest) {
   if (!manifest || typeof manifest !== "object") {
@@ -177,8 +186,11 @@ function activeDirForFile(candidateDir, fileParam) {
   return normalizedCandidate;
 }
 
-export function readActiveCadDir() {
+export function readActiveCadDir({ assetBackend = viewerAssetBackendFromEnv() } = {}) {
   if (typeof window === "undefined") {
+    return "";
+  }
+  if (cadViewerUsesHostedCatalog(assetBackend)) {
     return "";
   }
   let url = null;

--- a/packages/cadjs/src/lib/cadManifestStore.test.js
+++ b/packages/cadjs/src/lib/cadManifestStore.test.js
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { readActiveCadDir } from "./cadManifestStore.js";
+import {
+  cadViewerUsesHostedCatalog,
+  readActiveCadDir
+} from "./cadManifestStore.js";
 
 function createMemorySessionStorage() {
   const store = new Map();
@@ -69,5 +72,16 @@ test("readActiveCadDir keeps stored directory mode for relative file params", ()
 
     setHref("http://viewer.test/?file=robots%2Fnext.step");
     assert.equal(readActiveCadDir(), "/tmp/models");
+  });
+});
+
+test("hosted catalog mode ignores local directory query state", () => {
+  assert.equal(cadViewerUsesHostedCatalog("vercel-blob"), true);
+
+  withWindow("http://viewer.test/?dir=%2Ftmp%2Fmodels&file=robots%2Fnext.step", ({ setHref }) => {
+    assert.equal(readActiveCadDir({ assetBackend: "vercel-blob" }), "");
+
+    setHref("http://viewer.test/?file=robots%2Fnext.step");
+    assert.equal(readActiveCadDir({ assetBackend: "vercel-blob" }), "");
   });
 });

--- a/viewer/docs/backend.md
+++ b/viewer/docs/backend.md
@@ -114,6 +114,8 @@ Expected deployment shape:
 - Deploy the viewer with `VIEWER_ASSET_BACKEND=vercel-blob` and a read-only
   catalog configuration. Catalog warnings such as stale STEP artifacts are shown
   in the UI instead of being fixed by the hosted app.
+- Hosted Vercel routes ignore local filesystem `?dir=` query values and read the
+  configured hosted `catalog.json` instead.
 
 The Vercel deployment entrypoints are intentionally thin:
 

--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -214,7 +214,12 @@ import {
   validateUrdfMotionJointValues
 } from "cadjs/lib/urdf/motion";
 import { checkMoveIt2ServerLive, moveit2ServerEnabled, requestMoveIt2Server } from "cadjs/lib/urdf/moveit2ServerClient";
-import { readActiveCadDir, requestStepArtifactGeneration, requestStepSourceStatus } from "cadjs/lib/cadManifestStore";
+import {
+  cadViewerUsesHostedCatalog,
+  readActiveCadDir,
+  requestStepArtifactGeneration,
+  requestStepSourceStatus
+} from "cadjs/lib/cadManifestStore";
 import { stepArtifactCanGenerate } from "@/workbench/stepArtifactStatus";
 import {
   buildFileStatusItems,
@@ -392,6 +397,7 @@ export default function CadWorkspace({
 }) {
   const manifestEntries = Array.isArray(manifestEntriesProp) ? manifestEntriesProp : [];
   const catalogEntries = manifestEntries;
+  const viewerAssetBackend = viewerAssetBackendFromEnv();
   const activeGeneratorFiles = useMemo(() => (
     Object.entries(generationStatus?.files || {})
       .filter(([, status]) => status?.running === true)
@@ -399,7 +405,6 @@ export default function CadWorkspace({
       .filter(Boolean)
   ), [generationStatus]);
   const catalogRootDir = String(activeDir || "").trim();
-  const directoryCatalogActive = Boolean(catalogRootDir);
   const [query, setQuery] = useState("");
   const initialFileViewerDirectoryStateRef = useRef(null);
   if (!initialFileViewerDirectoryStateRef.current) {
@@ -417,6 +422,10 @@ export default function CadWorkspace({
   ));
   const [openTabs, setOpenTabs] = useState([]);
   const [viewerServerInfo, setViewerServerInfo] = useState(null);
+  const viewerServerBackend = String(viewerServerInfo?.backend || "").trim().toLowerCase();
+  const directoryCatalogActive = Boolean(catalogRootDir) ||
+    cadViewerUsesHostedCatalog(viewerAssetBackend) ||
+    cadViewerUsesHostedCatalog(viewerServerBackend);
   const [selectedKey, setSelectedKey] = useState("");
   const [fileSheetOpenSectionIds, setFileSheetOpenSectionIds] = useState(null);
   const [dxfThicknessMm, setDxfThicknessMm] = useState(0);
@@ -692,8 +701,6 @@ export default function CadWorkspace({
   );
   const selectedEntrySourceFormat = entrySourceFormat(selectedEntry);
   const selectedFileSheetKind = fileSheetKindForEntry(selectedEntry);
-  const viewerServerBackend = String(viewerServerInfo?.backend || "").trim();
-  const viewerAssetBackend = viewerAssetBackendFromEnv();
   const stepArtifactGenerationAvailable = viewerServerInfo
     ? viewerServerInfo.stepArtifactGenerationAvailable !== false
     : viewerAssetBackend === LOCAL_ASSET_BACKEND;

--- a/viewer/src/server/vercelApi.mjs
+++ b/viewer/src/server/vercelApi.mjs
@@ -94,6 +94,7 @@ export async function handleHostedCadApi(req, res, {
 
   const originalUrl = req.url || "/";
   const originalRequestUrl = new URL(originalUrl, "http://localhost");
+  originalRequestUrl.searchParams.delete("dir");
   req.url = `${normalizedCadPath}${originalRequestUrl.search}`;
   try {
     const middleware = createCadViewerApiMiddleware({

--- a/viewer/src/server/vercelApi.test.mjs
+++ b/viewer/src/server/vercelApi.test.mjs
@@ -69,6 +69,33 @@ test("hosted CAD API serves catalog through an injected Blob backend", async () 
 });
 
 
+test("hosted CAD API ignores local dir query params", async () => {
+  const calls = [];
+  const backend = {
+    kind: "vercel-blob",
+    catalogPath: "demo/catalog.json",
+    readCatalog: async (request) => {
+      calls.push(request);
+      return { schemaVersion: 4, entries: [{ file: "part.step" }] };
+    },
+  };
+  const req = { method: "GET", url: "/api/cad/catalog?dir=%2Ftmp%2Fmodels&file=part.step" };
+  const res = createResponse();
+
+  await handleHostedCadApi(req, res, {
+    cadPath: "/__cad/catalog",
+    backend,
+    env: { VIEWER_ASSET_BACKEND: "vercel-blob" },
+  });
+
+  assert.equal(req.url, "/api/cad/catalog?dir=%2Ftmp%2Fmodels&file=part.step");
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(calls, [
+    { rootDir: "", fileRef: "part.step" },
+  ]);
+});
+
+
 test("hosted CAD API redirects catalog reads to public Blob URLs when configured", async () => {
   const backend = {
     kind: "vercel-blob",


### PR DESCRIPTION
## Summary

Fixes the hosted CAD Viewer path so Vercel/Blob deployments do not fall back to the local filesystem `?dir=` prompt.

## Root Cause

The client treated an empty active directory as file-only local mode. Hosted Blob catalogs intentionally have no local active directory, so the catalog could load while the home UI still asked for `?dir=`.

## Changes

- Treat `vercel-blob` as hosted catalog mode in the client manifest store and workspace navigation state.
- Use `/__cad/server` backend metadata as a fallback signal for hosted catalog mode when the client build does not have `VIEWER_ASSET_BACKEND` baked in.
- Strip `dir` query params in hosted Vercel API handling before delegating to catalog/download middleware.
- Add focused tests for hosted catalog directory ignoring and Vercel API query sanitization.
- Document that hosted Vercel routes ignore local filesystem `?dir=` values.

## Validation

- `npm --prefix packages/cadjs test -- src/lib/cadManifestStore.test.js`
- `npm --prefix viewer run test -- src/server/vercelApi.test.mjs`
- `npm --prefix viewer run build`
- `scripts/bundle/bundle.sh --check`
- `scripts/test/test-docs.sh` (rerun outside sandbox after Turbopack hit a sandbox-only EPERM)
- Browser check against a local hosted-style catalog, including `/?dir=%2Ftmp%2Fignored`, confirmed the viewer shows the hosted catalog entry and does not show the `?dir=` prompt.