### PR TITLE
[codex] Add on-demand STEP collision analysis

### DIFF
--- a/packages/cadjs/src/common/cadScene.js
+++ b/packages/cadjs/src/common/cadScene.js
@@ -933,6 +933,10 @@ export function applyMaterialSettingsToRecord(THREE, record, materialSettings, {
   record.baseOpacity = clamp(Number(materialSettings.opacity) || 0, 0, 1);
   record.material.opacity = record.baseOpacity;
   record.material.transparent = record.baseOpacity < 0.999;
+  record.baseDepthWrite = typeof materialSettings.depthWrite === "boolean"
+    ? materialSettings.depthWrite
+    : true;
+  record.material.depthWrite = record.baseDepthWrite;
   record.material.envMapIntensity = Math.max(Number(materialSettings.envMapIntensity) || 0, 0);
   if (record.material.color && record.baseColor) {
     record.material.color.copy(record.baseColor);

--- a/packages/cadjs/src/common/displaySettings.js
+++ b/packages/cadjs/src/common/displaySettings.js
@@ -6,6 +6,8 @@ import {
 
 export const CAD_DISPLAY_MODE = Object.freeze({
   SOLID: "solid",
+  TRANSPARENT: "transparent",
+  COLLISION: "collision",
   WIREFRAME: "wireframe"
 });
 
@@ -19,8 +21,9 @@ function isObject(value) {
 }
 
 export function normalizeDisplayMode(value) {
-  return String(value || "").trim().toLowerCase() === CAD_DISPLAY_MODE.WIREFRAME
-    ? CAD_DISPLAY_MODE.WIREFRAME
+  const normalized = String(value || "").trim().toLowerCase();
+  return Object.values(CAD_DISPLAY_MODE).includes(normalized)
+    ? normalized
     : CAD_DISPLAY_MODE.SOLID;
 }
 

--- a/packages/cadjs/src/common/displaySettings.test.js
+++ b/packages/cadjs/src/common/displaySettings.test.js
@@ -12,6 +12,8 @@ import {
 test("display settings normalize mode and clip independently from appearance settings", () => {
   assert.deepEqual(normalizeDisplaySettings(), DEFAULT_DISPLAY_SETTINGS);
   assert.equal(resolveDisplayMode({ mode: "wireframe" }), CAD_DISPLAY_MODE.WIREFRAME);
+  assert.equal(resolveDisplayMode({ mode: "transparent" }), CAD_DISPLAY_MODE.TRANSPARENT);
+  assert.equal(resolveDisplayMode({ mode: "collision" }), CAD_DISPLAY_MODE.COLLISION);
   assert.deepEqual(normalizeDisplaySettings({
     mode: "wireframe",
     clip: {

--- a/packages/cadjs/src/common/renderEdges.js
+++ b/packages/cadjs/src/common/renderEdges.js
@@ -431,6 +431,7 @@ export function createDisplayEdgeObject(context = {}, {
   const color = wireframeMode
     ? (wireframeEdgeColor || edgeSettings?.color || baseTheme?.edge || "#18181b")
     : (edgeSettings?.color || baseTheme?.edge || "#18181b");
+  const depthTest = edgeSettings?.depthTest !== false;
   if (wireframeMode && THREE) {
     const opacity = Math.max(edgeOpacity, 0.9);
     const material = new THREE.LineBasicMaterial({
@@ -453,7 +454,7 @@ export function createDisplayEdgeObject(context = {}, {
     opacity: edgeOpacity,
     lineWidth: Number.isFinite(Number(thickness)) ? Number(thickness) : 1,
     renderOrder: 3,
-    depthTest: true,
+    depthTest,
     depthWrite: false,
     depthBias: topologyLineDepthBiasForWidth(thickness)
   }, materials);
@@ -487,11 +488,12 @@ export function createTopologyDisplayEdgeObject(context = {}, selectorRuntime, e
   const thickness = Number.isFinite(Number(edgeSettings?.thickness))
     ? clamp(Number(edgeSettings.thickness), 0.5, 6)
     : (baseTheme?.edgeThickness ?? 1);
+  const depthTest = edgeSettings?.depthTest !== false;
   const baseOptions = {
     color: edgeSettings?.color || baseTheme?.edge || "#18181b",
     lineWidth: thickness,
     renderOrder: 3,
-    depthTest: true,
+    depthTest,
     depthWrite: false,
     depthBias: topologyLineDepthBiasForWidth(thickness)
   };

--- a/packages/cadjs/src/common/renderEdges.test.js
+++ b/packages/cadjs/src/common/renderEdges.test.js
@@ -79,6 +79,27 @@ test("screen-space display edge creation registers material settings", () => {
   assert.equal(edgeMaterial.resolution.y, 480);
 });
 
+test("screen-space display edges can render through transparent solids", () => {
+  const { edgeMaterial } = createDisplayEdgeObject(edgeContext(), {
+    geometry: twoPointGeometry(),
+    edgeSettings: {
+      color: "#123456",
+      opacity: 0.42,
+      thickness: 2,
+      depthTest: false
+    },
+    baseTheme: {
+      edge: "#000000",
+      edgeOpacity: 0.84
+    },
+    partId: "part-a",
+    displayMode: "solid",
+    thickness: 2
+  });
+
+  assert.equal(edgeMaterial.depthTest, false);
+});
+
 test("wireframe display edges preserve high opacity and basic line material", () => {
   const { edgeMesh, edgeMaterial } = createDisplayEdgeObject(edgeContext(), {
     geometry: twoPointGeometry(),
@@ -128,8 +149,34 @@ test("topology display edge helper builds filtered screen-space edges", () => {
   assert.equal(line.userData.partId, "__topology__");
   assert.equal(line.material.opacity, 0.66);
   assert.equal(line.material.linewidth, 1.5);
+  assert.equal(line.material.depthTest, true);
   assert.equal(line.material.polygonOffset, true);
   assert.equal(line.material.polygonOffsetUnits, -5);
+});
+
+test("topology display edge helper can render CAD edges through transparent solids", () => {
+  const line = createTopologyDisplayEdgeObject(
+    edgeContext(),
+    {
+      proxy: {
+        edgePositions: new Float32Array([0, 0, 0, 1, 0, 0]),
+        edgeIndices: new Uint32Array([0, 1])
+      }
+    },
+    {
+      color: "#654321",
+      opacity: 0.66,
+      thickness: 1.5,
+      depthTest: false
+    },
+    {
+      edge: "#000000",
+      edgeOpacity: 0.84,
+      edgeThickness: 1
+    }
+  );
+
+  assert.equal(line.material.depthTest, false);
 });
 
 test("topology display edge helper renders feature-class edges by default", () => {

--- a/packages/cadjs/src/common/topologyDisplayEdgeRuntime.js
+++ b/packages/cadjs/src/common/topologyDisplayEdgeRuntime.js
@@ -172,12 +172,14 @@ export function shouldRenderTopologyDisplayEdges({
   selectorRuntime = null,
   edgeSettings = null
 } = {}) {
+  const forceTopologyOverlay = edgeSettings?.forceTopologyOverlay === true;
+  const topologyRuntime = displayEdgeRuntime || selectorRuntime;
   return Boolean(
     edgesVisible &&
     !wireframeMode &&
     cadEdgeSource &&
-    !runtimeUsesSurfaceOwnedEdges(displayEdgeRuntime || selectorRuntime) &&
-    shouldUseTopologyDisplayEdges(displayEdgeRuntime || selectorRuntime, edgeSettings)
+    (forceTopologyOverlay || !runtimeUsesSurfaceOwnedEdges(topologyRuntime)) &&
+    shouldUseTopologyDisplayEdges(topologyRuntime, edgeSettings)
   );
 }
 

--- a/packages/cadjs/src/common/topologyDisplayEdgeRuntime.test.js
+++ b/packages/cadjs/src/common/topologyDisplayEdgeRuntime.test.js
@@ -130,6 +130,18 @@ test("shouldRenderTopologyDisplayEdges gates CAD topology overlays", () => {
     cadEdgeSource: true,
     selectorRuntime: { schemaVersion: 3, surfaceEdgeRendering: true, edges: [] }
   }), false);
+  assert.equal(shouldRenderTopologyDisplayEdges({
+    edgesVisible: true,
+    cadEdgeSource: true,
+    selectorRuntime: {
+      ...runtime,
+      schemaVersion: 3,
+      surfaceEdgeRendering: true
+    },
+    edgeSettings: {
+      forceTopologyOverlay: true
+    }
+  }), true);
 });
 
 test("surface offset scales for thick topology display edges", () => {

--- a/packages/cadjs/src/common/topologyDisplayEdges.js
+++ b/packages/cadjs/src/common/topologyDisplayEdges.js
@@ -291,10 +291,15 @@ export function hasTopologyDisplayEdgeClassification(selectorRuntime) {
   return hasTopologyDisplayEdgeProxy(selectorRuntime);
 }
 
-export function shouldUseTopologyDisplayEdges(selectorRuntime) {
-  return !selectorRuntime?.surfaceEdgeRendering &&
-    Number(selectorRuntime?.schemaVersion || 0) < 3 &&
-    hasTopologyDisplayEdgeProxy(selectorRuntime);
+export function shouldUseTopologyDisplayEdges(selectorRuntime, edgeSettings = null) {
+  const forceTopologyOverlay = edgeSettings?.forceTopologyOverlay === true;
+  return hasTopologyDisplayEdgeProxy(selectorRuntime) && (
+    forceTopologyOverlay ||
+    (
+      !selectorRuntime?.surfaceEdgeRendering &&
+      Number(selectorRuntime?.schemaVersion || 0) < 3
+    )
+  );
 }
 
 export function buildTopologyDisplayEdgePositions(selectorRuntime, {

--- a/packages/cadjs/src/lib/cadDirectoryScanner.mjs
+++ b/packages/cadjs/src/lib/cadDirectoryScanner.mjs
@@ -1134,12 +1134,8 @@ function pythonStepSourceFromStepMetadata(repoRoot, stepPath) {
   if (!metadataSourcePath) {
     return null;
   }
-  const sourceIdentity = sourcePathFromManifest(repoRoot, metadataSourcePath, { baseDir: path.dirname(stepPath) });
+  const sourceIdentity = generatorSourcePathFromManifest(repoRoot, metadataSourcePath, { baseDir: path.dirname(stepPath) });
   if (!sourceIdentity.sourcePath) {
-    return null;
-  }
-  const sourceExtension = path.extname(sourceIdentity.filePath || sourceIdentity.sourcePath).toLowerCase();
-  if (sourceExtension !== ".py") {
     return null;
   }
   return {

--- a/packages/cadjs/src/lib/entryAssets.js
+++ b/packages/cadjs/src/lib/entryAssets.js
@@ -54,7 +54,10 @@ export function entryAsset(entry, key) {
   if (
     assetKey === kind ||
     assetKey === sourceFormat ||
-    (sourceFormat === RENDER_FORMAT.STEP && ["glb", "topology", "selectortopology", "displayedgetopology"].includes(assetKey)) ||
+    (
+      sourceFormat === RENDER_FORMAT.STEP &&
+      ["glb", "topology", "selectortopology", "displayedgetopology"].includes(assetKey)
+    ) ||
     (kind === "srdf" && assetKey === "srdf")
   ) {
     return primaryAsset(entry);

--- a/packages/cadjs/src/lib/renderAssetClient.test.js
+++ b/packages/cadjs/src/lib/renderAssetClient.test.js
@@ -57,7 +57,13 @@ function pad4(buffer, byte = 0) {
   return padding ? Buffer.concat([buffer, Buffer.alloc(padding, byte)]) : buffer;
 }
 
-function topologyGlb(manifest, buffers = {}, { schemaVersion = STEP_TOPOLOGY_SCHEMA_VERSION } = {}) {
+function topologyGlb(
+  manifest,
+  buffers = {},
+  {
+    schemaVersion = STEP_TOPOLOGY_SCHEMA_VERSION,
+  } = {}
+) {
   const bufferViews = [];
   let binary = Buffer.alloc(0);
   function addBufferView(payload) {

--- a/packages/cadjs/src/lib/viewer/surfaceMaterials.js
+++ b/packages/cadjs/src/lib/viewer/surfaceMaterials.js
@@ -180,6 +180,10 @@ export function applyMaterialSettingsToRecord(THREE, record, materialSettings) {
   record.baseOpacity = clamp(Number(materialSettings.opacity) || 0, 0, 1);
   record.material.opacity = record.baseOpacity;
   record.material.transparent = record.baseOpacity < 0.999;
+  record.baseDepthWrite = typeof materialSettings.depthWrite === "boolean"
+    ? materialSettings.depthWrite
+    : true;
+  record.material.depthWrite = record.baseDepthWrite;
   record.material.envMapIntensity = Math.max(Number(materialSettings.envMapIntensity) || 0, 0);
   if (record.material.color && record.baseColor) {
     record.material.color.copy(record.baseColor);

--- a/packages/cadjs/src/lib/viewer/surfaceMaterials.test.js
+++ b/packages/cadjs/src/lib/viewer/surfaceMaterials.test.js
@@ -138,8 +138,39 @@ test("fill colors and record material settings preserve override semantics", () 
   assert.equal(record.baseOpacity, 0.6);
   assert.equal(record.material.opacity, 0.6);
   assert.equal(record.material.transparent, true);
+  assert.equal(record.baseDepthWrite, true);
+  assert.equal(record.material.depthWrite, true);
   assert.equal(record.material.envMapIntensity, 0.7);
   assert.equal(record.baseEmissiveIntensity, 0.8);
   assert.equal(record.material.emissiveIntensity, 0.8);
   assert.ok(record.material.version > initialMaterialVersion);
+});
+
+test("record material settings can disable transparent depth writes", () => {
+  const material = new THREE.MeshPhysicalMaterial({ color: "#000000" });
+  const record = {
+    material,
+    hasVertexColors: false,
+    sourceColor: null,
+    fillIndex: 0
+  };
+
+  applyMaterialSettingsToRecord(THREE, record, {
+    defaultColor: "#445566",
+    opacity: 0.25,
+    depthWrite: false
+  });
+
+  assert.equal(record.material.transparent, true);
+  assert.equal(record.material.depthWrite, false);
+  assert.equal(record.baseDepthWrite, false);
+
+  applyMaterialSettingsToRecord(THREE, record, {
+    defaultColor: "#445566",
+    opacity: 1
+  });
+
+  assert.equal(record.material.transparent, false);
+  assert.equal(record.material.depthWrite, true);
+  assert.equal(record.baseDepthWrite, true);
 });

--- a/packages/cadjs/src/lib/viewer/topologyDisplayEdgeLine.js
+++ b/packages/cadjs/src/lib/viewer/topologyDisplayEdgeLine.js
@@ -60,6 +60,8 @@ function topologyDisplayEdgeLineSettingsKey(
     thickness: numberOrNull(edgeSettings?.thickness),
     includePartIds: normalizePartIdList(edgeSettings?.includePartIds),
     excludePartIds: normalizePartIdList(edgeSettings?.excludePartIds),
+    depthTest: edgeSettings?.depthTest !== false,
+    forceTopologyOverlay: edgeSettings?.forceTopologyOverlay === true,
     visibilityClasses: normalizePartIdList(edgeSettings?.visibilityClasses),
     classes: edgeSettings?.classes && typeof edgeSettings.classes === "object"
       ? Object.fromEntries(Object.entries(edgeSettings.classes).map(([classId, settings]) => [

--- a/packages/cadpy/README.md
+++ b/packages/cadpy/README.md
@@ -3,9 +3,10 @@
 Shared Python runtime for STEP-backed and Python-backed CAD Viewer GLB/topology artifacts.
 
 The package boundary is intentionally narrow: it owns artifact generation,
-validation, selector/topology extraction, mesh settings, source hashing, and the
-`cadpy-step-artifact` CLI. Skill-specific UX, prompts, viewer UI, and snapshot job
-orchestration stay in their owning skills.
+validation, selector/topology extraction, mesh settings, source hashing,
+standalone agent-oriented interference reports, and the
+`cadpy-step-artifact` / `cadpy-interference` CLIs. Skill-specific UX, prompts,
+viewer UI, and snapshot job orchestration stay in their owning skills.
 
 ## Local Development
 

--- a/packages/cadpy/pyproject.toml
+++ b/packages/cadpy/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 ]
 
 [project.scripts]
+cadpy-interference = "cadpy.interference:main"
 cadpy-step-artifact = "cadpy.step_artifact:main"
 
 [tool.setuptools.packages.find]

--- a/packages/cadpy/src/cadpy/catalog.py
+++ b/packages/cadpy/src/cadpy/catalog.py
@@ -395,7 +395,6 @@ def _read_step_source(
         if options.glb is not None
         else None
     )
-
     cad_ref = cad_ref_from_step_path(resolved_step_path)
 
     return CadSource(

--- a/packages/cadpy/src/cadpy/generation.py
+++ b/packages/cadpy/src/cadpy/generation.py
@@ -334,7 +334,14 @@ def _spec_output_paths(spec: EntrySpec) -> tuple[Path, ...]:
     if spec.step_path is not None:
         paths.append(spec.step_path)
         paths.append(part_glb_path(spec.step_path))
-    for path in (spec.dxf_path, spec.urdf_path, spec.sdf_path, spec.stl_path, spec.three_mf_path, spec.native_glb_path):
+    for path in (
+        spec.dxf_path,
+        spec.urdf_path,
+        spec.sdf_path,
+        spec.stl_path,
+        spec.three_mf_path,
+        spec.native_glb_path,
+    ):
         if path is not None:
             paths.append(path)
     return tuple(path.resolve() for path in paths)

--- a/packages/cadpy/src/cadpy/interference.py
+++ b/packages/cadpy/src/cadpy/interference.py
@@ -1,0 +1,836 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import fnmatch
+import json
+import math
+from pathlib import Path
+import time
+from typing import Any
+
+from OCP.BRep import BRep_Builder
+from OCP.BRepAlgoAPI import BRepAlgoAPI_Common
+from OCP.BRepExtrema import BRepExtrema_DistShapeShape
+from OCP.BRepGProp import BRepGProp
+from OCP.GProp import GProp_GProps
+from OCP.TopoDS import TopoDS_Compound
+
+from cadpy.render import relative_to_repo
+from cadpy.step_scene import (
+    LoadedStepScene,
+    OccurrenceNode,
+    _bbox_from_shape,
+    load_step_scene,
+    load_step_scene_cached,
+    occurrence_selector_id,
+    scene_occurrence_shape,
+    step_file_hash,
+)
+
+
+INTERFERENCE_SCHEMA_VERSION = 1
+DEFAULT_CLEARANCE_MM = 0.0
+DEFAULT_CONTACT_TOLERANCE_MM = 1.0e-4
+DEFAULT_COLLISION_VOLUME_TOLERANCE_MM3 = 1.0e-9
+DEFAULT_MAX_PAIRS = 1000
+
+
+@dataclass(frozen=True)
+class InterferenceOptions:
+    clearance_mm: float = DEFAULT_CLEARANCE_MM
+    contact_tolerance_mm: float = DEFAULT_CONTACT_TOLERANCE_MM
+    collision_volume_tolerance_mm3: float = DEFAULT_COLLISION_VOLUME_TOLERANCE_MM3
+    max_pairs: int = DEFAULT_MAX_PAIRS
+    time_budget_ms: float | None = None
+    body_depth: int | None = None
+    collapse: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+    set_a: tuple[str, ...] = ()
+    set_b: tuple[str, ...] = ()
+    pairs: tuple[str, ...] = ()
+    allow_pairs: tuple[str, ...] = ()
+    include_contact: bool = False
+    include_clearance: bool = False
+    include_separated: bool = False
+    include_allowed: bool = False
+    list_bodies: bool = False
+
+
+@dataclass(frozen=True)
+class _InterferenceBody:
+    id: str
+    name: str
+    shape: Any
+    bbox: dict[str, Any]
+    source_occurrence_ids: tuple[str, ...]
+    source_occurrence_names: tuple[str, ...]
+    collapsed: bool = False
+    collapse_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class _DistanceResult:
+    value: float
+    witness: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class _IntersectionResult:
+    volume_mm3: float = 0.0
+    witness: dict[str, Any] | None = None
+
+
+def normalize_interference_numeric(value: object, *, field_name: str) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be a number")
+    normalized = float(value)
+    if not math.isfinite(normalized):
+        raise ValueError(f"{field_name} must be finite")
+    if normalized < 0.0:
+        raise ValueError(f"{field_name} must be greater than or equal to 0")
+    return normalized
+
+
+def normalize_interference_max_pairs(value: object, *, field_name: str = "max_pairs") -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field_name} must be an integer")
+    if value <= 0:
+        raise ValueError(f"{field_name} must be greater than 0")
+    return int(value)
+
+
+def normalize_interference_body_depth(value: object, *, field_name: str = "body_depth") -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field_name} must be an integer")
+    if value <= 0:
+        raise ValueError(f"{field_name} must be greater than 0")
+    return int(value)
+
+
+def analyze_interference_scene(
+    scene: LoadedStepScene,
+    *,
+    options: InterferenceOptions | None = None,
+) -> dict[str, Any]:
+    resolved_options = options or InterferenceOptions()
+    started = time.perf_counter()
+    bodies = _analysis_bodies(scene, resolved_options)
+    if resolved_options.exclude:
+        bodies = [body for body in bodies if not _matches_any_body_selector(body, resolved_options.exclude)]
+
+    if resolved_options.list_bodies:
+        return _report_payload(
+            scene,
+            options=resolved_options,
+            bodies=bodies,
+            pairs=[],
+            total_pair_count=0,
+            candidate_pair_count=0,
+            analyzed_pair_count=0,
+            skipped_by_bbox_count=0,
+            skipped_by_pair_limit_count=0,
+            truncated=False,
+            timed_out=False,
+            elapsed_ms=_elapsed_ms(started),
+        )
+
+    scoped_pairs = _scoped_pairs(bodies, resolved_options)
+    total_pair_count = len(scoped_pairs)
+    threshold = math.inf if resolved_options.pairs else max(
+        resolved_options.clearance_mm,
+        resolved_options.contact_tolerance_mm,
+    )
+    candidate_pairs_all = [
+        (_bbox_distance(left.bbox, right.bbox), left, right)
+        for left, right in scoped_pairs
+        if _bbox_distance(left.bbox, right.bbox) <= threshold
+    ]
+    candidate_pairs_all.sort(key=lambda item: (item[0], item[1].id, item[2].id))
+    candidate_pair_count = len(candidate_pairs_all)
+    truncated = candidate_pair_count > resolved_options.max_pairs
+    candidate_pairs = candidate_pairs_all[: resolved_options.max_pairs]
+
+    pair_payloads: list[dict[str, Any]] = []
+    timed_out = False
+    analyzed_pair_count = 0
+    explicit_pair_mode = bool(resolved_options.pairs)
+    for bbox_distance_mm, left, right in candidate_pairs:
+        if resolved_options.time_budget_ms is not None and _elapsed_ms(started) >= resolved_options.time_budget_ms:
+            timed_out = True
+            break
+        pair = _analyze_pair(
+            left,
+            right,
+            bbox_distance_mm=bbox_distance_mm,
+            options=resolved_options,
+        )
+        analyzed_pair_count += 1
+        if explicit_pair_mode or _should_report_pair(pair, options=resolved_options):
+            pair_payloads.append(pair)
+
+    skipped_by_bbox = total_pair_count - candidate_pair_count
+    skipped_by_pair_limit = max(0, candidate_pair_count - len(candidate_pairs))
+    return _report_payload(
+        scene,
+        options=resolved_options,
+        bodies=bodies,
+        pairs=pair_payloads,
+        total_pair_count=total_pair_count,
+        candidate_pair_count=candidate_pair_count,
+        analyzed_pair_count=analyzed_pair_count,
+        skipped_by_bbox_count=max(0, skipped_by_bbox),
+        skipped_by_pair_limit_count=skipped_by_pair_limit,
+        truncated=truncated,
+        timed_out=timed_out,
+        elapsed_ms=_elapsed_ms(started),
+    )
+
+
+def analyze_interference_file(
+    step_path: Path,
+    *,
+    options: InterferenceOptions | None = None,
+    use_cache: bool = True,
+) -> dict[str, Any]:
+    scene = load_step_scene_cached(step_path) if use_cache else load_step_scene(step_path)
+    if not scene.step_hash and scene.step_path.is_file():
+        scene.step_hash = step_file_hash(scene.step_path)
+    return analyze_interference_scene(scene, options=options)
+
+
+def _analysis_bodies(scene: LoadedStepScene, options: InterferenceOptions) -> list[_InterferenceBody]:
+    bodies: list[_InterferenceBody] = []
+    for root in scene.roots:
+        _collect_analysis_bodies(scene, root, options=options, bodies=bodies)
+    return bodies
+
+
+def _collect_analysis_bodies(
+    scene: LoadedStepScene,
+    node: OccurrenceNode,
+    *,
+    options: InterferenceOptions,
+    bodies: list[_InterferenceBody],
+) -> None:
+    if not _node_has_geometry(scene, node):
+        return
+    selector_id = occurrence_selector_id(node)
+    collapse_match = _matches_node_selector(node, options.collapse)
+    depth_match = options.body_depth is not None and len(node.path) >= options.body_depth
+    leaf_match = node.prototype_key is not None and not node.children
+    if collapse_match or depth_match or leaf_match:
+        reason = "selector" if collapse_match else "body-depth" if depth_match and not leaf_match else None
+        bodies.append(_body_from_node(scene, node, collapsed=not leaf_match, collapse_reason=reason))
+        return
+    for child in node.children:
+        _collect_analysis_bodies(scene, child, options=options, bodies=bodies)
+
+
+def _node_has_geometry(scene: LoadedStepScene, node: OccurrenceNode) -> bool:
+    if node.prototype_key is not None and node.prototype_key in scene.prototype_shapes:
+        return True
+    return any(_node_has_geometry(scene, child) for child in node.children)
+
+
+def _body_from_node(
+    scene: LoadedStepScene,
+    node: OccurrenceNode,
+    *,
+    collapsed: bool,
+    collapse_reason: str | None,
+) -> _InterferenceBody:
+    leaves = _subtree_leaf_occurrences(node)
+    if node.prototype_key is not None and node.prototype_key in scene.prototype_shapes:
+        shape = scene_occurrence_shape(scene, node)
+    else:
+        shape = _compound_from_shapes(scene_occurrence_shape(scene, leaf) for leaf in leaves)
+    selector_id = occurrence_selector_id(node)
+    name = str(node.name or node.source_name or selector_id)
+    source_names = tuple(
+        str(leaf.name or leaf.source_name or occurrence_selector_id(leaf))
+        for leaf in leaves
+    )
+    return _InterferenceBody(
+        id=selector_id,
+        name=name,
+        shape=shape,
+        bbox=_bbox_from_shape(shape),
+        source_occurrence_ids=tuple(occurrence_selector_id(leaf) for leaf in leaves),
+        source_occurrence_names=source_names,
+        collapsed=collapsed or len(leaves) > 1,
+        collapse_reason=collapse_reason,
+    )
+
+
+def _subtree_leaf_occurrences(node: OccurrenceNode) -> list[OccurrenceNode]:
+    leaves: list[OccurrenceNode] = []
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        if current.prototype_key is not None:
+            leaves.append(current)
+        stack.extend(reversed(current.children))
+    return leaves
+
+
+def _compound_from_shapes(shapes: Iterable[Any]) -> Any:
+    builder = BRep_Builder()
+    compound = TopoDS_Compound()
+    builder.MakeCompound(compound)
+    for shape in shapes:
+        builder.Add(compound, shape)
+    return compound
+
+
+def _scoped_pairs(bodies: list[_InterferenceBody], options: InterferenceOptions) -> list[tuple[_InterferenceBody, _InterferenceBody]]:
+    if options.pairs:
+        pairs: list[tuple[_InterferenceBody, _InterferenceBody]] = []
+        for pair_selector in options.pairs:
+            left_selector, right_selector = _split_pair_selector(pair_selector)
+            for left in bodies:
+                if not _matches_body_selector(left, left_selector):
+                    continue
+                for right in bodies:
+                    if left.id == right.id or not _matches_body_selector(right, right_selector):
+                        continue
+                    pairs.append(_ordered_body_pair(left, right))
+        return _dedupe_body_pairs(pairs)
+
+    if options.set_a or options.set_b:
+        left_bodies = _select_bodies(bodies, options.set_a or options.set_b)
+        right_bodies = _select_bodies(bodies, options.set_b or options.set_a)
+        return _dedupe_body_pairs(
+            _ordered_body_pair(left, right)
+            for left in left_bodies
+            for right in right_bodies
+            if left.id != right.id
+        )
+
+    return [
+        (left, right)
+        for left_index, left in enumerate(bodies)
+        for right in bodies[left_index + 1 :]
+    ]
+
+
+def _select_bodies(bodies: list[_InterferenceBody], selectors: Sequence[str]) -> list[_InterferenceBody]:
+    if not selectors:
+        return list(bodies)
+    return [body for body in bodies if _matches_any_body_selector(body, selectors)]
+
+
+def _ordered_body_pair(left: _InterferenceBody, right: _InterferenceBody) -> tuple[_InterferenceBody, _InterferenceBody]:
+    return (left, right) if left.id <= right.id else (right, left)
+
+
+def _dedupe_body_pairs(pairs: Iterable[tuple[_InterferenceBody, _InterferenceBody]]) -> list[tuple[_InterferenceBody, _InterferenceBody]]:
+    seen: set[tuple[str, str]] = set()
+    result: list[tuple[_InterferenceBody, _InterferenceBody]] = []
+    for left, right in pairs:
+        key = (left.id, right.id)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append((left, right))
+    return result
+
+
+def _analyze_pair(
+    left: _InterferenceBody,
+    right: _InterferenceBody,
+    *,
+    bbox_distance_mm: float,
+    options: InterferenceOptions,
+) -> dict[str, Any]:
+    intersection = _IntersectionResult()
+    if bbox_distance_mm <= options.contact_tolerance_mm:
+        intersection = _intersection_shape_properties(left.shape, right.shape)
+
+    if intersection.volume_mm3 > options.collision_volume_tolerance_mm3:
+        status = "collision"
+        min_distance_mm = 0.0
+        witness = intersection.witness
+    else:
+        distance = _shape_distance(left.shape, right.shape)
+        min_distance_mm = distance.value
+        witness = distance.witness
+        if min_distance_mm <= options.contact_tolerance_mm:
+            status = "contact"
+        elif min_distance_mm <= options.clearance_mm:
+            status = "clearance"
+        else:
+            status = "separated"
+
+    allowed = _pair_allowed(left, right, options.allow_pairs)
+    violation = status == "collision" and not allowed
+    payload: dict[str, Any] = {
+        "id": f"{left.id}:{right.id}",
+        "a": left.id,
+        "b": right.id,
+        "aName": left.name,
+        "bName": right.name,
+        "status": status,
+        "policy": "allow_interference" if allowed else "forbid_interference",
+        "violation": violation,
+        "bboxDistanceMm": _round_float(bbox_distance_mm),
+        "minDistanceMm": _round_float(min_distance_mm),
+        "intersectionVolumeMm3": _round_float(intersection.volume_mm3),
+    }
+    if witness:
+        payload["witness"] = witness
+    if violation:
+        payload["suggestedCorrection"] = _suggested_bbox_correction(left, right, options=options)
+    return payload
+
+
+def _should_report_pair(pair: dict[str, Any], *, options: InterferenceOptions) -> bool:
+    status = str(pair.get("status") or "")
+    allowed = pair.get("policy") == "allow_interference"
+    if allowed and not options.include_allowed:
+        return False
+    if status == "collision":
+        return True
+    if status == "contact":
+        return bool(options.include_contact)
+    if status == "clearance":
+        return bool(options.include_clearance)
+    if status == "separated":
+        return bool(options.include_separated)
+    return False
+
+
+def _shape_distance(left_shape: Any, right_shape: Any) -> _DistanceResult:
+    try:
+        distance = BRepExtrema_DistShapeShape(left_shape, right_shape)
+        distance.SetMultiThread(True)
+        distance.Perform()
+        if not distance.IsDone():
+            return _DistanceResult(math.inf)
+        value = float(distance.Value())
+        witness = None
+        if distance.NbSolution() > 0:
+            left_point = distance.PointOnShape1(1)
+            right_point = distance.PointOnShape2(1)
+            witness = {
+                "aPoint": _point_payload(left_point),
+                "bPoint": _point_payload(right_point),
+                "vectorAToB": _vector_between(left_point, right_point),
+            }
+        return _DistanceResult(value=value, witness=witness)
+    except Exception:
+        return _DistanceResult(math.inf)
+
+
+def _intersection_shape_properties(left_shape: Any, right_shape: Any) -> _IntersectionResult:
+    try:
+        common = BRepAlgoAPI_Common(left_shape, right_shape)
+        common.SetRunParallel(True)
+        common.Build()
+        if not common.IsDone():
+            return _IntersectionResult()
+        shape = common.Shape()
+        if shape.IsNull():
+            return _IntersectionResult()
+        props = GProp_GProps()
+        BRepGProp.VolumeProperties_s(shape, props, False, False, True)
+        volume = max(0.0, float(props.Mass()))
+        center = props.CentreOfMass()
+        witness = {
+            "intersectionCenter": _point_payload(center),
+        }
+        return _IntersectionResult(volume_mm3=volume, witness=witness)
+    except Exception:
+        return _IntersectionResult()
+
+
+def _suggested_bbox_correction(
+    left: _InterferenceBody,
+    right: _InterferenceBody,
+    *,
+    options: InterferenceOptions,
+) -> dict[str, Any] | None:
+    left_min = _bbox_point(left.bbox, "min")
+    left_max = _bbox_point(left.bbox, "max")
+    right_min = _bbox_point(right.bbox, "min")
+    right_max = _bbox_point(right.bbox, "max")
+    if left_min is None or left_max is None or right_min is None or right_max is None:
+        return None
+    overlaps = []
+    for index, axis in enumerate(("x", "y", "z")):
+        overlap = min(left_max[index], right_max[index]) - max(left_min[index], right_min[index])
+        if overlap <= 0.0:
+            continue
+        left_center = (left_min[index] + left_max[index]) * 0.5
+        right_center = (right_min[index] + right_max[index]) * 0.5
+        sign = 1.0 if right_center >= left_center else -1.0
+        overlaps.append((overlap, index, axis, sign))
+    if not overlaps:
+        return None
+    overlap, index, axis, sign = min(overlaps, key=lambda item: item[0])
+    delta = [0.0, 0.0, 0.0]
+    delta[index] = sign * (overlap + max(options.contact_tolerance_mm, 1.0e-6))
+    return {
+        "move": right.id,
+        "translationMm": [_round_float(value) for value in delta],
+        "axis": axis,
+        "basis": "bbox-minimum-separation",
+        "confidence": "coarse",
+        "reason": "smallest axis-aligned bounding-box separation for the reported interfering pair",
+    }
+
+
+def _report_payload(
+    scene: LoadedStepScene,
+    *,
+    options: InterferenceOptions,
+    bodies: list[_InterferenceBody],
+    pairs: list[dict[str, Any]],
+    total_pair_count: int,
+    candidate_pair_count: int,
+    analyzed_pair_count: int,
+    skipped_by_bbox_count: int,
+    skipped_by_pair_limit_count: int,
+    truncated: bool,
+    timed_out: bool,
+    elapsed_ms: float,
+) -> dict[str, Any]:
+    status_counts: dict[str, int] = {}
+    unexpected_count = 0
+    allowed_count = 0
+    for pair in pairs:
+        status = str(pair.get("status") or "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+        if status == "collision" and pair.get("violation") is True:
+            unexpected_count += 1
+        elif status == "collision":
+            allowed_count += 1
+    step_hash = scene.step_hash or ""
+    if not step_hash and scene.step_path.is_file():
+        step_hash = step_file_hash(scene.step_path)
+    return {
+        "schemaVersion": INTERFERENCE_SCHEMA_VERSION,
+        "kind": "cadpy-interference-report",
+        "profile": "agent-interference",
+        "units": "mm",
+        "generatedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "source": {
+            "stepPath": relative_to_repo(scene.step_path),
+            **({"stepHash": step_hash} if step_hash else {}),
+        },
+        "options": _options_payload(options),
+        "summary": {
+            "bodyCount": len(bodies),
+            "totalPairCount": total_pair_count,
+            "candidatePairCount": candidate_pair_count,
+            "analyzedPairCount": analyzed_pair_count,
+            "reportedPairCount": len(pairs),
+            "skippedByBoundingBoxCount": skipped_by_bbox_count,
+            "skippedByPairLimitCount": skipped_by_pair_limit_count,
+            "truncated": truncated,
+            "timedOut": timed_out,
+            "elapsedMs": round(elapsed_ms, 1),
+            "statusCounts": status_counts,
+            "unexpectedInterferenceCount": unexpected_count,
+            "allowedInterferenceCount": allowed_count,
+        },
+        "bodies": [_body_payload(body) for body in bodies],
+        "pairs": pairs,
+    }
+
+
+def _options_payload(options: InterferenceOptions) -> dict[str, Any]:
+    return {
+        "clearanceMm": options.clearance_mm,
+        "contactToleranceMm": options.contact_tolerance_mm,
+        "collisionVolumeToleranceMm3": options.collision_volume_tolerance_mm3,
+        "maxPairs": options.max_pairs,
+        **({"timeBudgetMs": options.time_budget_ms} if options.time_budget_ms is not None else {}),
+        **({"bodyDepth": options.body_depth} if options.body_depth is not None else {}),
+        **({"collapse": list(options.collapse)} if options.collapse else {}),
+        **({"exclude": list(options.exclude)} if options.exclude else {}),
+        **({"setA": list(options.set_a)} if options.set_a else {}),
+        **({"setB": list(options.set_b)} if options.set_b else {}),
+        **({"pairs": list(options.pairs)} if options.pairs else {}),
+        **({"allowPairs": list(options.allow_pairs)} if options.allow_pairs else {}),
+        "includeContact": options.include_contact,
+        "includeClearance": options.include_clearance,
+        "includeSeparated": options.include_separated,
+        "includeAllowed": options.include_allowed,
+        "listBodies": options.list_bodies,
+    }
+
+
+def _body_payload(body: _InterferenceBody) -> dict[str, Any]:
+    return {
+        "id": body.id,
+        "name": body.name,
+        "bbox": _compact_bbox(body.bbox),
+        "sourceOccurrences": list(body.source_occurrence_ids),
+        "sourceOccurrenceNames": list(body.source_occurrence_names),
+        "collapsed": body.collapsed,
+        **({"collapseReason": body.collapse_reason} if body.collapse_reason else {}),
+    }
+
+
+def _pair_allowed(left: _InterferenceBody, right: _InterferenceBody, allow_pairs: Sequence[str]) -> bool:
+    for pair_selector in allow_pairs:
+        left_selector, right_selector = _split_pair_selector(pair_selector)
+        if _matches_body_selector(left, left_selector) and _matches_body_selector(right, right_selector):
+            return True
+        if _matches_body_selector(left, right_selector) and _matches_body_selector(right, left_selector):
+            return True
+    return False
+
+
+def _split_pair_selector(value: str) -> tuple[str, str]:
+    if ":" not in value:
+        raise ValueError(f"Pair selector must use LEFT:RIGHT syntax, got {value!r}")
+    left, right = value.split(":", 1)
+    left = left.strip()
+    right = right.strip()
+    if not left or not right:
+        raise ValueError(f"Pair selector must include both sides, got {value!r}")
+    return left, right
+
+
+def _matches_node_selector(node: OccurrenceNode, selectors: Sequence[str]) -> bool:
+    if not selectors:
+        return False
+    selector_id = occurrence_selector_id(node)
+    candidates = (
+        selector_id,
+        str(node.name or ""),
+        str(node.source_name or ""),
+    )
+    return any(_selector_matches(candidate, selector) for selector in selectors for candidate in candidates if candidate)
+
+
+def _matches_any_body_selector(body: _InterferenceBody, selectors: Sequence[str]) -> bool:
+    return any(_matches_body_selector(body, selector) for selector in selectors)
+
+
+def _matches_body_selector(body: _InterferenceBody, selector: str) -> bool:
+    candidates = (
+        body.id,
+        body.name,
+        *body.source_occurrence_ids,
+        *body.source_occurrence_names,
+    )
+    return any(_selector_matches(candidate, selector) for candidate in candidates if candidate)
+
+
+def _selector_matches(candidate: str, selector: str) -> bool:
+    normalized = str(selector or "").strip()
+    if not normalized:
+        return False
+    return candidate == normalized or fnmatch.fnmatchcase(candidate, normalized)
+
+
+def _bbox_distance(left: dict[str, Any], right: dict[str, Any]) -> float:
+    left_min = left.get("min") or [0.0, 0.0, 0.0]
+    left_max = left.get("max") or [0.0, 0.0, 0.0]
+    right_min = right.get("min") or [0.0, 0.0, 0.0]
+    right_max = right.get("max") or [0.0, 0.0, 0.0]
+    squared = 0.0
+    for index in range(3):
+        if float(left_max[index]) < float(right_min[index]):
+            delta = float(right_min[index]) - float(left_max[index])
+        elif float(right_max[index]) < float(left_min[index]):
+            delta = float(left_min[index]) - float(right_max[index])
+        else:
+            delta = 0.0
+        squared += delta * delta
+    return math.sqrt(squared)
+
+
+def _bbox_point(bbox: dict[str, Any], key: str) -> tuple[float, float, float] | None:
+    value = bbox.get(key)
+    if not isinstance(value, (list, tuple)) or len(value) != 3:
+        return None
+    try:
+        return (float(value[0]), float(value[1]), float(value[2]))
+    except (TypeError, ValueError):
+        return None
+
+
+def _compact_bbox(bbox: dict[str, Any]) -> dict[str, list[float | None]]:
+    return {
+        "min": [_round_float(value) for value in bbox.get("min", [])],
+        "max": [_round_float(value) for value in bbox.get("max", [])],
+    }
+
+
+def _point_payload(point: Any) -> list[float | None]:
+    try:
+        return [_round_float(point.X()), _round_float(point.Y()), _round_float(point.Z())]
+    except Exception:
+        return [None, None, None]
+
+
+def _vector_between(left_point: Any, right_point: Any) -> list[float | None]:
+    left = _point_payload(left_point)
+    right = _point_payload(right_point)
+    if any(value is None for value in left + right):
+        return [None, None, None]
+    return [_round_float(float(right[index]) - float(left[index])) for index in range(3)]
+
+
+def _round_float(value: object, *, digits: int = 6) -> float | None:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric):
+        return None
+    rounded = round(numeric, digits)
+    return 0.0 if rounded == -0.0 else rounded
+
+
+def _elapsed_ms(started: float) -> float:
+    return (time.perf_counter() - started) * 1000.0
+
+
+def _normalize_cli_numeric(value: object, *, field_name: str, parser: argparse.ArgumentParser) -> float | None:
+    try:
+        return normalize_interference_numeric(value, field_name=field_name)
+    except ValueError as exc:
+        parser.error(str(exc))
+    return None
+
+
+def _normalize_cli_max_pairs(value: object, *, parser: argparse.ArgumentParser) -> int | None:
+    try:
+        return normalize_interference_max_pairs(value, field_name="max_pairs")
+    except ValueError as exc:
+        parser.error(str(exc))
+    return None
+
+
+def _normalize_cli_body_depth(value: object, *, parser: argparse.ArgumentParser) -> int | None:
+    try:
+        return normalize_interference_body_depth(value, field_name="body_depth")
+    except ValueError as exc:
+        parser.error(str(exc))
+    return None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cadpy-interference",
+        description="Run on-demand STEP assembly interference detection for agentic CAD validation.",
+    )
+    parser.add_argument("step_path", help="STEP/STP file to inspect.")
+    parser.add_argument("--clearance", type=float, default=DEFAULT_CLEARANCE_MM, help="Near-clearance threshold in millimeters.")
+    parser.add_argument("--contact-tolerance", type=float, default=DEFAULT_CONTACT_TOLERANCE_MM, help="Contact tolerance in millimeters.")
+    parser.add_argument(
+        "--collision-volume-tolerance",
+        type=float,
+        default=DEFAULT_COLLISION_VOLUME_TOLERANCE_MM3,
+        help="Minimum common solid volume in cubic millimeters classified as interference.",
+    )
+    parser.add_argument("--max-pairs", type=int, default=DEFAULT_MAX_PAIRS, help="Maximum candidate pairs to solve exactly.")
+    parser.add_argument("--time-budget-ms", type=float, help="Stop before starting a new pair once this elapsed time budget is reached.")
+    parser.add_argument("--body-depth", type=int, help="Collapse the occurrence tree into analysis bodies at this 1-based occurrence depth.")
+    parser.add_argument("--collapse", action="append", default=[], help="Shell-style occurrence selector/name pattern to collapse into one analysis body.")
+    parser.add_argument("--exclude", action="append", default=[], help="Shell-style body selector/name pattern to omit.")
+    parser.add_argument("--set-a", action="append", default=[], help="Body selector/name pattern for the left analysis set.")
+    parser.add_argument("--set-b", action="append", default=[], help="Body selector/name pattern for the right analysis set.")
+    parser.add_argument("--pair", action="append", default=[], help="Explicit LEFT:RIGHT body selector pair. May be repeated.")
+    parser.add_argument("--allow-pair", action="append", default=[], help="LEFT:RIGHT pair whose interference is intentional and not a violation.")
+    parser.add_argument("--include-contact", action="store_true", help="Report contact pairs in addition to interferences.")
+    parser.add_argument("--include-clearance", action="store_true", help="Report near-clearance pairs in addition to interferences.")
+    parser.add_argument("--include-separated", action="store_true", help="Report separated analyzed pairs.")
+    parser.add_argument("--include-allowed", action="store_true", help="Include allowed interference pairs in the reported pairs list.")
+    parser.add_argument("--list-bodies", action="store_true", help="Only emit the resolved analysis bodies.")
+    parser.add_argument("--no-cache", action="store_true", help="Load the STEP file without the temporary scene cache.")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output.")
+    parser.add_argument("--format", choices=("json", "text"), default="json", help="Output format. JSON is the agent-oriented default.")
+    parser.add_argument("--fail-on-interference", action="store_true", help="Exit with status 2 when unexpected interferences are found.")
+    return parser
+
+
+def _options_from_args(args: argparse.Namespace, *, parser: argparse.ArgumentParser) -> InterferenceOptions:
+    try:
+        for pair_selector in [*(args.pair or []), *(args.allow_pair or [])]:
+            _split_pair_selector(pair_selector)
+    except ValueError as exc:
+        parser.error(str(exc))
+    clearance = _normalize_cli_numeric(args.clearance, field_name="clearance", parser=parser)
+    contact_tolerance = _normalize_cli_numeric(args.contact_tolerance, field_name="contact_tolerance", parser=parser)
+    collision_volume_tolerance = _normalize_cli_numeric(
+        args.collision_volume_tolerance,
+        field_name="collision_volume_tolerance",
+        parser=parser,
+    )
+    max_pairs = _normalize_cli_max_pairs(args.max_pairs, parser=parser)
+    return InterferenceOptions(
+        clearance_mm=DEFAULT_CLEARANCE_MM if clearance is None else clearance,
+        contact_tolerance_mm=DEFAULT_CONTACT_TOLERANCE_MM if contact_tolerance is None else contact_tolerance,
+        collision_volume_tolerance_mm3=(
+            DEFAULT_COLLISION_VOLUME_TOLERANCE_MM3
+            if collision_volume_tolerance is None
+            else collision_volume_tolerance
+        ),
+        max_pairs=DEFAULT_MAX_PAIRS if max_pairs is None else max_pairs,
+        time_budget_ms=_normalize_cli_numeric(args.time_budget_ms, field_name="time_budget_ms", parser=parser),
+        body_depth=_normalize_cli_body_depth(args.body_depth, parser=parser),
+        collapse=tuple(args.collapse or ()),
+        exclude=tuple(args.exclude or ()),
+        set_a=tuple(args.set_a or ()),
+        set_b=tuple(args.set_b or ()),
+        pairs=tuple(args.pair or ()),
+        allow_pairs=tuple(args.allow_pair or ()),
+        include_contact=bool(args.include_contact),
+        include_clearance=bool(args.include_clearance),
+        include_separated=bool(args.include_separated),
+        include_allowed=bool(args.include_allowed),
+        list_bodies=bool(args.list_bodies),
+    )
+
+
+def _format_text_report(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    lines = [
+        "Interference report",
+        f"  bodies: {summary.get('bodyCount', 0)}",
+        f"  pairs: {summary.get('reportedPairCount', 0)} reported / {summary.get('candidatePairCount', 0)} candidates / {summary.get('totalPairCount', 0)} scoped",
+        f"  unexpected interferences: {summary.get('unexpectedInterferenceCount', 0)}",
+    ]
+    for pair in payload.get("pairs", []) if isinstance(payload.get("pairs"), list) else []:
+        if not isinstance(pair, dict):
+            continue
+        marker = "VIOLATION" if pair.get("violation") else "allowed"
+        lines.append(
+            f"  - {marker} {pair.get('status')}: {pair.get('aName') or pair.get('a')} <-> {pair.get('bName') or pair.get('b')} "
+            f"volume={pair.get('intersectionVolumeMm3', 0)}mm^3"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    payload = analyze_interference_file(
+        Path(args.step_path),
+        options=_options_from_args(args, parser=parser),
+        use_cache=not bool(args.no_cache),
+    )
+    if args.format == "text":
+        print(_format_text_report(payload))
+    else:
+        print(json.dumps(payload, indent=2 if args.pretty else None, sort_keys=bool(args.pretty)))
+    unexpected = int((payload.get("summary") or {}).get("unexpectedInterferenceCount") or 0)
+    return 2 if bool(args.fail_on_interference) and unexpected > 0 else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/cadpy/src/cadpy/step_artifact.py
+++ b/packages/cadpy/src/cadpy/step_artifact.py
@@ -279,6 +279,7 @@ def main(argv: list[str] | None = None) -> int:
         args.mesh_angular_tolerance,
         field_name="mesh_angular_tolerance",
     )
+
     if bool(args.skip_step_write):
         existing_spec = spec
         if mesh_tolerance is not None or mesh_angular_tolerance is not None:

--- a/skills/cad/SKILL.md
+++ b/skills/cad/SKILL.md
@@ -46,7 +46,7 @@ Do not ask the user to provide a JSON specification and do not make JSON the use
 
 Keep these roots separate:
 
-- **CAD skill directory**: this folder. Tool launchers live here as `scripts/step`, `scripts/snapshot`, `scripts/inspect`, and `scripts/dxf`.
+- **CAD skill directory**: this folder. Tool launchers live here as `scripts/step`, `scripts/snapshot`, `scripts/inspect`, `scripts/interference`, and `scripts/dxf`.
 - **Tool process cwd**: relative CAD targets are resolved from the command's current working directory. Use absolute target paths when running from the skill directory, or run from the workspace root and invoke the launchers with a path to this skill directory.
 
 Short command examples in this skill use launcher paths relative to the CAD skill directory. Adapt the launcher path or target path so project CAD files resolve from the intended workspace, not accidentally under the skill directory.
@@ -61,6 +61,7 @@ From the CAD skill directory, the launcher shape is:
 python scripts/step ...
 python scripts/snapshot ...
 python scripts/inspect ...
+python scripts/interference ...
 python scripts/dxf ...
 ```
 
@@ -76,8 +77,8 @@ Use `python scripts/<tool> --help` for the complete current command interface; r
 4. **Check named purchasable components.** When an assembly includes named off-the-shelf actuators, servos, motors, electronics boards, connectors, or other purchasable components, search `$step-parts` before creating simplified placeholder geometry. If no exact match is found, record the miss and then use a documented envelope.
 5. **Plan before coding.** Define parameters, labels, source paths, expected bounding boxes, and any mating/positioning datums before editing.
 6. **Edit source, not generated artifacts.** Prefer build123d Python with `gen_step()` for STEP generation.
-7. **Generate explicit targets.** Use `scripts/step` for STEP/STP generation, GLB/topology artifacts, and sidecars. When a Python generator exists, its GLB/topology artifact is Python-backed even when the STEP is also written. Use `--kind part` or `--kind assembly` only for direct STEP/STP imports. Use `--skip-step-write` only when explicitly generating a Python-backed GLB/topology artifact without writing STEP. Do not run directory-wide generation.
-8. **Validate geometrically.** Use `scripts/inspect refs --facts --planes --positioning`, then targeted `measure`, `mate`, `frame`, or `diff` when needed.
+7. **Generate explicit targets.** Use `scripts/step` for STEP/STP generation, GLB/topology artifacts, and sidecars. Do not run collision/interference detection as a default generation side effect; use `scripts/interference` on demand after the STEP exists. When a Python generator exists, its GLB/topology artifact is Python-backed even when the STEP is also written. Use `--kind part` or `--kind assembly` only for direct STEP/STP imports. Use `--skip-step-write` only when explicitly generating a Python-backed GLB/topology artifact without writing STEP. Do not run directory-wide generation.
+8. **Validate geometrically.** Use `scripts/inspect refs --facts --planes --positioning`, then targeted `measure`, `mate`, `frame`, or `diff` when needed. For unexpected solid overlaps across an assembly, run the standalone `scripts/interference` CLI with explicit scope, body-depth, collapse, allow-pair, or pair controls.
 9. **Verify primary STEP visually with snapshots.** After creating or visibly updating a primary STEP/STP part or assembly, ALWAYS run CAD `scripts/snapshot` against the primary STEP/STP artifact for visual verification/review. Do not skip snapshots for speed, convenience, confidence, or because deterministic checks passed. Skip only when `references/snapshot-review.md` says no visible geometry changed or no valid artifact exists, and report that reason. Use PNGs for static reviews and GIFs for motion/animation reviews; `scripts/inspect`, measurements, mating checks, frames, and diffs are complementary, not replacements.
 10. **Repair and rerun.** If a check fails, change the smallest responsible source section, regenerate, and rerun the failed validation.
 
@@ -105,7 +106,7 @@ Load these files only when their trigger applies:
 - `references/natural-language-specs.md` — converting prose requirements into a CAD brief without requiring user JSON.
 - `references/parameters.md` — parameter, control, and animation design best practices.
 - `references/step-generation.md` — STEP generation, direct STEP/STP targets, part-vs-assembly behavior, and post-generation inspection.
-- `references/inspection-and-validation.md` — validation gates, `@cad[...]` refs, facts, planes, topology, measurements, mating, diff, frame, and final validation reporting.
+- `references/inspection-and-validation.md` — validation gates, `@cad[...]` refs, facts, planes, topology, measurements, mating, interference, diff, frame, and final validation reporting.
 - `references/snapshot-review.md` — risk-based snapshot triggers, small snapshot packets, targeted visual views, multimodal critique, and converting visual findings into geometry checks.
 - `references/positioning.md` — part-local datums, assembly transforms, build123d joints, CLI mate validation, and positioning reports.
 - `references/dxf.md` — secondary DXF workflow.

--- a/skills/cad/references/inspection-and-validation.md
+++ b/skills/cad/references/inspection-and-validation.md
@@ -11,6 +11,7 @@ Read this file for every generated STEP artifact and whenever the user asks for 
 - Reference discovery
 - Measurement checks
 - Mating checks
+- Interference detection
 - Frame inspection
 - Diff checks
 - CAD Viewer handoff
@@ -56,10 +57,11 @@ Default validation sequence:
 2. `refs --facts --planes --positioning` confirms scale, labels, major planes, and placement-ready references.
 3. `measure` confirms critical dimensions and offsets.
 4. `mate` confirms read-only alignment deltas for assembly interfaces or ref-to-ref positioning; it does not create source-level build123d joints.
-5. `frame` confirms world frame for occurrences or selected references.
-6. `diff` compares before/after geometry for modifications.
-7. Created or modified supported artifacts are handed to `$cad-viewer` for live viewer links when available.
-8. Saved CAD `scripts/snapshot` packets are ALWAYS run for visible created or updated primary STEP/STP artifacts unless `snapshot-review.md` documents that no visible geometry changed or no valid artifact exists; when run, every visual concern is followed by a deterministic geometry check before it becomes a validation claim.
+5. `scripts/interference` runs on-demand solid interference checks when unexpected assembly collisions are plausible or the user asks for collision detection. Use explicit scope, pair, body-depth, collapse, and allow-pair controls instead of making interference a generation side effect.
+6. `frame` confirms world frame for occurrences or selected references.
+7. `diff` compares before/after geometry for modifications.
+8. Created or modified supported artifacts are handed to `$cad-viewer` for live viewer links when available.
+9. Saved CAD `scripts/snapshot` packets are ALWAYS run for visible created or updated primary STEP/STP artifacts unless `snapshot-review.md` documents that no visible geometry changed or no valid artifact exists; when run, every visual concern is followed by a deterministic geometry check before it becomes a validation claim.
 
 ## Reference discovery
 
@@ -119,6 +121,20 @@ python scripts/inspect mate \
 ```
 
 Apply any required correction in the Python source using build123d joint definitions, `.connect_to()` calls, `Location`, parameter changes, or assembly child placement. Regenerate and re-inspect.
+
+## Interference detection
+
+Run standalone interference detection when an assembly may contain unexpected solid overlaps. The tool is agent-oriented: JSON is the default, all collisions are treated as violations unless an `--allow-pair` rule says otherwise, and scope controls are explicit.
+
+```bash
+python scripts/interference path/to/assembly.step --pretty
+python scripts/interference path/to/assembly.step --body-depth 2 --fail-on-interference
+python scripts/interference path/to/assembly.step --set-a 'o1.3.*' --set-b 'o1.4.*' --pretty
+python scripts/interference path/to/assembly.step --pair base_plate:triangular_prism --include-separated --pretty
+python scripts/interference path/to/assembly.step --collapse '*servo*' --allow-pair press_fit_pin:socket --pretty
+```
+
+Use `--body-depth` or `--collapse` to avoid spending time inside trusted rigid/vendor subassemblies. Use `--set-a`/`--set-b` for cross-set checks, `--pair` for a targeted drilldown, `--clearance` plus `--include-clearance` for near-miss checks, and `--include-allowed` when auditing intentional interferences. Interference detection is intentionally on demand rather than a `scripts/step` generation side effect.
 
 ## Frame inspection
 

--- a/skills/cad/references/step-generation.md
+++ b/skills/cad/references/step-generation.md
@@ -48,6 +48,7 @@ python scripts/inspect refs path/to/part.step --facts --planes --positioning
 ```bash
 python scripts/step path/to/assembly.py
 python scripts/inspect refs path/to/assembly.step --facts --planes --positioning
+python scripts/interference path/to/assembly.step --body-depth 2 --pretty
 ```
 
 Passing a generated assembly `.step` directly treats it as imported native STEP. Pass the `.py` assembly source when source-level assembly composition must be preserved.
@@ -101,6 +102,7 @@ Before running the command:
 - Confirm the source defines `gen_step()`.
 - Prefer the Python generator over a generated STEP/STP file when both are available.
 - Confirm labels are assigned for exported parts and assembly children.
+- For functional assemblies, decide whether standalone `scripts/interference` should run after generation, and choose explicit body-depth/collapse/scope controls before invoking it.
 - Confirm the target path is explicit.
 - Confirm expected bbox, labels, and positioning checks are known.
 

--- a/skills/cad/scripts/cadpy_common/catalog.py
+++ b/skills/cad/scripts/cadpy_common/catalog.py
@@ -395,7 +395,6 @@ def _read_step_source(
         if options.glb is not None
         else None
     )
-
     cad_ref = cad_ref_from_step_path(resolved_step_path)
 
     return CadSource(

--- a/skills/cad/scripts/cadpy_common/generation.py
+++ b/skills/cad/scripts/cadpy_common/generation.py
@@ -335,7 +335,14 @@ def _spec_output_paths(spec: EntrySpec) -> tuple[Path, ...]:
     if spec.step_path is not None:
         paths.append(spec.step_path)
         paths.append(part_glb_path(spec.step_path))
-    for path in (spec.dxf_path, spec.urdf_path, spec.sdf_path, spec.stl_path, spec.three_mf_path, spec.native_glb_path):
+    for path in (
+        spec.dxf_path,
+        spec.urdf_path,
+        spec.sdf_path,
+        spec.stl_path,
+        spec.three_mf_path,
+        spec.native_glb_path,
+    ):
         if path is not None:
             paths.append(path)
     return tuple(path.resolve() for path in paths)

--- a/skills/cad/scripts/interference/__main__.py
+++ b/skills/cad/scripts/interference/__main__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    scripts_dir = Path(__file__).resolve().parents[1]
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    from interference.cli import main
+else:
+    from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/cad/scripts/interference/cli.py
+++ b/skills/cad/scripts/interference/cli.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+import sys
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from cadpy_common.package_path import ensure_cadpy_package_path
+
+ensure_cadpy_package_path()
+
+from cadpy.interference import main as cadpy_interference_main
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return cadpy_interference_main(argv)

--- a/tests/python/packages/cadpy/test_interference.py
+++ b/tests/python/packages/cadpy/test_interference.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+
+from tests.python.support.paths import add_repo_path
+
+add_repo_path("packages/cadpy/src")
+
+from cadpy.interference import InterferenceOptions, analyze_interference_scene  # noqa: E402
+from cadpy.step_scene import LoadedStepScene, OccurrenceNode, _location_from_transform_matrix  # noqa: E402
+
+
+IDENTITY_TRANSFORM = (1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
+
+
+def _translation_transform(x: float, y: float = 0.0, z: float = 0.0) -> tuple[float, ...]:
+    return (1, 0, 0, x, 0, 1, 0, y, 0, 0, 1, z, 0, 0, 0, 1)
+
+
+def _box_scene(step_path: Path, *, offset: float) -> LoadedStepScene:
+    import build123d as b
+
+    box = b.Box(1, 1, 1).wrapped
+    right_transform = _translation_transform(offset)
+    return LoadedStepScene(
+        step_path=step_path.resolve(),
+        roots=[
+            OccurrenceNode(
+                path=(1,),
+                name="left",
+                source_name="left",
+                transform=IDENTITY_TRANSFORM,
+                local_transform=IDENTITY_TRANSFORM,
+                location=_location_from_transform_matrix(IDENTITY_TRANSFORM),
+                prototype_key=1,
+            ),
+            OccurrenceNode(
+                path=(2,),
+                name="right",
+                source_name="right",
+                transform=right_transform,
+                local_transform=right_transform,
+                location=_location_from_transform_matrix(right_transform),
+                prototype_key=2,
+            ),
+        ],
+        prototype_shapes={1: box, 2: box},
+        source_kind="step",
+        step_hash="step-hash-123",
+    )
+
+
+def _nested_scene(step_path: Path) -> LoadedStepScene:
+    import build123d as b
+
+    box = b.Box(1, 1, 1).wrapped
+    leaf_a_transform = _translation_transform(0.0)
+    leaf_b_transform = _translation_transform(0.8)
+    leaf_c_transform = _translation_transform(3.0)
+    return LoadedStepScene(
+        step_path=step_path.resolve(),
+        roots=[
+            OccurrenceNode(
+                path=(1,),
+                name="fixture",
+                source_name="fixture",
+                transform=IDENTITY_TRANSFORM,
+                local_transform=IDENTITY_TRANSFORM,
+                location=_location_from_transform_matrix(IDENTITY_TRANSFORM),
+                prototype_key=None,
+                children=[
+                    OccurrenceNode(
+                        path=(1, 1),
+                        name="trusted_servo",
+                        source_name="trusted_servo",
+                        transform=IDENTITY_TRANSFORM,
+                        local_transform=IDENTITY_TRANSFORM,
+                        location=_location_from_transform_matrix(IDENTITY_TRANSFORM),
+                        prototype_key=None,
+                        children=[
+                            OccurrenceNode(
+                                path=(1, 1, 1),
+                                name="servo_case",
+                                source_name="servo_case",
+                                transform=leaf_a_transform,
+                                local_transform=leaf_a_transform,
+                                location=_location_from_transform_matrix(leaf_a_transform),
+                                prototype_key=1,
+                            ),
+                            OccurrenceNode(
+                                path=(1, 1, 2),
+                                name="servo_gear",
+                                source_name="servo_gear",
+                                transform=leaf_b_transform,
+                                local_transform=leaf_b_transform,
+                                location=_location_from_transform_matrix(leaf_b_transform),
+                                prototype_key=2,
+                            ),
+                        ],
+                    ),
+                    OccurrenceNode(
+                        path=(1, 2),
+                        name="mount",
+                        source_name="mount",
+                        transform=leaf_c_transform,
+                        local_transform=leaf_c_transform,
+                        location=_location_from_transform_matrix(leaf_c_transform),
+                        prototype_key=3,
+                    ),
+                ],
+            )
+        ],
+        prototype_shapes={1: box, 2: box, 3: box},
+        source_kind="step",
+        step_hash="step-hash-123",
+    )
+
+
+class InterferenceTests(unittest.TestCase):
+    def test_collision_pair_reports_unexpected_interference(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="cadpy-interference-") as tempdir:
+            scene = _box_scene(Path(tempdir) / "collision.step", offset=0.8)
+
+            payload = analyze_interference_scene(scene)
+
+        self.assertEqual("cadpy-interference-report", payload["kind"])
+        self.assertEqual(2, payload["summary"]["bodyCount"])
+        self.assertEqual(1, payload["summary"]["unexpectedInterferenceCount"])
+        pair = payload["pairs"][0]
+        self.assertEqual("collision", pair["status"])
+        self.assertTrue(pair["violation"])
+        self.assertEqual("forbid_interference", pair["policy"])
+        self.assertGreater(pair["intersectionVolumeMm3"], 0.19)
+        self.assertIn("suggestedCorrection", pair)
+
+    def test_allowed_pair_is_suppressed_by_default(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="cadpy-interference-") as tempdir:
+            scene = _box_scene(Path(tempdir) / "allowed.step", offset=0.8)
+
+            payload = analyze_interference_scene(
+                scene,
+                options=InterferenceOptions(allow_pairs=("left:right",)),
+            )
+
+        self.assertEqual(0, payload["summary"]["unexpectedInterferenceCount"])
+        self.assertEqual(0, payload["summary"]["reportedPairCount"])
+
+    def test_allowed_pair_can_be_included_for_audit(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="cadpy-interference-") as tempdir:
+            scene = _box_scene(Path(tempdir) / "allowed.step", offset=0.8)
+
+            payload = analyze_interference_scene(
+                scene,
+                options=InterferenceOptions(allow_pairs=("left:right",), include_allowed=True),
+            )
+
+        self.assertEqual(0, payload["summary"]["unexpectedInterferenceCount"])
+        self.assertEqual(1, payload["summary"]["allowedInterferenceCount"])
+        self.assertFalse(payload["pairs"][0]["violation"])
+        self.assertEqual("allow_interference", payload["pairs"][0]["policy"])
+
+    def test_body_depth_collapses_internal_subassembly_pairs(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="cadpy-interference-") as tempdir:
+            scene = _nested_scene(Path(tempdir) / "nested.step")
+
+            leaf_payload = analyze_interference_scene(scene)
+            collapsed_payload = analyze_interference_scene(scene, options=InterferenceOptions(body_depth=2))
+
+        self.assertEqual(3, leaf_payload["summary"]["bodyCount"])
+        self.assertEqual(1, leaf_payload["summary"]["unexpectedInterferenceCount"])
+        self.assertEqual(2, collapsed_payload["summary"]["bodyCount"])
+        self.assertEqual(0, collapsed_payload["summary"]["unexpectedInterferenceCount"])
+        self.assertEqual(["o1.1.1", "o1.1.2"], collapsed_payload["bodies"][0]["sourceOccurrences"])
+
+    def test_explicit_pair_reports_separated_result_even_outside_clearance(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="cadpy-interference-") as tempdir:
+            scene = _box_scene(Path(tempdir) / "separated.step", offset=5.0)
+
+            payload = analyze_interference_scene(
+                scene,
+                options=InterferenceOptions(pairs=("left:right",)),
+            )
+
+        self.assertEqual(1, payload["summary"]["reportedPairCount"])
+        self.assertEqual("separated", payload["pairs"][0]["status"])
+        self.assertGreater(payload["pairs"][0]["minDistanceMm"], 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/skills/cad/cadpy_inspect_refs/test_refs_inspect.py
+++ b/tests/python/skills/cad/cadpy_inspect_refs/test_refs_inspect.py
@@ -1,5 +1,6 @@
 import contextlib
 import io
+import json
 import shutil
 import unittest
 from array import array
@@ -21,6 +22,10 @@ from cadpy.render import part_glb_path
 from cadpy.selector_types import SelectorBundle, SelectorProfile
 from cadpy.source_hash import python_source_hash
 from tests.python.support.cad_test_roots import IsolatedCadRoots
+
+
+def _pad4(payload: bytes, byte: bytes = b"\0") -> bytes:
+    return payload + byte * ((4 - (len(payload) % 4)) % 4)
 
 
 def _refs_manifest(cad_ref: str) -> dict[str, object]:

--- a/viewer/src/client/components/CadViewer.js
+++ b/viewer/src/client/components/CadViewer.js
@@ -116,6 +116,9 @@ import {
   THEME_FLOOR_MODES,
   resolveThemeSettingsDisplayEdgeSettings
 } from "cadjs/lib/themeSettings";
+import {
+  CAD_DISPLAY_MODE
+} from "cadjs/lib/displaySettings";
 import ViewPlaneControl from "./viewer/ViewPlaneControl";
 import { useViewerDrawingOverlay } from "./viewer/hooks/useViewerDrawingOverlay";
 import { useViewerPicking } from "./viewer/hooks/useViewerPicking";
@@ -176,6 +179,16 @@ const VIEW_PLANE_DEFAULT_PRESET = {
   up: WORLD_UP
 };
 const CAD_EDGE_OPACITY = 0.84;
+const ANALYSIS_SURFACE_REVIEW_SOLID_OPACITY = 0.22;
+const ANALYSIS_SURFACE_REVIEW_SOLID_COLOR = "#cbd5e1";
+const ANALYSIS_SURFACE_REVIEW_EDGE_COLOR = "#dbeafe";
+const ANALYSIS_SURFACE_REVIEW_EDGE_OPACITY = 0.96;
+const ANALYSIS_SURFACE_REVIEW_EDGE_CLASSES = Object.freeze({
+  feature: Object.freeze({ opacity: 0.98, thickness: 1.55 }),
+  seam: Object.freeze({ opacity: 0.88, thickness: 1.35 }),
+  tangent: Object.freeze({ opacity: 0.62, thickness: 1.15 }),
+  degenerate: Object.freeze({ opacity: 0, thickness: 0 })
+});
 const DEFAULT_LIGHTING = {
   toneMappingExposure: 1.08,
   hemisphereSky: "#d3dde6",
@@ -899,6 +912,327 @@ function clearOverlayGroup(runtime, group) {
   }
 }
 
+const STEP_ANALYSIS_STATUS_META = Object.freeze({
+  collision: Object.freeze({ color: "#ff3b30", opacity: 0.96, lineWidth: 3.4, rank: 4 }),
+  contact: Object.freeze({ color: "#22c55e", opacity: 0.94, lineWidth: 3, rank: 3 }),
+  clearance: Object.freeze({ color: "#22d3ee", opacity: 0.82, lineWidth: 2.4, rank: 2 }),
+  separated: Object.freeze({ color: "#94a3b8", opacity: 0.45, lineWidth: 1.7, rank: 1 })
+});
+
+const STEP_ANALYSIS_SURFACE_OPACITY = 0.15;
+const STEP_ANALYSIS_INTERFERENCE_VOLUME_OPACITY = 0.15;
+const STEP_ANALYSIS_VISIBLE_STATUSES = new Set(["collision", "contact", "clearance"]);
+const STEP_ANALYSIS_MAX_OVERLAY_PAIRS = 200;
+
+function normalizeStepAnalysisOverlaySettings(settings) {
+  const value = settings && typeof settings === "object" ? settings : {};
+  return {
+    enabled: value.enabled === true,
+    selectedPairId: String(value.selectedPairId || "").trim(),
+    showSurfaceReview: value.showSurfaceReview !== false,
+    showSurfaceHighlights: value.showSurfaceHighlights !== false,
+    showWitnesses: value.showWitnesses !== false,
+    showInterferenceVolumes: value.showInterferenceVolumes === true,
+    showBounds: value.showBounds === true,
+    statuses: {
+      collision: value.showCollisions !== false,
+      contact: value.showContacts !== false,
+      clearance: value.showClearances !== false
+    }
+  };
+}
+
+function stepAnalysisStatusMeta(status) {
+  const normalizedStatus = String(status || "").trim().toLowerCase();
+  return STEP_ANALYSIS_STATUS_META[normalizedStatus] || STEP_ANALYSIS_STATUS_META.separated;
+}
+
+function normalizeStepAnalysisStatus(status) {
+  const normalizedStatus = String(status || "").trim().toLowerCase();
+  return STEP_ANALYSIS_STATUS_META[normalizedStatus] ? normalizedStatus : "separated";
+}
+
+function numericPoint3(value) {
+  if (!Array.isArray(value) || value.length < 3) {
+    return null;
+  }
+  const point = value.slice(0, 3).map((component) => Number(component));
+  return point.every((component) => Number.isFinite(component)) ? point : null;
+}
+
+function vector3FromPoint(THREE, value) {
+  const point = numericPoint3(value);
+  return point ? new THREE.Vector3(point[0], point[1], point[2]) : null;
+}
+
+function stepAnalysisBoundsLinePositions(bounds) {
+  const min = numericPoint3(bounds?.min);
+  const max = numericPoint3(bounds?.max);
+  if (!min || !max) {
+    return null;
+  }
+  const width = Math.abs(max[0] - min[0]);
+  const depth = Math.abs(max[1] - min[1]);
+  const height = Math.abs(max[2] - min[2]);
+  if (width <= 0 && depth <= 0 && height <= 0) {
+    return null;
+  }
+  const corners = [
+    [min[0], min[1], min[2]],
+    [max[0], min[1], min[2]],
+    [max[0], max[1], min[2]],
+    [min[0], max[1], min[2]],
+    [min[0], min[1], max[2]],
+    [max[0], min[1], max[2]],
+    [max[0], max[1], max[2]],
+    [min[0], max[1], max[2]]
+  ];
+  const edgeIndexes = [
+    [0, 1], [1, 2], [2, 3], [3, 0],
+    [4, 5], [5, 6], [6, 7], [7, 4],
+    [0, 4], [1, 5], [2, 6], [3, 7]
+  ];
+  const positions = [];
+  for (const [startIndex, endIndex] of edgeIndexes) {
+    positions.push(...corners[startIndex], ...corners[endIndex]);
+  }
+  return positions;
+}
+
+function addStepAnalysisMarker(runtime, point, meta, markerRadius) {
+  const { THREE } = runtime;
+  const geometry = new THREE.SphereGeometry(markerRadius, 16, 8);
+  const material = new THREE.MeshBasicMaterial({
+    color: meta.color,
+    transparent: true,
+    opacity: Math.min(1, meta.opacity + 0.08),
+    depthTest: false,
+    depthWrite: false
+  });
+  const marker = new THREE.Mesh(geometry, material);
+  marker.position.copy(point);
+  marker.renderOrder = 82;
+  marker.frustumCulled = false;
+  runtime.stepAnalysisOverlayGroup.add(marker);
+}
+
+function addStepAnalysisWitness(runtime, pair, meta, markerRadius) {
+  const { THREE } = runtime;
+  const aPoint = vector3FromPoint(THREE, pair?.witness?.aPoint);
+  const bPoint = vector3FromPoint(THREE, pair?.witness?.bPoint);
+  if (!aPoint && !bPoint) {
+    return;
+  }
+  if (aPoint) {
+    addStepAnalysisMarker(runtime, aPoint, meta, markerRadius);
+  }
+  if (bPoint && (!aPoint || aPoint.distanceToSquared(bPoint) > markerRadius * markerRadius * 0.04)) {
+    addStepAnalysisMarker(runtime, bPoint, meta, markerRadius);
+  }
+  if (!aPoint || !bPoint || aPoint.distanceToSquared(bPoint) <= 0) {
+    return;
+  }
+  const line = createScreenSpaceLineSegments(runtime, [
+    aPoint.x, aPoint.y, aPoint.z,
+    bPoint.x, bPoint.y, bPoint.z
+  ], {
+    color: meta.color,
+    opacity: Math.min(1, meta.opacity + 0.1),
+    lineWidth: Math.max(meta.lineWidth + 0.8, 3),
+    renderOrder: 81,
+    depthTest: false,
+    depthWrite: false
+  });
+  if (line) {
+    runtime.stepAnalysisOverlayGroup.add(line);
+  }
+}
+
+function addStepAnalysisIntersectionMesh(runtime, pair, meta) {
+  const vertices = Array.isArray(pair?.intersectionMesh?.vertices) ? pair.intersectionMesh.vertices : [];
+  const indices = Array.isArray(pair?.intersectionMesh?.indices) ? pair.intersectionMesh.indices : [];
+  if (vertices.length < 9 || indices.length < 3) {
+    return;
+  }
+  const { THREE } = runtime;
+  const positionValues = vertices.map((value) => Number(value));
+  const indexValues = indices.map((value) => Number(value));
+  if (
+    positionValues.some((value) => !Number.isFinite(value)) ||
+    indexValues.some((value) => !Number.isInteger(value) || value < 0)
+  ) {
+    return;
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(positionValues), 3));
+  geometry.setIndex(new THREE.BufferAttribute(new Uint32Array(indexValues), 1));
+  geometry.computeVertexNormals();
+  geometry.computeBoundingSphere();
+  const material = new THREE.MeshBasicMaterial({
+    color: meta.color,
+    transparent: true,
+    opacity: STEP_ANALYSIS_INTERFERENCE_VOLUME_OPACITY,
+    depthTest: false,
+    depthWrite: false,
+    side: THREE.DoubleSide
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.renderOrder = 84;
+  mesh.frustumCulled = false;
+  mesh.userData.analysisPairId = String(pair?.id || "").trim();
+  runtime.stepAnalysisOverlayGroup.add(mesh);
+}
+
+function addStepAnalysisSurfaceMesh(runtime, surface, meta, pair) {
+  const vertices = Array.isArray(surface?.vertices) ? surface.vertices : [];
+  const indices = Array.isArray(surface?.indices) ? surface.indices : [];
+  if (vertices.length < 9 || indices.length < 3) {
+    return;
+  }
+  const { THREE } = runtime;
+  const positionValues = vertices.map((value) => Number(value));
+  const indexValues = indices.map((value) => Number(value));
+  if (
+    positionValues.some((value) => !Number.isFinite(value)) ||
+    indexValues.some((value) => !Number.isInteger(value) || value < 0)
+  ) {
+    return;
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.BufferAttribute(new Float32Array(positionValues), 3));
+  geometry.setIndex(new THREE.BufferAttribute(new Uint32Array(indexValues), 1));
+  geometry.computeVertexNormals();
+  geometry.computeBoundingSphere();
+  const material = new THREE.MeshBasicMaterial({
+    color: meta.color,
+    transparent: true,
+    opacity: STEP_ANALYSIS_SURFACE_OPACITY,
+    depthTest: false,
+    depthWrite: false,
+    side: THREE.DoubleSide
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.renderOrder = 86;
+  mesh.frustumCulled = false;
+  mesh.userData.analysisPairId = String(pair?.id || "").trim();
+  mesh.userData.analysisOccurrenceId = String(surface?.occurrenceId || "").trim();
+  runtime.stepAnalysisOverlayGroup.add(mesh);
+}
+
+function addStepAnalysisOccurrenceBox(runtime, occurrence, status) {
+  const positions = stepAnalysisBoundsLinePositions(occurrence?.bbox);
+  if (!positions) {
+    return;
+  }
+  const meta = stepAnalysisStatusMeta(status);
+  const line = createScreenSpaceLineSegments(runtime, positions, {
+    color: meta.color,
+    opacity: meta.opacity,
+    lineWidth: meta.lineWidth,
+    renderOrder: 80,
+    depthTest: false,
+    depthWrite: false
+  });
+  if (line) {
+    line.userData.analysisOccurrenceId = String(occurrence?.id || "").trim();
+    runtime.stepAnalysisOverlayGroup.add(line);
+  }
+}
+
+function ensureStepAnalysisOverlayGroup(runtime) {
+  if (!runtime?.THREE || !runtime?.modelGroup) {
+    return null;
+  }
+  if (!runtime.stepAnalysisOverlayGroup || runtime.stepAnalysisOverlayGroup.parent !== runtime.modelGroup) {
+    runtime.stepAnalysisOverlayGroup = new runtime.THREE.Group();
+    runtime.stepAnalysisOverlayGroup.name = "step-analysis-overlay";
+    runtime.stepAnalysisOverlayGroup.renderOrder = 80;
+    runtime.modelGroup.add(runtime.stepAnalysisOverlayGroup);
+  }
+  return runtime.stepAnalysisOverlayGroup;
+}
+
+function syncStepAnalysisOverlay(runtime, analysis, settings = null) {
+  const group = ensureStepAnalysisOverlayGroup(runtime);
+  if (!group) {
+    return;
+  }
+  clearOverlayGroup(runtime, group);
+  const overlaySettings = normalizeStepAnalysisOverlaySettings(settings);
+  if (!overlaySettings.enabled) {
+    return;
+  }
+
+  const pairs = (Array.isArray(analysis?.pairs) ? analysis.pairs : [])
+    .filter((pair) => {
+      if (overlaySettings.selectedPairId && String(pair?.id || "").trim() !== overlaySettings.selectedPairId) {
+        return false;
+      }
+      const status = normalizeStepAnalysisStatus(pair?.status);
+      return STEP_ANALYSIS_VISIBLE_STATUSES.has(status) && overlaySettings.statuses[status] !== false;
+    })
+    .slice(0, STEP_ANALYSIS_MAX_OVERLAY_PAIRS);
+  if (!pairs.length) {
+    return;
+  }
+
+  const occurrenceById = new Map(
+    (Array.isArray(analysis?.occurrences) ? analysis.occurrences : [])
+      .map((occurrence) => [String(occurrence?.id || "").trim(), occurrence])
+      .filter(([occurrenceId]) => occurrenceId)
+  );
+  const occurrenceStatus = new Map();
+  for (const pair of pairs) {
+    const status = normalizeStepAnalysisStatus(pair?.status);
+    const meta = stepAnalysisStatusMeta(status);
+    for (const occurrenceId of [pair?.a, pair?.b]) {
+      const id = String(occurrenceId || "").trim();
+      if (!id) {
+        continue;
+      }
+      const currentStatus = occurrenceStatus.get(id) || "separated";
+      if (meta.rank > stepAnalysisStatusMeta(currentStatus).rank) {
+        occurrenceStatus.set(id, status);
+      }
+    }
+  }
+
+  if (overlaySettings.showBounds) {
+    for (const [occurrenceId, status] of occurrenceStatus) {
+      addStepAnalysisOccurrenceBox(runtime, occurrenceById.get(occurrenceId), status);
+    }
+  }
+
+  if (overlaySettings.showInterferenceVolumes) {
+    for (const pair of pairs) {
+      if (normalizeStepAnalysisStatus(pair?.status) === "collision") {
+        addStepAnalysisIntersectionMesh(runtime, pair, stepAnalysisStatusMeta(pair?.status));
+      }
+    }
+  }
+
+  if (overlaySettings.showSurfaceHighlights) {
+    for (const pair of pairs) {
+      const status = normalizeStepAnalysisStatus(pair?.status);
+      if (status !== "collision" && status !== "contact") {
+        continue;
+      }
+      const meta = stepAnalysisStatusMeta(status);
+      for (const surface of Array.isArray(pair?.surfaceMeshes) ? pair.surfaceMeshes : []) {
+        addStepAnalysisSurfaceMesh(runtime, surface, meta, pair);
+      }
+    }
+  }
+
+  const markerRadius = Math.max((Number(runtime.modelRadius) || 1) * 0.0075, 0.28);
+  if (overlaySettings.showWitnesses) {
+    for (const pair of pairs) {
+      addStepAnalysisWitness(runtime, pair, stepAnalysisStatusMeta(pair?.status), markerRadius);
+    }
+  }
+  group.visible = group.children.length > 0;
+}
+
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
@@ -963,6 +1297,8 @@ const CadViewer = forwardRef(function CadViewer({
   selectedReferenceIds = [],
   selectorRuntime = null,
   displayEdgeRuntime = null,
+  stepAnalysis = null,
+  stepAnalysisSettings = null,
   stepParameters = null,
   pickableFaces = [],
   pickableEdges = [],
@@ -1054,7 +1390,30 @@ const CadViewer = forwardRef(function CadViewer({
     () => resolveThemeSettingsDisplayEdgeSettings(normalizedThemeSettings),
     [normalizedThemeSettings]
   );
-  const wireframeMode = normalizedDisplayMode === "wireframe";
+  const normalizedStepAnalysisOverlaySettings = useMemo(
+    () => normalizeStepAnalysisOverlaySettings(stepAnalysisSettings),
+    [stepAnalysisSettings]
+  );
+  const transparentMode = normalizedDisplayMode === CAD_DISPLAY_MODE.TRANSPARENT;
+  const collisionMode = normalizedDisplayMode === CAD_DISPLAY_MODE.COLLISION;
+  const effectiveStepAnalysisOverlaySettings = useMemo(() => ({
+    ...normalizedStepAnalysisOverlaySettings,
+    enabled: collisionMode,
+    showSurfaceReview: transparentMode ||
+      collisionMode ||
+      normalizedStepAnalysisOverlaySettings.showSurfaceReview
+  }), [collisionMode, normalizedStepAnalysisOverlaySettings, transparentMode]);
+  const analysisSurfaceReviewActive =
+    transparentMode ||
+    (
+      effectiveStepAnalysisOverlaySettings.enabled &&
+      effectiveStepAnalysisOverlaySettings.showSurfaceReview
+    );
+  const wireframeMode = normalizedDisplayMode === CAD_DISPLAY_MODE.WIREFRAME;
+  const effectiveWireframeMode = wireframeMode;
+  const effectiveDisplayMode = wireframeMode
+    ? CAD_DISPLAY_MODE.WIREFRAME
+    : CAD_DISPLAY_MODE.SOLID;
   const wireframeEdgeColor = useMemo(
     () => displayEdgeSettings?.color || "#132232",
     [displayEdgeSettings]
@@ -1065,15 +1424,77 @@ const CadViewer = forwardRef(function CadViewer({
       : (viewerTheme?.edgeOpacity ?? BASE_VIEWER_THEME.edgeOpacity ?? CAD_EDGE_OPACITY);
     return Math.max(baseOpacity, 0.9);
   }, [displayEdgeSettings, viewerTheme]);
-  const visualEdgeSettings = useMemo(() => wireframeMode
-    ? {
+  const visualEdgeSettings = useMemo(() => {
+    if (analysisSurfaceReviewActive) {
+      const baseThickness = Number.isFinite(Number(displayEdgeSettings?.thickness))
+        ? clamp(Number(displayEdgeSettings.thickness), 0.5, 6)
+        : 1;
+      return {
+        ...displayEdgeSettings,
+        enabled: true,
+        contrastMode: "manual",
+        color: ANALYSIS_SURFACE_REVIEW_EDGE_COLOR,
+        opacity: ANALYSIS_SURFACE_REVIEW_EDGE_OPACITY,
+        thickness: Math.max(baseThickness, 1.35),
+        depthTest: false,
+        forceTopologyOverlay: true,
+        silhouette: false,
+        classes: {
+          feature: {
+            ...ANALYSIS_SURFACE_REVIEW_EDGE_CLASSES.feature,
+            thickness: Math.max(baseThickness, ANALYSIS_SURFACE_REVIEW_EDGE_CLASSES.feature.thickness)
+          },
+          seam: {
+            ...ANALYSIS_SURFACE_REVIEW_EDGE_CLASSES.seam,
+            thickness: Math.max(baseThickness, ANALYSIS_SURFACE_REVIEW_EDGE_CLASSES.seam.thickness)
+          },
+          tangent: {
+            ...ANALYSIS_SURFACE_REVIEW_EDGE_CLASSES.tangent,
+            thickness: Math.max(baseThickness, ANALYSIS_SURFACE_REVIEW_EDGE_CLASSES.tangent.thickness)
+          },
+          degenerate: ANALYSIS_SURFACE_REVIEW_EDGE_CLASSES.degenerate
+        }
+      };
+    }
+    if (effectiveWireframeMode) {
+      return {
         ...displayEdgeSettings,
         contrastMode: "manual",
         color: wireframeEdgeColor,
         opacity: wireframeEdgeOpacity
-      }
-    : displayEdgeSettings,
-  [displayEdgeSettings, wireframeEdgeColor, wireframeEdgeOpacity, wireframeMode]);
+      };
+    }
+    return displayEdgeSettings;
+  }, [analysisSurfaceReviewActive, displayEdgeSettings, effectiveWireframeMode, wireframeEdgeColor, wireframeEdgeOpacity]);
+  const resolvedMaterialSettings = useMemo(() => {
+    const baseMaterialSettings = {
+      ...normalizedThemeSettings.materials,
+      envMapIntensity: normalizedThemeSettings.materials.envMapIntensity * (
+        normalizedThemeSettings.environment.enabled ? normalizedThemeSettings.environment.intensity : 0
+      )
+    };
+    if (!analysisSurfaceReviewActive || effectiveWireframeMode) {
+      return baseMaterialSettings;
+    }
+    return {
+      ...baseMaterialSettings,
+      defaultColor: ANALYSIS_SURFACE_REVIEW_SOLID_COLOR,
+      overrideSourceColors: true,
+      opacity: Math.min(
+        Number.isFinite(Number(baseMaterialSettings.opacity)) ? Number(baseMaterialSettings.opacity) : 1,
+        ANALYSIS_SURFACE_REVIEW_SOLID_OPACITY
+      ),
+      depthWrite: false,
+      metalness: 0,
+      clearcoat: 0,
+      clearcoatRoughness: 1
+    };
+  }, [
+    analysisSurfaceReviewActive,
+    effectiveWireframeMode,
+    normalizedThemeSettings.environment,
+    normalizedThemeSettings.materials
+  ]);
   const focusedPartIds = useMemo(() => normalizePartIdList(focusedPartId), [focusedPartId]);
   const focusedPartIdSet = useMemo(() => new Set(focusedPartIds), [focusedPartIds]);
   const normalizedClipSettings = normalizedViewerRenderState.clipSettings;
@@ -1096,10 +1517,14 @@ const CadViewer = forwardRef(function CadViewer({
     floorMode,
     normalizedThemeSettings.floor
   ), [normalizedThemeSettings.floor]);
-  const edgesVisible = showEdges && shouldUseCadEdgeSource && (displayEdgeSettings.enabled || wireframeMode);
+  const edgesVisible = showEdges && shouldUseCadEdgeSource && (
+    displayEdgeSettings.enabled ||
+    effectiveWireframeMode ||
+    analysisSurfaceReviewActive
+  );
   const topologyDisplayEdgesVisible = shouldRenderTopologyDisplayEdges({
     edgesVisible,
-    wireframeMode,
+    wireframeMode: effectiveWireframeMode,
     cadEdgeSource: shouldUseCadEdgeSource,
     displayEdgeRuntime: activeDisplayEdgeRuntime,
     selectorRuntime: activeSelectorRuntime,
@@ -1118,10 +1543,10 @@ const CadViewer = forwardRef(function CadViewer({
     edgesVisible,
     topologyDisplayEdgesVisible,
     displayEdgesVisible,
-    wireframeMode
+    wireframeMode: effectiveWireframeMode
   });
   const preserveInteractionPixelRatio = Boolean(
-    wireframeMode ||
+    effectiveWireframeMode ||
     edgesVisible ||
     topologyDisplayEdgesVisible ||
     displayEdgesVisible ||
@@ -1819,14 +2244,8 @@ const CadViewer = forwardRef(function CadViewer({
     runtime.keyLight.castShadow = runtime.keyLight.visible;
     runtime.spotLight.castShadow = false;
 
-    const materialSettings = {
-      ...normalizedThemeSettings.materials,
-      envMapIntensity: normalizedThemeSettings.materials.envMapIntensity * (
-        normalizedThemeSettings.environment.enabled ? normalizedThemeSettings.environment.intensity : 0
-      )
-    };
     for (const record of runtime.displayRecords || []) {
-      applyMaterialSettingsToRecord(runtime.THREE, record, materialSettings);
+      applyMaterialSettingsToRecord(runtime.THREE, record, resolvedMaterialSettings);
     }
 
     runtime.gridConfig = null;
@@ -1856,6 +2275,7 @@ const CadViewer = forwardRef(function CadViewer({
     defaultGridRadius,
     normalizedThemeSettings,
     normalizedSceneScaleMode,
+    resolvedMaterialSettings,
     resolvedFloorMode,
     viewerReadyTick,
     viewerTheme,
@@ -2044,6 +2464,7 @@ const CadViewer = forwardRef(function CadViewer({
       runtime.edgePickObjects = [];
       runtime.topologyDisplayEdgeLine = null;
       runtime.topologyDisplayEdgeTransformByRecord = false;
+      runtime.stepAnalysisOverlayGroup = null;
       runtime.displayRecords = [];
       runtime.hasVisibleModel = false;
       runtime.activeModelKey = "";
@@ -2071,7 +2492,7 @@ const CadViewer = forwardRef(function CadViewer({
       Array.isArray(meshData?.parts) &&
       meshData.parts.length > 0;
     const shouldRenderSourceColorParts =
-      !wireframeMode &&
+      !effectiveWireframeMode &&
       normalizedThemeSettings.materials?.overrideSourceColors !== true &&
       meshNeedsPartRenderingForSourceColors(meshData);
     const shouldRenderParts =
@@ -2090,12 +2511,6 @@ const CadViewer = forwardRef(function CadViewer({
       : shouldRenderFillParts || shouldRenderSourceColorParts
         ? meshData.parts
         : pickableParts;
-    const materialSettings = {
-      ...normalizedThemeSettings.materials,
-      envMapIntensity: normalizedThemeSettings.materials.envMapIntensity * (
-        normalizedThemeSettings.environment.enabled ? normalizedThemeSettings.environment.intensity : 0
-      )
-    };
     const modelStepParameters = stepParameterRuntime?.definition
       ? {
           ...stepParameterRuntime,
@@ -2103,7 +2518,7 @@ const CadViewer = forwardRef(function CadViewer({
         }
       : null;
 
-    const sceneTheme = wireframeMode
+    const sceneTheme = effectiveWireframeMode
       ? {
           ...normalizedThemeSettings,
           edges: {
@@ -2129,10 +2544,10 @@ const CadViewer = forwardRef(function CadViewer({
         };
     const cadScene = buildModel(THREE, meshData, {
       theme: sceneTheme,
-      displayMode: normalizedDisplayMode,
+      displayMode: effectiveDisplayMode,
       scale: normalizedSceneScaleMode,
       baseTheme: viewerTheme,
-      materialSettings,
+      materialSettings: resolvedMaterialSettings,
       recomputeNormals,
       silhouette: topologyDisplayEdgesVisible && displayEdgeSettings.silhouette === true,
       parts: shouldRenderParts ? renderedParts : [],
@@ -2337,16 +2752,41 @@ const CadViewer = forwardRef(function CadViewer({
     pickableParts,
     selectorRuntime,
     displayEdgeRuntime,
-    normalizedDisplayMode,
+    effectiveDisplayMode,
+    effectiveWireframeMode,
+    wireframeEdgeColor,
     normalizedSceneScaleMode,
     resolvedFloorMode,
+    resolvedMaterialSettings,
     viewerTheme,
     normalizedThemeSettings.materials,
     normalizedThemeSettings.environment,
     displayEdgeSettings,
     visualEdgeSettings,
-    wireframeEdgeColor,
     updateActiveGridHelper
+  ]);
+
+  useEffect(() => {
+    const runtime = runtimeRef.current;
+    if (!runtime?.THREE || !runtime?.modelGroup) {
+      return;
+    }
+    if (isLoading || !meshData || !runtime.hasVisibleModel) {
+      if (runtime.stepAnalysisOverlayGroup) {
+        clearOverlayGroup(runtime, runtime.stepAnalysisOverlayGroup);
+        runtime.requestRender?.();
+      }
+      return;
+    }
+    syncStepAnalysisOverlay(runtime, stepAnalysis, effectiveStepAnalysisOverlaySettings);
+    runtime.requestRender?.();
+  }, [
+    isLoading,
+    meshData,
+    modelKey,
+    effectiveStepAnalysisOverlaySettings,
+    stepAnalysis,
+    viewerReadyTick
   ]);
 
   useEffect(() => {
@@ -2416,7 +2856,7 @@ const CadViewer = forwardRef(function CadViewer({
 
     applyPartVisualState(runtime.THREE, runtime.displayRecords, partVisualStateRef.current);
     runtime.requestRender();
-  }, [viewerReadyTick, partVisualStateEnabled, recordEdgesVisible, focusedPartIds, hiddenPartIds, hoveredPartId, pickMode, pickableParts, selectedPartIds, viewerTheme, visualEdgeSettings, normalizedDisplayMode]);
+  }, [viewerReadyTick, partVisualStateEnabled, recordEdgesVisible, focusedPartIds, hiddenPartIds, hoveredPartId, pickMode, pickableParts, selectedPartIds, viewerTheme, visualEdgeSettings, effectiveDisplayMode]);
 
   useEffect(() => {
     const runtime = runtimeRef.current;
@@ -2510,7 +2950,7 @@ const CadViewer = forwardRef(function CadViewer({
       applyPartVisualState(runtime.THREE, runtime.displayRecords, partVisualStateRef.current);
       const baseTopologyDisplayEdgesVisible = shouldRenderTopologyDisplayEdges({
         edgesVisible,
-        wireframeMode,
+        wireframeMode: effectiveWireframeMode,
         cadEdgeSource: shouldUseCadEdgeSource,
         displayEdgeRuntime,
         selectorRuntime,
@@ -2585,7 +3025,7 @@ const CadViewer = forwardRef(function CadViewer({
     });
     const nextTopologyDisplayEdgesVisible = shouldRenderTopologyDisplayEdges({
       edgesVisible,
-      wireframeMode,
+      wireframeMode: effectiveWireframeMode,
       cadEdgeSource: shouldUseCadEdgeSource,
       displayEdgeRuntime: useRecordTopologyEdgeTransforms ? displayEdgeRuntime : nextEdgeRuntimes.displayEdgeRuntime,
       selectorRuntime: nextEdgeRuntimes.selectorRuntime,
@@ -2632,7 +3072,7 @@ const CadViewer = forwardRef(function CadViewer({
   }, [
     visualEdgeSettings,
     edgesVisible,
-    wireframeMode,
+    effectiveWireframeMode,
     shouldUseCadEdgeSource,
     focusedPartIds,
     recordEdgesVisible,

--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -8,7 +8,6 @@ import DxfFileSheet from "./workbench/DxfFileSheet";
 import GcodeFileSheet from "./workbench/GcodeFileSheet";
 import FileViewerSidebar from "./workbench/FileViewerSidebar";
 import {
-  DisplaySettingsSection,
   ThemeSettingsSections
 } from "./workbench/ThemeSettingsPopover";
 import MeshFileSheet from "./workbench/MeshFileSheet";
@@ -45,6 +44,8 @@ import {
   THEME_COLOR_MODES
 } from "cadjs/lib/themeSettings";
 import {
+  CAD_DISPLAY_MODE,
+  normalizeDisplayMode,
   normalizeDisplaySettings
 } from "cadjs/lib/displaySettings";
 import { clonePerspectiveSnapshot } from "cadjs/lib/perspective";
@@ -419,6 +420,145 @@ function ownProperty(object, key) {
   return Object.prototype.hasOwnProperty.call(object || {}, key);
 }
 
+function normalizeCollisionStringList(value) {
+  const rawValues = Array.isArray(value)
+    ? value
+    : String(value || "").split(/[\n,]+/u);
+  return rawValues
+    .map((item) => String(item || "").trim())
+    .filter(Boolean);
+}
+
+const DEFAULT_STEP_ANALYSIS_SETTINGS = Object.freeze({
+  enabled: false,
+  selectedPairId: "",
+  bodyDepth: 2,
+  maxPairs: 1000,
+  clearanceMm: 0,
+  contactToleranceMm: 0.0001,
+  collisionVolumeToleranceMm3: 0.000000001,
+  timeBudgetMs: 0,
+  includeContact: true,
+  includeClearance: false,
+  includeSeparated: false,
+  includeAllowed: false,
+  listBodies: false,
+  noCache: false,
+  setA: [],
+  setB: [],
+  pairs: [],
+  allowPairs: [],
+  exclude: [],
+  collapse: [],
+  showSurfaceReview: true,
+  showSurfaceHighlights: true,
+  showWitnesses: true,
+  showInterferenceVolumes: false,
+  showBounds: false,
+  showCollisions: true,
+  showContacts: true,
+  showClearances: true
+});
+
+function normalizeStepAnalysisSettings(value) {
+  const settings = value && typeof value === "object" ? value : {};
+  return {
+    enabled: settings.enabled === true,
+    selectedPairId: String(settings.selectedPairId || "").trim(),
+    bodyDepth: clampNumber(Number.isFinite(Number(settings.bodyDepth)) ? settings.bodyDepth : 2, 1, 12),
+    maxPairs: Math.min(Math.max(Math.round(Number(settings.maxPairs) || 1000), 1), 100000),
+    clearanceMm: clampNumber(settings.clearanceMm, 0, 100000),
+    contactToleranceMm: clampNumber(
+      Number.isFinite(Number(settings.contactToleranceMm)) ? settings.contactToleranceMm : 0.0001,
+      0,
+      1000
+    ),
+    collisionVolumeToleranceMm3: clampNumber(
+      Number.isFinite(Number(settings.collisionVolumeToleranceMm3)) ? settings.collisionVolumeToleranceMm3 : 0.000000001,
+      0,
+      1000000000
+    ),
+    timeBudgetMs: clampNumber(settings.timeBudgetMs, 0, 3600000),
+    includeContact: settings.includeContact !== false,
+    includeClearance: settings.includeClearance === true,
+    includeSeparated: settings.includeSeparated === true,
+    includeAllowed: settings.includeAllowed === true,
+    listBodies: settings.listBodies === true,
+    noCache: settings.noCache === true,
+    setA: normalizeCollisionStringList(settings.setA),
+    setB: normalizeCollisionStringList(settings.setB),
+    pairs: normalizeCollisionStringList(settings.pairs),
+    allowPairs: normalizeCollisionStringList(settings.allowPairs),
+    exclude: normalizeCollisionStringList(settings.exclude),
+    collapse: normalizeCollisionStringList(settings.collapse),
+    showSurfaceReview: settings.showSurfaceReview !== false,
+    showSurfaceHighlights: settings.showSurfaceHighlights !== false,
+    showWitnesses: settings.showWitnesses !== false,
+    showInterferenceVolumes: settings.showInterferenceVolumes === true,
+    showBounds: settings.showBounds === true,
+    showCollisions: settings.showCollisions !== false,
+    showContacts: settings.showContacts !== false,
+    showClearances: settings.showClearances !== false
+  };
+}
+
+function collisionSettingsKey(settings) {
+  const normalized = normalizeStepAnalysisSettings(settings);
+  return [
+    normalized.bodyDepth,
+    normalized.maxPairs,
+    normalized.clearanceMm,
+    normalized.contactToleranceMm,
+    normalized.collisionVolumeToleranceMm3,
+    normalized.timeBudgetMs,
+    normalized.includeContact,
+    normalized.includeClearance,
+    normalized.includeSeparated,
+    normalized.includeAllowed,
+    normalized.listBodies,
+    normalized.noCache,
+    normalized.setA.join(","),
+    normalized.setB.join(","),
+    normalized.pairs.join(","),
+    normalized.allowPairs.join(","),
+    normalized.exclude.join(","),
+    normalized.collapse.join(",")
+  ].join(":");
+}
+
+function normalizeCollisionReportForViewer(report) {
+  if (!report || typeof report !== "object") {
+    return null;
+  }
+  const summary = report.summary && typeof report.summary === "object" ? report.summary : {};
+  const statusCounts = summary.statusCounts && typeof summary.statusCounts === "object"
+    ? summary.statusCounts
+    : {};
+  const bodies = Array.isArray(report.bodies) ? report.bodies : [];
+  return {
+    schemaVersion: report.schemaVersion,
+    kind: String(report.kind || "cadpy-interference-report"),
+    profile: String(report.profile || "agent-interference"),
+    units: report.units || "mm",
+    source: report.source || null,
+    summary: {
+      ...summary,
+      occurrenceCount: bodies.length,
+      collisionCount: Math.max(Number(statusCounts.collision) || 0, 0),
+      contactCount: Math.max(Number(statusCounts.contact) || 0, 0),
+      clearanceCount: Math.max(Number(statusCounts.clearance) || 0, 0)
+    },
+    occurrences: bodies.map((body) => ({
+      id: String(body?.id || "").trim(),
+      name: String(body?.name || body?.id || "").trim(),
+      bbox: body?.bbox || null,
+      sourceOccurrences: Array.isArray(body?.sourceOccurrences) ? body.sourceOccurrences : [],
+      collapsed: body?.collapsed === true
+    })).filter((body) => body.id),
+    pairs: Array.isArray(report.pairs) ? report.pairs : []
+  };
+}
+
 function mergeStepSourceStatusIntoEntry(entry, stepSourceStatus) {
   if (!entry || !stepSourceStatus || typeof stepSourceStatus !== "object") {
     return entry;
@@ -532,6 +672,13 @@ export default function CadWorkspace({
   const [stepTreeRootShowMore, setStepTreeRootShowMore] = useState(false);
   const [hiddenPartIds, setHiddenPartIds] = useState([]);
   const [displaySettings, setDisplaySettings] = useState(() => normalizeDisplaySettings());
+  const [stepAnalysisSettings, setStepAnalysisSettings] = useState(() => (
+    normalizeStepAnalysisSettings(DEFAULT_STEP_ANALYSIS_SETTINGS)
+  ));
+  const [collisionReportState, setCollisionReportState] = useState(null);
+  const [collisionStatus, setCollisionStatus] = useState(REFERENCE_STATUS.IDLE);
+  const [collisionError, setCollisionError] = useState("");
+  const [collisionLoadStage, setCollisionLoadStage] = useState("");
   const [hoveredListPartId, setHoveredListPartId] = useState("");
   const [hoveredModelPartId, setHoveredModelPartId] = useState("");
   const [copyStatus, setCopyStatus] = useState("");
@@ -627,6 +774,8 @@ export default function CadWorkspace({
   });
   const stepArtifactGenerationRequestsRef = useRef(new Map());
   const selectedStepArtifactBuildKeyRef = useRef("");
+  const collisionRequestIdRef = useRef(0);
+  const collisionAbortControllerRef = useRef(null);
 
   const handlePersistenceWriteError = useCallback(({ key }) => {
     const failureKey = String(key || "browser-storage");
@@ -830,6 +979,7 @@ export default function CadWorkspace({
   const selectedEntryHasUrdf = entryHasUrdf(selectedEntry);
   const selectedEntryHasReferences = entryHasReferences(selectedEntry);
   const selectedEntryHasDisplayEdges = entryHasDisplayEdges(selectedEntry);
+  const selectedEntryCanRunCollisions = isStepView && fileAccessBackend === "local-fs";
   const selectedEntryHasDxf = entryHasDxf(selectedEntry);
   const selectedEntryHasGcode = entryHasGcode(selectedEntry);
   const selectedStepArtifactExternalGenerationActive = stepArtifactGenerationInProgress({
@@ -900,6 +1050,13 @@ export default function CadWorkspace({
     !!selectedEntry &&
     gcodeState.file === fileKey(selectedEntry) &&
     gcodeState.gcodeHash === entryAssetHash(selectedEntry, "gcode");
+  const selectedCollisionSettingsKey = collisionSettingsKey(stepAnalysisSettings);
+  const selectedCollisionMatches =
+    !!collisionReportState &&
+    !!selectedEntry &&
+    collisionReportState.fileRef === fileKey(selectedEntry) &&
+    collisionReportState.entryHash === entryMeshAssetSignature(selectedEntry) &&
+    collisionReportState.settingsKey === selectedCollisionSettingsKey;
   const selectedUrdfMatches =
     !!urdfState &&
     !!selectedEntry &&
@@ -909,6 +1066,134 @@ export default function CadWorkspace({
   const selectedUrdfMeshes = selectedUrdfMatches ? urdfState.meshesByUrl : null;
   const selectedDxfData = selectedDxfMatches ? dxfState.dxfData : null;
   const selectedGcodeData = selectedGcodeMatches ? gcodeState.gcodeData : null;
+  const selectedStepAnalysis = selectedCollisionMatches ? collisionReportState.viewerReport : null;
+  const selectedCollisionStatus = selectedCollisionMatches || collisionStatus === REFERENCE_STATUS.LOADING
+    ? collisionStatus
+    : REFERENCE_STATUS.IDLE;
+  const selectedCollisionError = selectedCollisionMatches || collisionStatus === REFERENCE_STATUS.ERROR
+    ? collisionError
+    : "";
+  const updateStepAnalysisSettings = useCallback((patch) => {
+    setStepAnalysisSettings((current) => normalizeStepAnalysisSettings({
+      ...current,
+      ...(patch && typeof patch === "object" ? patch : {})
+    }));
+  }, []);
+  const cancelCollisionRun = useCallback(() => {
+    collisionRequestIdRef.current += 1;
+    collisionAbortControllerRef.current?.abort();
+    collisionAbortControllerRef.current = null;
+    setCollisionLoadStage("");
+  }, []);
+  const runCollisionsForEntry = useCallback(async (entry = selectedEntry) => {
+    const targetFileRef = fileKey(entry);
+    if (!targetFileRef) {
+      return;
+    }
+    cancelCollisionRun();
+    const requestId = collisionRequestIdRef.current;
+    const controller = new AbortController();
+    collisionAbortControllerRef.current = controller;
+    const settings = normalizeStepAnalysisSettings(stepAnalysisSettings);
+    const settingsKey = collisionSettingsKey(settings);
+    const params = new URLSearchParams({
+      file: targetFileRef,
+      bodyDepth: String(settings.bodyDepth),
+      maxPairs: String(settings.maxPairs),
+      clearanceMm: String(settings.clearanceMm),
+      contactToleranceMm: String(settings.contactToleranceMm),
+      collisionVolumeToleranceMm3: String(settings.collisionVolumeToleranceMm3),
+      includeContact: settings.includeContact ? "1" : "0",
+      includeClearance: settings.includeClearance ? "1" : "0",
+      includeSeparated: settings.includeSeparated ? "1" : "0",
+      includeAllowed: settings.includeAllowed ? "1" : "0",
+      listBodies: settings.listBodies ? "1" : "0",
+      noCache: settings.noCache ? "1" : "0"
+    });
+    if (settings.timeBudgetMs > 0) {
+      params.set("timeBudgetMs", String(settings.timeBudgetMs));
+    }
+    for (const value of settings.collapse) {
+      params.append("collapse", value);
+    }
+    for (const value of settings.exclude) {
+      params.append("exclude", value);
+    }
+    for (const value of settings.setA) {
+      params.append("setA", value);
+    }
+    for (const value of settings.setB) {
+      params.append("setB", value);
+    }
+    for (const value of settings.pairs) {
+      params.append("pair", value);
+    }
+    for (const value of settings.allowPairs) {
+      params.append("allowPair", value);
+    }
+    setCollisionStatus(REFERENCE_STATUS.LOADING);
+    setCollisionError("");
+    setCollisionLoadStage("running collisions");
+    try {
+      const response = await fetch(`/__cad/collisions?${params.toString()}`, {
+        method: "POST",
+        signal: controller.signal
+      });
+      const payload = await response.json().catch(() => null);
+      if (!response.ok || !payload?.ok) {
+        const fallback = payload?.error || "Collision detection failed.";
+        throw new Error(payload?.error || await readResponseError(response, fallback));
+      }
+      const report = payload.result;
+      const viewerReport = normalizeCollisionReportForViewer(report);
+      if (!viewerReport) {
+        throw new Error("Collision detection returned an unrecognized report.");
+      }
+      if (requestId !== collisionRequestIdRef.current) {
+        return;
+      }
+      setCollisionReportState({
+        fileRef: targetFileRef,
+        entryHash: entryMeshAssetSignature(entry),
+        settingsKey,
+        report,
+        viewerReport
+      });
+      setCollisionStatus(REFERENCE_STATUS.READY);
+      setCollisionError("");
+    } catch (err) {
+      if (requestId !== collisionRequestIdRef.current || controller.signal.aborted) {
+        return;
+      }
+      setCollisionStatus(REFERENCE_STATUS.ERROR);
+      setCollisionError(err instanceof Error ? err.message : String(err));
+      setCollisionReportState(null);
+    } finally {
+      if (collisionAbortControllerRef.current === controller) {
+        collisionAbortControllerRef.current = null;
+      }
+      if (requestId === collisionRequestIdRef.current) {
+        setCollisionLoadStage("");
+      }
+    }
+  }, [cancelCollisionRun, selectedEntry, stepAnalysisSettings]);
+  const handleStepDisplayModeChange = useCallback((nextMode) => {
+    const mode = normalizeDisplayMode(nextMode);
+    updateDisplaySettings((current) => ({
+      ...normalizeDisplaySettings(current),
+      mode
+    }));
+    setStepAnalysisSettings((current) => normalizeStepAnalysisSettings({
+      ...current,
+      enabled: mode === CAD_DISPLAY_MODE.COLLISION,
+      showSurfaceReview: mode === CAD_DISPLAY_MODE.COLLISION
+        ? true
+        : current?.showSurfaceReview
+    }));
+  }, [updateDisplaySettings]);
+  useEffect(() => () => {
+    cancelCollisionRun();
+  }, [cancelCollisionRun]);
   const selectedDxfFileRef = selectedEntrySourceFormat === RENDER_FORMAT.DXF
     ? fileKey(selectedEntry)
     : "";
@@ -2664,6 +2949,9 @@ export default function CadWorkspace({
           parameterValues: snapshotStepModuleParameterValues,
           animationState: snapshotStepModuleAnimationState
         },
+        ...(entrySourceFormat(targetEntry) === RENDER_FORMAT.STEP
+          ? { collisions: stepAnalysisSettings }
+          : {}),
         urdf: {
           jointValues: targetUrdfJointValues,
           motionState: targetUrdfMotionState
@@ -2681,6 +2969,7 @@ export default function CadWorkspace({
     jointValuesByFileRef,
     largeFileState,
     selectedEntry,
+    stepAnalysisSettings,
     stepModuleAnimationState,
     stepModuleEnabled,
     stepModuleParameterValues,
@@ -2746,6 +3035,11 @@ export default function CadWorkspace({
       entrySourceFormat(entry) === RENDER_FORMAT.STEP
         ? normalizeDisplaySettings(sessionState?.slices?.display)
         : normalizeDisplaySettings()
+    );
+    setStepAnalysisSettings(
+      entrySourceFormat(entry) === RENDER_FORMAT.STEP
+        ? normalizeStepAnalysisSettings(sessionState?.slices?.collisions)
+        : normalizeStepAnalysisSettings(DEFAULT_STEP_ANALYSIS_SETTINGS)
     );
 
     const dxfSlice = sessionState?.slices?.dxf || null;
@@ -3689,7 +3983,7 @@ export default function CadWorkspace({
   const selectedStepDisplayEdgesRequested =
     effectiveRenderFormat === RENDER_FORMAT.STEP &&
     selectedEntryHasDisplayEdges &&
-    displaySettings.mode !== "wireframe" &&
+    displaySettings.mode !== CAD_DISPLAY_MODE.WIREFRAME &&
     resolvedDisplayEdgeSettings.enabled !== false;
   const selectedTopologyExplicitlyEnabled = largeFileState.selectableTopologyEnabled === true;
   const selectedTopologyLargeByCost = Boolean(
@@ -6009,14 +6303,6 @@ export default function CadWorkspace({
     null;
   const themeSections = (
     <>
-      {isStepView ? (
-        <DisplaySettingsSection
-          displaySettings={displaySettings}
-          updateDisplaySettings={updateDisplaySettings}
-          clipBounds={selectedMeshData?.bounds || null}
-          showClip
-        />
-      ) : null}
       <ThemeSettingsSections
         themePresets={availableThemePresets}
         themeSettings={themeSettings}
@@ -6049,6 +6335,11 @@ export default function CadWorkspace({
           renderPartsIndividually={isUrdfView || Boolean(selectedStepParameterRuntime)}
           stepParameters={selectedStepParameterRuntime}
           selectedMeshData={selectedMeshData}
+          stepAnalysis={selectedStepAnalysis}
+          stepAnalysisSettings={stepAnalysisSettings}
+          stepAnalysisStatus={selectedCollisionStatus}
+          stepAnalysisError={selectedCollisionError}
+          stepAnalysisLoadStage={collisionLoadStage}
           selectedDxfData={selectedDxfData}
           selectedDxfMeshData={selectedDxfMeshData}
           selectedKey={selectedKey}
@@ -6349,6 +6640,50 @@ export default function CadWorkspace({
                   onEnabledChange: handleStepModuleEnabledChange,
                   onCopyParams: handleCopyStepModuleParams,
                   onPasteParams: handlePasteStepModuleParams
+                }}
+                display={{
+                  settings: displaySettings,
+                  updateSettings: updateDisplaySettings,
+                  onModeChange: handleStepDisplayModeChange,
+                  clipBounds: selectedMeshData?.bounds || null
+                }}
+                collisions={{
+                  available: Boolean(selectedStepAnalysis),
+                  canRun: selectedEntryCanRunCollisions,
+                  status: selectedCollisionStatus,
+                  error: selectedCollisionError,
+                  loadStage: collisionLoadStage,
+                  summary: selectedStepAnalysis?.summary || null,
+                  occurrences: Array.isArray(selectedStepAnalysis?.occurrences) ? selectedStepAnalysis.occurrences : [],
+                  pairs: Array.isArray(selectedStepAnalysis?.pairs) ? selectedStepAnalysis.pairs : [],
+                  settings: stepAnalysisSettings,
+                  enabled: stepAnalysisSettings.enabled,
+                  selectedPairId: stepAnalysisSettings.selectedPairId,
+                  showSurfaceReview: stepAnalysisSettings.showSurfaceReview,
+                  showSurfaceHighlights: stepAnalysisSettings.showSurfaceHighlights,
+                  showWitnesses: stepAnalysisSettings.showWitnesses,
+                  showInterferenceVolumes: stepAnalysisSettings.showInterferenceVolumes,
+                  showBounds: stepAnalysisSettings.showBounds,
+                  showCollisions: stepAnalysisSettings.showCollisions,
+                  showContacts: stepAnalysisSettings.showContacts,
+                  showClearances: stepAnalysisSettings.showClearances,
+                  onRun: () => {
+                    void runCollisionsForEntry(selectedEntry);
+                  },
+                  onSettingsChange: updateStepAnalysisSettings,
+                  onEnabledChange: (checked) => updateStepAnalysisSettings({ enabled: checked === true }),
+                  onSelectedPairChange: (pairId) => updateStepAnalysisSettings({
+                    selectedPairId: String(pairId || "").trim(),
+                    enabled: true
+                  }),
+                  onShowSurfaceReviewChange: (checked) => updateStepAnalysisSettings({ showSurfaceReview: checked === true }),
+                  onShowSurfaceHighlightsChange: (checked) => updateStepAnalysisSettings({ showSurfaceHighlights: checked === true }),
+                  onShowWitnessesChange: (checked) => updateStepAnalysisSettings({ showWitnesses: checked === true }),
+                  onShowInterferenceVolumesChange: (checked) => updateStepAnalysisSettings({ showInterferenceVolumes: checked === true }),
+                  onShowBoundsChange: (checked) => updateStepAnalysisSettings({ showBounds: checked === true }),
+                  onShowCollisionsChange: (checked) => updateStepAnalysisSettings({ showCollisions: checked === true }),
+                  onShowContactsChange: (checked) => updateStepAnalysisSettings({ showContacts: checked === true }),
+                  onShowClearancesChange: (checked) => updateStepAnalysisSettings({ showClearances: checked === true })
                 }}
                 fileDownloadAvailable={fileLinkCopyAvailable}
                 viewerServerInfo={viewerServerInfo}

--- a/viewer/src/client/components/workbench/CadRenderPane.js
+++ b/viewer/src/client/components/workbench/CadRenderPane.js
@@ -41,11 +41,34 @@ function viewportIssueMetaForAlert(alert) {
     : VIEWPORT_ISSUE_META.error;
 }
 
+function analysisSummaryText(analysis) {
+  const summary = analysis?.summary && typeof analysis.summary === "object" ? analysis.summary : {};
+  const collisionCount = Math.max(Number(summary.collisionCount) || 0, 0);
+  const contactCount = Math.max(Number(summary.contactCount) || 0, 0);
+  const clearanceCount = Math.max(Number(summary.clearanceCount) || 0, 0);
+  const chunks = [];
+  if (collisionCount) {
+    chunks.push(`${collisionCount} collision${collisionCount === 1 ? "" : "s"}`);
+  }
+  if (contactCount) {
+    chunks.push(`${contactCount} contact${contactCount === 1 ? "" : "s"}`);
+  }
+  if (clearanceCount) {
+    chunks.push(`${clearanceCount} clearance${clearanceCount === 1 ? "" : "s"}`);
+  }
+  return chunks.length ? chunks.join(" · ") : "No close pairs";
+}
+
 export default function CadRenderPane({
   viewerRef,
   renderFormat,
   renderPartsIndividually = false,
   selectedMeshData,
+  stepAnalysis = null,
+  stepAnalysisSettings = null,
+  stepAnalysisStatus = "",
+  stepAnalysisError = "",
+  stepAnalysisLoadStage = "",
   selectedDxfData,
   selectedDxfMeshData,
   selectedKey,
@@ -125,6 +148,16 @@ export default function CadRenderPane({
   const topologySelectionPending = Boolean(referenceSelectionPending && !dxfMode && !urdfMode && !pathPreviewMode);
   const topologySelectionUnavailable = Boolean(referenceSelectionUnavailable && !dxfMode && !urdfMode && !pathPreviewMode);
   const topologySelectionDeferred = Boolean(referenceSelectionDeferred && activeMeshData && !dxfMode && !urdfMode && !pathPreviewMode);
+  const stepAnalysisVisible = !dxfMode && !urdfMode && !pathPreviewMode && renderFormat === RENDER_FORMAT.STEP;
+  const stepAnalysisEnabled = stepAnalysisVisible && stepAnalysisSettings?.enabled === true;
+  const stepAnalysisReady = stepAnalysisEnabled && stepAnalysis && typeof stepAnalysis === "object";
+  const stepAnalysisBadgeLabel = stepAnalysisReady
+    ? analysisSummaryText(stepAnalysis)
+    : stepAnalysisEnabled && stepAnalysisStatus === "loading"
+      ? (stepAnalysisLoadStage || "Running collisions")
+      : stepAnalysisEnabled && stepAnalysisStatus === "error"
+        ? (stepAnalysisError || "Collisions unavailable")
+        : "";
   const urdfPosePickerActive = Boolean(urdfPosePicker?.active);
   const urdfPosePickerPrompt = "Select target";
   const posePickerExitStyle = {
@@ -236,6 +269,8 @@ export default function CadRenderPane({
           selectedReferenceIds={dxfMode || pathPreviewMode ? [] : selectedReferenceIds}
           selectorRuntime={dxfMode || pathPreviewMode ? null : selectorRuntime}
           displayEdgeRuntime={dxfMode || pathPreviewMode ? null : displayEdgeRuntime}
+          stepAnalysis={dxfMode || pathPreviewMode || !stepAnalysisEnabled ? null : stepAnalysis}
+          stepAnalysisSettings={dxfMode || pathPreviewMode || !stepAnalysisEnabled ? null : stepAnalysisSettings}
           stepParameters={dxfMode || pathPreviewMode ? null : resolvedStepParameters}
           pickableFaces={dxfMode || pathPreviewMode ? [] : pickableFaces}
           pickableEdges={dxfMode || pathPreviewMode ? [] : pickableEdges}
@@ -324,6 +359,22 @@ export default function CadRenderPane({
             className="cad-glass-popover w-auto px-3 py-1.5 text-[11px] font-medium text-popover-foreground shadow-sm"
           >
             STEP changed. Updating/regenerating references...
+          </Alert>
+        </div>
+      ) : null}
+      {!previewMode && stepAnalysisBadgeLabel ? (
+        <div
+          className="pointer-events-none absolute z-20 flex items-start justify-start px-3 py-3 sm:px-4"
+          style={modelViewportOverlayStyle}
+        >
+          <Alert
+            role="status"
+            className={cn(
+              "cad-glass-popover w-auto max-w-[min(22rem,100%)] px-3 py-1.5 text-[11px] font-medium text-popover-foreground shadow-sm",
+              stepAnalysisStatus === "error" ? "border-destructive/45 text-destructive dark:text-red-300" : ""
+            )}
+          >
+            Collisions: {stepAnalysisBadgeLabel}
           </Alert>
         </div>
       ) : null}

--- a/viewer/src/client/components/workbench/StepFileSheet.js
+++ b/viewer/src/client/components/workbench/StepFileSheet.js
@@ -13,6 +13,10 @@ import {
 import { Button } from "../ui/button";
 import { ColorPicker } from "../ui/color-picker";
 import {
+  CAD_DISPLAY_MODE,
+  normalizeDisplaySettings
+} from "cadjs/lib/displaySettings";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -24,6 +28,7 @@ import FileSheet, {
   FILE_SHEET_COMPACT_BUTTON_CLASSES,
   FILE_SHEET_COMPACT_INPUT_CLASSES,
   FILE_SHEET_PRECISION_SLIDER_CLASSES,
+  FileSheetBooleanToggle,
   FileSheetControlRow,
   FileSheetSection,
   FileSheetSectionBody,
@@ -34,16 +39,69 @@ import FileSheet, {
 } from "./FileSheet";
 import FileMetadataSection from "./FileMetadataSection";
 import FileStatusSection from "./FileStatusSection";
+import {
+  ClipSettingsControls,
+  DisplaySettingsControls
+} from "./ThemeSettingsPopover";
 
 const compactButtonClasses = FILE_SHEET_COMPACT_BUTTON_CLASSES;
 const compactInputClasses = FILE_SHEET_COMPACT_INPUT_CLASSES;
 const compactIconButtonClasses = "size-6 text-muted-foreground hover:text-foreground";
 const treeRowButtonClasses = "h-7 min-w-0 rounded-md px-1.5 text-xs font-normal text-sidebar-foreground shadow-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground";
 const treeSectionId = "tree";
+const displaySectionId = "display";
+const collisionsSectionId = "collisions";
 const treeRevealScrollPaddingTopPx = 120;
 export const STEP_TREE_ROOT_ITEM_LIMIT = 15;
 const STEP_MODULE_ANIMATION_SPEED_MIN = 0.1;
 const STEP_MODULE_ANIMATION_SPEED_MAX = 3;
+const STEP_ANALYSIS_PAIR_STATUS_RANK = Object.freeze({
+  collision: 0,
+  contact: 1,
+  clearance: 2,
+  separated: 3
+});
+const STEP_ANALYSIS_STATUS_STYLES = Object.freeze({
+  collision: "border-red-400/55 bg-red-500/14 text-red-200",
+  contact: "border-emerald-400/50 bg-emerald-500/14 text-emerald-200",
+  clearance: "border-cyan-400/45 bg-cyan-500/12 text-cyan-100",
+  separated: "border-slate-400/40 bg-slate-500/12 text-slate-200"
+});
+const STEP_ANALYSIS_TOOL_LABELS = Object.freeze({
+  surfaces: "Surfaces",
+  witnesses: "Witnesses",
+  volumes: "Volumes",
+  bounds: "Bounds",
+  collisions: "Collisions",
+  contacts: "Contacts",
+  clearances: "Clearances"
+});
+const STEP_DISPLAY_MODE_OPTIONS = Object.freeze([
+  { value: CAD_DISPLAY_MODE.SOLID, label: "Solid" },
+  { value: CAD_DISPLAY_MODE.TRANSPARENT, label: "Transparent" },
+  { value: CAD_DISPLAY_MODE.COLLISION, label: "Collision" },
+  { value: CAD_DISPLAY_MODE.WIREFRAME, label: "Wire" }
+]);
+const DEFAULT_COLLISION_RUN_SETTINGS = Object.freeze({
+  bodyDepth: 2,
+  maxPairs: 1000,
+  clearanceMm: 0,
+  contactToleranceMm: 0.0001,
+  collisionVolumeToleranceMm3: 0.000000001,
+  timeBudgetMs: 0,
+  includeContact: true,
+  includeClearance: false,
+  includeSeparated: false,
+  includeAllowed: false,
+  listBodies: false,
+  noCache: false,
+  setA: [],
+  setB: [],
+  pairs: [],
+  allowPairs: [],
+  exclude: [],
+  collapse: []
+});
 
 function formatControlNumber(value) {
   const numericValue = Number(value);
@@ -70,6 +128,197 @@ function parseAnimationSpeedInput(value, fallbackValue = 1) {
     min: STEP_MODULE_ANIMATION_SPEED_MIN,
     max: STEP_MODULE_ANIMATION_SPEED_MAX
   });
+}
+
+function parseCollisionIntegerInput(value, fallbackValue, { min = 1, max = 100000 } = {}) {
+  const parsedValue = Number.parseInt(String(value ?? ""), 10);
+  const numericValue = Number.isFinite(parsedValue) ? parsedValue : fallbackValue;
+  return Math.min(Math.max(Math.round(Number(numericValue) || fallbackValue), min), max);
+}
+
+function parseCollisionNumberInput(value, fallbackValue, { min = 0, max = Number.MAX_SAFE_INTEGER } = {}) {
+  const parsedValue = Number(value);
+  const numericValue = Number.isFinite(parsedValue) ? parsedValue : fallbackValue;
+  return Math.min(Math.max(numericValue, min), max);
+}
+
+function collisionStringListValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item || "").trim()).filter(Boolean).join(", ");
+  }
+  return String(value || "").trim();
+}
+
+function parseCollisionStringListInput(value) {
+  return String(value || "")
+    .split(/[\n,]+/u)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function formatAnalysisCount(value) {
+  const count = Math.max(Math.round(Number(value) || 0), 0);
+  return count.toLocaleString();
+}
+
+function formatAnalysisNumber(value) {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) {
+    return "";
+  }
+  const absoluteValue = Math.abs(numericValue);
+  const fixedValue = absoluteValue >= 1000
+    ? numericValue.toFixed(0)
+    : absoluteValue >= 100
+      ? numericValue.toFixed(1)
+      : absoluteValue >= 1
+        ? numericValue.toFixed(2)
+        : numericValue.toFixed(3);
+  return fixedValue.replace(/\.?0+$/, "");
+}
+
+function formatAnalysisMeasurement(value, unit) {
+  const formattedValue = formatAnalysisNumber(value);
+  return formattedValue ? `${formattedValue} ${unit}` : "";
+}
+
+function normalizeAnalysisPairStatus(status) {
+  const normalizedStatus = String(status || "").trim().toLowerCase();
+  return Object.prototype.hasOwnProperty.call(STEP_ANALYSIS_PAIR_STATUS_RANK, normalizedStatus)
+    ? normalizedStatus
+    : "separated";
+}
+
+function analysisPairSortRank(status) {
+  const normalizedStatus = normalizeAnalysisPairStatus(status);
+  return STEP_ANALYSIS_PAIR_STATUS_RANK[normalizedStatus] ?? STEP_ANALYSIS_PAIR_STATUS_RANK.separated;
+}
+
+function analysisStatusLabel(status) {
+  const normalizedStatus = normalizeAnalysisPairStatus(status);
+  return normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);
+}
+
+function analysisOccurrenceName(value) {
+  const normalizedValue = String(value || "").trim();
+  if (!normalizedValue) {
+    return "";
+  }
+  return normalizedValue.startsWith("component:")
+    ? normalizedValue.slice("component:".length)
+    : normalizedValue;
+}
+
+function analysisPairMetric(pair, status) {
+  if (status === "collision") {
+    return {
+      label: "Intersection volume",
+      value: formatAnalysisMeasurement(pair?.intersectionVolumeMm3, "mm3")
+    };
+  }
+  return {
+    label: "Minimum distance",
+    value: formatAnalysisMeasurement(pair?.minDistanceMm ?? pair?.distanceMm, "mm")
+  };
+}
+
+function analysisStatusStyle(status) {
+  return STEP_ANALYSIS_STATUS_STYLES[normalizeAnalysisPairStatus(status)] || STEP_ANALYSIS_STATUS_STYLES.separated;
+}
+
+function AnalysisCountPill({ label, value, status }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex min-w-0 items-center justify-between gap-1.5 rounded-md border px-1.5 py-1 text-[10px] leading-none",
+        analysisStatusStyle(status)
+      )}
+      title={`${label}: ${value}`}
+    >
+      <span className="truncate">{label}</span>
+      <span className="font-mono font-semibold tabular-nums">{value}</span>
+    </span>
+  );
+}
+
+function CompactAnalysisToggle({ label, checked, onCheckedChange, disabled = false, ariaLabel }) {
+  return (
+    <label
+      className={cn(
+        "flex h-7 min-w-0 items-center justify-between gap-2 rounded-md border border-border/55 bg-sidebar-accent/20 px-2 text-[11px] text-sidebar-foreground/80",
+        disabled && "opacity-55"
+      )}
+      title={label}
+    >
+      <span className="min-w-0 truncate">{label}</span>
+      <FileSheetBooleanToggle
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        disabled={disabled}
+        ariaLabel={ariaLabel || label}
+      />
+    </label>
+  );
+}
+
+function CollisionNumberField({
+  label,
+  value,
+  min,
+  max,
+  step,
+  disabled,
+  onChange,
+  ariaLabel,
+  title
+}) {
+  return (
+    <label
+      className="min-w-0 space-y-1 text-[10px] font-medium uppercase tracking-wide text-[var(--ui-text-muted)]"
+      title={title || label}
+    >
+      <span>{label}</span>
+      <input
+        className={cn(compactInputClasses, "w-full font-mono tabular-nums")}
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange?.(event.target.value)}
+        aria-label={ariaLabel || label}
+      />
+    </label>
+  );
+}
+
+function CollisionTextField({
+  label,
+  value,
+  disabled,
+  onChange,
+  ariaLabel,
+  title
+}) {
+  return (
+    <label
+      className="min-w-0 space-y-1 text-[10px] font-medium uppercase tracking-wide text-[var(--ui-text-muted)]"
+      title={title || label}
+    >
+      <span>{label}</span>
+      <textarea
+        className={cn(
+          "min-h-12 w-full resize-y rounded-md border border-input bg-transparent px-2 py-1 text-[11px] font-mono leading-4 tabular-nums text-foreground shadow-xs outline-none transition-[color,box-shadow,border-color] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-50 dark:bg-input/30"
+        )}
+        rows={2}
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange?.(event.target.value)}
+        aria-label={ariaLabel || label}
+      />
+    </label>
+  );
 }
 
 function leafIdsHidden(leafPartIds, hiddenPartIds) {
@@ -183,6 +432,8 @@ export default function StepFileSheet({
   hideSelectedParts,
   showAllHiddenParts,
   stepModule = null,
+  collisions = null,
+  display = null,
   fileDownloadAvailable = false,
   viewerServerInfo = null,
   localFileOpenAvailable = false,
@@ -240,6 +491,122 @@ export default function StepFileSheet({
   const stepModuleAnimationState = stepModule?.animationState || {};
   const stepModuleAnimationDuration = Math.max(Number(stepModuleAnimationState.duration) || 1, 0.001);
   const stepModuleEnabled = stepModule?.enabled !== false;
+  const displaySettings = useMemo(
+    () => normalizeDisplaySettings(display?.settings),
+    [display?.settings]
+  );
+  const displayMode = displaySettings.mode;
+  const displayModeIsCollision = displayMode === CAD_DISPLAY_MODE.COLLISION;
+  const collisionReportAvailable = collisions?.available === true;
+  const collisionCanRun = collisions?.canRun === true;
+  const displayModeOptions = useMemo(
+    () => STEP_DISPLAY_MODE_OPTIONS.map((option) => (
+      option.value === CAD_DISPLAY_MODE.COLLISION && !collisionReportAvailable
+        ? {
+            ...option,
+            disabled: true,
+            title: collisionCanRun ? "Run collisions first" : "Collision generation unavailable"
+          }
+        : option
+    )),
+    [collisionCanRun, collisionReportAvailable]
+  );
+  const collisionStatus = String(collisions?.status || "").trim();
+  const collisionRunning = collisionStatus === "loading";
+  const collisionError = String(collisions?.error || "").trim();
+  const collisionSettings = collisions?.settings && typeof collisions.settings === "object" ? collisions.settings : {};
+  const collisionBodyDepth = parseCollisionIntegerInput(collisionSettings.bodyDepth, 2, { min: 1, max: 12 });
+  const collisionMaxPairs = parseCollisionIntegerInput(collisionSettings.maxPairs, 1000, { min: 1, max: 100000 });
+  const collisionClearanceMm = parseCollisionNumberInput(collisionSettings.clearanceMm, 0, { min: 0, max: 100000 });
+  const collisionContactToleranceMm = parseCollisionNumberInput(collisionSettings.contactToleranceMm, 0.0001, { min: 0, max: 1000 });
+  const collisionVolumeToleranceMm3 = parseCollisionNumberInput(
+    collisionSettings.collisionVolumeToleranceMm3,
+    0.000000001,
+    { min: 0, max: 1000000000 }
+  );
+  const collisionTimeBudgetMs = parseCollisionNumberInput(collisionSettings.timeBudgetMs, 0, { min: 0, max: 3600000 });
+  const collisionIncludeContact = collisionSettings.includeContact !== false;
+  const collisionIncludeClearance = collisionSettings.includeClearance === true;
+  const collisionIncludeSeparated = collisionSettings.includeSeparated === true;
+  const collisionIncludeAllowed = collisionSettings.includeAllowed === true;
+  const collisionListBodies = collisionSettings.listBodies === true;
+  const collisionNoCache = collisionSettings.noCache === true;
+  const collisionSetA = collisionStringListValue(collisionSettings.setA);
+  const collisionSetB = collisionStringListValue(collisionSettings.setB);
+  const collisionPairsFilter = collisionStringListValue(collisionSettings.pairs);
+  const collisionAllowPairs = collisionStringListValue(collisionSettings.allowPairs);
+  const collisionExclude = collisionStringListValue(collisionSettings.exclude);
+  const collisionCollapse = collisionStringListValue(collisionSettings.collapse);
+  const collisionSummary = collisions?.summary && typeof collisions.summary === "object" ? collisions.summary : {};
+  const collisionOccurrenceCount = formatAnalysisCount(collisionSummary.occurrenceCount);
+  const collisionPairCount = formatAnalysisCount(collisionSummary.reportedPairCount ?? collisionSummary.analyzedPairCount);
+  const collisionCollisionCount = formatAnalysisCount(collisionSummary.collisionCount);
+  const collisionContactCount = formatAnalysisCount(collisionSummary.contactCount);
+  const collisionClearanceCount = formatAnalysisCount(collisionSummary.clearanceCount);
+  const collisionPairs = useMemo(() => {
+    const occurrenceNameById = new Map(
+      (Array.isArray(collisions?.occurrences) ? collisions.occurrences : [])
+        .map((occurrence) => {
+          const id = String(occurrence?.id || "").trim();
+          const name = analysisOccurrenceName(occurrence?.name) || id;
+          return [id, name];
+        })
+        .filter(([id]) => id)
+    );
+    return (Array.isArray(collisions?.pairs) ? collisions.pairs : [])
+      .map((pair) => {
+        const aId = String(pair?.a || "").trim();
+        const bId = String(pair?.b || "").trim();
+        const id = String(pair?.id || (aId && bId ? `${aId}:${bId}` : "")).trim();
+        if (!id) {
+          return null;
+        }
+        const status = normalizeAnalysisPairStatus(pair?.status);
+        const statusLabel = analysisStatusLabel(status);
+        const aName = occurrenceNameById.get(aId) || aId || "A";
+        const bName = occurrenceNameById.get(bId) || bId || "B";
+        const metric = analysisPairMetric(pair, status);
+        return {
+          id,
+          status,
+          statusLabel,
+          aName,
+          bName,
+          label: `${statusLabel}: ${aName} / ${bName}`,
+          metricLabel: metric.label,
+          metricValue: metric.value
+        };
+      })
+      .filter(Boolean)
+      .sort((left, right) => (
+        analysisPairSortRank(left.status) - analysisPairSortRank(right.status)
+        || left.label.localeCompare(right.label)
+      ));
+  }, [collisions?.occurrences, collisions?.pairs]);
+  const selectedCollisionPairId = String(collisions?.selectedPairId || "").trim();
+  const collisionControlsDisabled = collisionRunning || collisionStatus === "error";
+  const updateCollisionSetting = (patch) => {
+    collisions?.onSettingsChange?.(patch);
+  };
+  const focusCollisionPair = (pairId = "") => {
+    if (!collisionReportAvailable) {
+      return;
+    }
+    display?.onModeChange?.(CAD_DISPLAY_MODE.COLLISION);
+    collisions?.onSelectedPairChange?.(pairId);
+  };
+  const handleDisplayModeChange = (nextMode) => {
+    if (nextMode === CAD_DISPLAY_MODE.COLLISION && !collisionReportAvailable) {
+      return;
+    }
+    display?.onModeChange?.(nextMode);
+  };
+
+  useEffect(() => {
+    if (displayModeIsCollision && !collisionReportAvailable) {
+      display?.onModeChange?.(CAD_DISPLAY_MODE.TRANSPARENT);
+    }
+  }, [collisionReportAvailable, display, displayModeIsCollision]);
 
   useEffect(() => {
     if (!activeTreeNodeId || !treeSectionOpen) {
@@ -780,6 +1147,399 @@ export default function StepFileSheet({
               </FileSheetSectionBody>
           </FileSheetSection>
         ) : null}
+
+        <FileSheetSection value={displaySectionId} title="Display">
+          <FileSheetSectionBody className="py-2">
+            <DisplaySettingsControls
+              displaySettings={displaySettings}
+              updateDisplaySettings={display?.updateSettings}
+              onDisplayModeChange={handleDisplayModeChange}
+              modeOptions={displayModeOptions}
+            />
+            <FileSheetSubsection title="Clip" contentClassName="px-3">
+              <ClipSettingsControls
+                displaySettings={displaySettings}
+                updateDisplaySettings={display?.updateSettings}
+                clipBounds={display?.clipBounds || null}
+              />
+            </FileSheetSubsection>
+          </FileSheetSectionBody>
+        </FileSheetSection>
+
+        <FileSheetSection value={collisionsSectionId} title="Collisions">
+          <FileSheetSectionBody className="py-2">
+            <div className="space-y-2 px-3">
+              <div className="flex flex-wrap items-center gap-1.5">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className={compactButtonClasses}
+                  onClick={() => collisions?.onRun?.()}
+                  disabled={!collisionCanRun || collisionRunning}
+                  title={collisionCanRun ? "Run collision detection" : "Collision generation is unavailable"}
+                >
+                  <Play className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+                  <span>{collisionRunning ? "Running" : collisionReportAvailable ? "Run again" : "Run"}</span>
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className={compactButtonClasses}
+                  onClick={() => collisions?.onSettingsChange?.(DEFAULT_COLLISION_RUN_SETTINGS)}
+                  disabled={collisionRunning}
+                  title="Reset collision run parameters"
+                >
+                  <RotateCcw className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+                  <span>Defaults</span>
+                </Button>
+                <span className="min-w-0 flex-1 truncate text-[10px] leading-4 text-[var(--ui-text-muted)]">
+                  {collisionRunning ? (
+                    collisions?.loadStage || "Running collisions..."
+                  ) : collisionStatus === "error" ? (
+                    <span className="text-destructive">{collisionError || "Collisions unavailable."}</span>
+                  ) : collisionReportAvailable ? (
+                    `${collisionPairCount} pairs across ${collisionOccurrenceCount} bodies`
+                  ) : collisionCanRun ? (
+                    "No collision report"
+                  ) : (
+                    "Unavailable"
+                  )}
+                </span>
+              </div>
+            </div>
+
+            <FileSheetSubsection title="Run Parameters" contentClassName="px-3">
+              <div className="grid grid-cols-2 gap-2">
+                <CollisionNumberField
+                  label="Depth"
+                  min={1}
+                  max={12}
+                  step={1}
+                  value={collisionBodyDepth}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({
+                    bodyDepth: parseCollisionIntegerInput(value, collisionBodyDepth, { min: 1, max: 12 })
+                  })}
+                  ariaLabel="Collision body depth"
+                  title="Occurrence depth used to group bodies"
+                />
+                <CollisionNumberField
+                  label="Pairs"
+                  min={1}
+                  max={100000}
+                  step={1}
+                  value={collisionMaxPairs}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({
+                    maxPairs: parseCollisionIntegerInput(value, collisionMaxPairs, { min: 1, max: 100000 })
+                  })}
+                  ariaLabel="Collision pair limit"
+                  title="Maximum candidate pairs to solve"
+                />
+                <CollisionNumberField
+                  label="Clearance mm"
+                  min={0}
+                  max={100000}
+                  step={0.01}
+                  value={collisionClearanceMm}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({
+                    clearanceMm: parseCollisionNumberInput(value, collisionClearanceMm, { min: 0, max: 100000 })
+                  })}
+                  ariaLabel="Collision clearance distance in millimeters"
+                  title="Near-clearance distance in millimeters"
+                />
+                <CollisionNumberField
+                  label="Budget ms"
+                  min={0}
+                  max={3600000}
+                  step={100}
+                  value={collisionTimeBudgetMs}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({
+                    timeBudgetMs: parseCollisionNumberInput(value, collisionTimeBudgetMs, { min: 0, max: 3600000 })
+                  })}
+                  ariaLabel="Collision time budget in milliseconds"
+                  title="Maximum elapsed milliseconds before stopping new pair solves"
+                />
+                <CollisionNumberField
+                  label="Contact tol"
+                  min={0}
+                  max={1000}
+                  step={0.0001}
+                  value={collisionContactToleranceMm}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({
+                    contactToleranceMm: parseCollisionNumberInput(value, collisionContactToleranceMm, { min: 0, max: 1000 })
+                  })}
+                  ariaLabel="Collision contact tolerance in millimeters"
+                  title="Contact tolerance in millimeters"
+                />
+                <CollisionNumberField
+                  label="Volume tol"
+                  min={0}
+                  max={1000000000}
+                  step={0.000000001}
+                  value={collisionVolumeToleranceMm3}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({
+                    collisionVolumeToleranceMm3: parseCollisionNumberInput(value, collisionVolumeToleranceMm3, {
+                      min: 0,
+                      max: 1000000000
+                    })
+                  })}
+                  ariaLabel="Collision volume tolerance in cubic millimeters"
+                  title="Minimum common volume classified as collision"
+                />
+              </div>
+            </FileSheetSubsection>
+
+            <FileSheetSubsection title="Report" contentClassName="px-3">
+              <div className="grid grid-cols-2 gap-1.5">
+                <CompactAnalysisToggle
+                  label="Contacts"
+                  checked={collisionIncludeContact}
+                  onCheckedChange={(checked) => updateCollisionSetting({ includeContact: checked === true })}
+                  disabled={collisionRunning}
+                  ariaLabel="Report contact pairs"
+                />
+                <CompactAnalysisToggle
+                  label="Clearances"
+                  checked={collisionIncludeClearance}
+                  onCheckedChange={(checked) => updateCollisionSetting({ includeClearance: checked === true })}
+                  disabled={collisionRunning}
+                  ariaLabel="Report clearance pairs"
+                />
+                <CompactAnalysisToggle
+                  label="Separated"
+                  checked={collisionIncludeSeparated}
+                  onCheckedChange={(checked) => updateCollisionSetting({ includeSeparated: checked === true })}
+                  disabled={collisionRunning}
+                  ariaLabel="Report separated pairs"
+                />
+                <CompactAnalysisToggle
+                  label="Allowed"
+                  checked={collisionIncludeAllowed}
+                  onCheckedChange={(checked) => updateCollisionSetting({ includeAllowed: checked === true })}
+                  disabled={collisionRunning}
+                  ariaLabel="Report allowed pairs"
+                />
+                <CompactAnalysisToggle
+                  label="Bodies only"
+                  checked={collisionListBodies}
+                  onCheckedChange={(checked) => updateCollisionSetting({ listBodies: checked === true })}
+                  disabled={collisionRunning}
+                  ariaLabel="Only list collision bodies"
+                />
+                <CompactAnalysisToggle
+                  label="No cache"
+                  checked={collisionNoCache}
+                  onCheckedChange={(checked) => updateCollisionSetting({ noCache: checked === true })}
+                  disabled={collisionRunning}
+                  ariaLabel="Run collisions without cache"
+                />
+              </div>
+            </FileSheetSubsection>
+
+            <FileSheetSubsection title="Selectors" contentClassName="px-3">
+              <div className="grid grid-cols-2 gap-2">
+                <CollisionTextField
+                  label="Set A"
+                  value={collisionSetA}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({ setA: parseCollisionStringListInput(value) })}
+                  ariaLabel="Collision set A selectors"
+                  title="Body selector or name patterns for set A"
+                />
+                <CollisionTextField
+                  label="Set B"
+                  value={collisionSetB}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({ setB: parseCollisionStringListInput(value) })}
+                  ariaLabel="Collision set B selectors"
+                  title="Body selector or name patterns for set B"
+                />
+                <CollisionTextField
+                  label="Pairs"
+                  value={collisionPairsFilter}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({ pairs: parseCollisionStringListInput(value) })}
+                  ariaLabel="Explicit collision pair selectors"
+                  title="Explicit left:right pair selectors"
+                />
+                <CollisionTextField
+                  label="Allow"
+                  value={collisionAllowPairs}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({ allowPairs: parseCollisionStringListInput(value) })}
+                  ariaLabel="Allowed collision pair selectors"
+                  title="left:right pair selectors treated as allowed"
+                />
+                <CollisionTextField
+                  label="Exclude"
+                  value={collisionExclude}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({ exclude: parseCollisionStringListInput(value) })}
+                  ariaLabel="Excluded collision selectors"
+                  title="Body selector or name patterns to omit"
+                />
+                <CollisionTextField
+                  label="Collapse"
+                  value={collisionCollapse}
+                  disabled={collisionRunning}
+                  onChange={(value) => updateCollisionSetting({ collapse: parseCollisionStringListInput(value) })}
+                  ariaLabel="Collapsed collision selectors"
+                  title="Occurrence selector or name patterns to collapse into one body"
+                />
+              </div>
+            </FileSheetSubsection>
+
+            {collisionReportAvailable ? (
+              <div className="grid grid-cols-3 gap-1 px-3">
+                <AnalysisCountPill label="Collisions" value={collisionCollisionCount} status="collision" />
+                <AnalysisCountPill label="Contacts" value={collisionContactCount} status="contact" />
+                <AnalysisCountPill label="Clearances" value={collisionClearanceCount} status="clearance" />
+              </div>
+            ) : null}
+
+            {collisionReportAvailable ? (
+              <FileSheetSubsection title="Pairs" contentClassName="px-1.5">
+                {collisionRunning ? (
+                  <p className="px-1.5 py-1 text-xs text-[var(--ui-text-muted)]">Running collisions...</p>
+                ) : collisionStatus === "error" ? (
+                  <p className="whitespace-pre-line px-1.5 py-1 text-xs text-destructive">{collisionError || "Collisions unavailable."}</p>
+                ) : (
+                  <div className="space-y-px" role="list" aria-label="Collision pairs">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className={cn(
+                        treeRowButtonClasses,
+                        "h-8 w-full justify-start gap-2 px-2 text-left",
+                        displayModeIsCollision && !selectedCollisionPairId && "bg-sidebar-accent text-sidebar-accent-foreground"
+                      )}
+                      onClick={() => focusCollisionPair("")}
+                      disabled={collisionControlsDisabled || !collisionPairs.length}
+                      aria-pressed={displayModeIsCollision && !selectedCollisionPairId}
+                      title="Show all collision pairs"
+                    >
+                      <span className="min-w-0 flex-1 truncate">All pairs</span>
+                      <span className="font-mono text-[10px] text-[var(--ui-text-muted)]">{collisionPairCount}</span>
+                    </Button>
+                    {collisionPairs.map((pair) => {
+                      const selected = displayModeIsCollision && selectedCollisionPairId === pair.id;
+                      return (
+                        <Button
+                          key={pair.id}
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className={cn(
+                            treeRowButtonClasses,
+                            "h-10 w-full justify-start gap-2 px-2 text-left",
+                            selected && "bg-sidebar-accent text-sidebar-accent-foreground"
+                          )}
+                          onClick={() => focusCollisionPair(pair.id)}
+                          disabled={collisionControlsDisabled}
+                          aria-pressed={selected}
+                          title={pair.label}
+                        >
+                          <span
+                            className={cn(
+                              "h-2 w-2 shrink-0 rounded-full border",
+                              analysisStatusStyle(pair.status)
+                            )}
+                            aria-hidden="true"
+                          />
+                          <span className="min-w-0 flex-1 overflow-hidden">
+                            <span className="block truncate text-[11px] font-medium leading-4">
+                              {pair.aName} / {pair.bName}
+                            </span>
+                            <span className="block truncate text-[10px] leading-3 text-[var(--ui-text-muted)]">
+                              {pair.metricValue || pair.statusLabel}
+                            </span>
+                          </span>
+                          <span
+                            className={cn(
+                              "shrink-0 rounded border px-1 py-0.5 text-[9px] font-medium leading-none",
+                              analysisStatusStyle(pair.status)
+                            )}
+                          >
+                            {pair.statusLabel}
+                          </span>
+                        </Button>
+                      );
+                    })}
+                    {!collisionPairs.length ? (
+                      <p className="px-1.5 py-1 text-[11px] leading-4 text-[var(--ui-text-muted)]">
+                        No reportable pairs.
+                      </p>
+                    ) : null}
+                  </div>
+                )}
+              </FileSheetSubsection>
+            ) : null}
+
+            {collisionReportAvailable && displayModeIsCollision ? (
+              <FileSheetSubsection title="Collision Tools" contentClassName="px-3">
+                <div className="grid grid-cols-2 gap-1.5">
+                  <CompactAnalysisToggle
+                    label={STEP_ANALYSIS_TOOL_LABELS.surfaces}
+                    checked={collisions?.showSurfaceHighlights !== false}
+                    onCheckedChange={(checked) => collisions?.onShowSurfaceHighlightsChange?.(checked)}
+                    disabled={collisionControlsDisabled}
+                    ariaLabel="Show collision and contact surfaces"
+                  />
+                  <CompactAnalysisToggle
+                    label={STEP_ANALYSIS_TOOL_LABELS.witnesses}
+                    checked={collisions?.showWitnesses !== false}
+                    onCheckedChange={(checked) => collisions?.onShowWitnessesChange?.(checked)}
+                    disabled={collisionControlsDisabled}
+                    ariaLabel="Show collision witnesses"
+                  />
+                  <CompactAnalysisToggle
+                    label={STEP_ANALYSIS_TOOL_LABELS.volumes}
+                    checked={collisions?.showInterferenceVolumes !== false}
+                    onCheckedChange={(checked) => collisions?.onShowInterferenceVolumesChange?.(checked)}
+                    disabled={collisionControlsDisabled}
+                    ariaLabel="Show interference volumes"
+                  />
+                  <CompactAnalysisToggle
+                    label={STEP_ANALYSIS_TOOL_LABELS.bounds}
+                    checked={collisions?.showBounds === true}
+                    onCheckedChange={(checked) => collisions?.onShowBoundsChange?.(checked)}
+                    disabled={collisionControlsDisabled}
+                    ariaLabel="Show collision part bounds"
+                  />
+                  <CompactAnalysisToggle
+                    label={STEP_ANALYSIS_TOOL_LABELS.collisions}
+                    checked={collisions?.showCollisions !== false}
+                    onCheckedChange={(checked) => collisions?.onShowCollisionsChange?.(checked)}
+                    disabled={collisionControlsDisabled}
+                    ariaLabel="Show collision pairs"
+                  />
+                  <CompactAnalysisToggle
+                    label={STEP_ANALYSIS_TOOL_LABELS.contacts}
+                    checked={collisions?.showContacts !== false}
+                    onCheckedChange={(checked) => collisions?.onShowContactsChange?.(checked)}
+                    disabled={collisionControlsDisabled}
+                    ariaLabel="Show contact pairs"
+                  />
+                  <CompactAnalysisToggle
+                    label={STEP_ANALYSIS_TOOL_LABELS.clearances}
+                    checked={collisions?.showClearances !== false}
+                    onCheckedChange={(checked) => collisions?.onShowClearancesChange?.(checked)}
+                    disabled={collisionControlsDisabled}
+                    ariaLabel="Show clearance pairs"
+                  />
+                </div>
+              </FileSheetSubsection>
+            ) : null}
+          </FileSheetSectionBody>
+        </FileSheetSection>
 
         {themeSections}
         <FileMetadataSection

--- a/viewer/src/client/components/workbench/ThemeSettingsPopover.js
+++ b/viewer/src/client/components/workbench/ThemeSettingsPopover.js
@@ -1,5 +1,5 @@
 import { Children, isValidElement, useEffect, useId, useMemo, useRef, useState } from "react";
-import { Box, Contrast, FlipHorizontal2, Grid3x3, Moon, MoreHorizontal, Pencil, Plus, RotateCcw, Sun, Trash2, X } from "lucide-react";
+import { Contrast, FlipHorizontal2, Moon, MoreHorizontal, Pencil, Plus, RotateCcw, Sun, Trash2, X } from "lucide-react";
 import {
   Accordion
 } from "../ui/accordion";
@@ -49,7 +49,6 @@ import {
   TabsList,
   TabsTrigger
 } from "../ui/tabs";
-import { ToggleGroup, ToggleGroupItem } from "../ui/toggle-group";
 import { cn } from "@/ui/utils";
 import {
   cloneThemePresetSettings,
@@ -82,6 +81,7 @@ import FileSheet, {
   FILE_SHEET_SEGMENTED_ITEM_CLASSES,
   FileSheetControlRow,
   FileSheetSection,
+  FileSheetSectionBody,
   FileSheetSliderField,
   FileSheetSubsection,
   FileSheetSubsubsection,
@@ -97,8 +97,10 @@ const BACKGROUND_MODE_OPTIONS = [
 ];
 
 const DISPLAY_MODE_OPTIONS = [
-  { value: CAD_DISPLAY_MODE.SOLID, label: "Solid", Icon: Box },
-  { value: CAD_DISPLAY_MODE.WIREFRAME, label: "Wire", Icon: Grid3x3 }
+  { value: CAD_DISPLAY_MODE.SOLID, label: "Solid" },
+  { value: CAD_DISPLAY_MODE.TRANSPARENT, label: "Transparent" },
+  { value: CAD_DISPLAY_MODE.COLLISION, label: "Collision" },
+  { value: CAD_DISPLAY_MODE.WIREFRAME, label: "Wire" }
 ];
 
 const FLOOR_MODE_OPTIONS = [
@@ -600,40 +602,79 @@ function FillColorEditor({ colors, onChange, cycleColors = false }) {
 }
 
 function SegmentedControl({ value, onChange, options }) {
-  const templateColumns = `repeat(${Math.max(options.length, 1)}, minmax(0, 1fr))`;
+  const groupName = useId();
+  const templateColumns = "repeat(auto-fit, minmax(min(6.75rem, 100%), 1fr))";
+  const enabledOptions = options.filter((option) => option.disabled !== true);
+  const commitValue = (nextValue) => {
+    if (nextValue) {
+      onChange(nextValue);
+    }
+  };
+  const handleKeyDown = (event, option) => {
+    const activeIndex = enabledOptions.findIndex((item) => item.value === option.value);
+    if (activeIndex < 0) {
+      return;
+    }
+    let nextIndex = activeIndex;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      nextIndex = (activeIndex + 1) % enabledOptions.length;
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      nextIndex = (activeIndex - 1 + enabledOptions.length) % enabledOptions.length;
+    } else if (event.key === "Home") {
+      nextIndex = 0;
+    } else if (event.key === "End") {
+      nextIndex = enabledOptions.length - 1;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    commitValue(enabledOptions[nextIndex]?.value);
+  };
   return (
-    <ToggleGroup
-      type="single"
-      variant="outline"
-      size="sm"
-      value={value}
-      onValueChange={(nextValue) => {
-        if (!nextValue) {
-          return;
-        }
-        onChange(nextValue);
-      }}
-      className="grid h-7 w-full min-w-0"
+    <div
+      role="radiogroup"
+      className="grid w-full min-w-0 gap-1"
       style={{ gridTemplateColumns: templateColumns }}
     >
       {options.map((option) => {
-        const Icon = option.Icon;
         const disabled = option.disabled === true;
+        const selected = value === option.value;
+        const inputId = `${groupName}-${option.value}`;
         return (
-          <ToggleGroupItem
+          <label
             key={option.value}
-            value={option.value}
-            disabled={disabled}
-            className={cn("min-w-0 gap-1.5 !h-7 px-1.5 text-[11px]", FILE_SHEET_SEGMENTED_ITEM_CLASSES)}
+            htmlFor={inputId}
+            data-state={selected ? "on" : "off"}
+            className={cn(
+              "relative inline-flex h-7 min-w-0 cursor-pointer items-center justify-center rounded-md border border-input bg-background px-2 text-[11px] font-medium text-muted-foreground shadow-none transition-colors",
+              "hover:bg-accent hover:text-foreground focus-within:z-10 focus-within:ring-2 focus-within:ring-ring/40",
+              disabled && "cursor-not-allowed opacity-50",
+              FILE_SHEET_SEGMENTED_ITEM_CLASSES
+            )}
             title={option.title || option.label}
-            aria-label={option.label}
+            onClick={() => {
+              if (!disabled) {
+                commitValue(option.value);
+              }
+            }}
+            onKeyDown={(event) => handleKeyDown(event, option)}
           >
-            {Icon ? <Icon className="size-3" strokeWidth={2} aria-hidden="true" /> : null}
-            <span className="truncate">{option.label}</span>
-          </ToggleGroupItem>
+            <input
+              id={inputId}
+              type="radio"
+              name={groupName}
+              value={option.value}
+              checked={selected}
+              disabled={disabled}
+              className="absolute inset-0 z-10 cursor-pointer opacity-0 disabled:cursor-not-allowed"
+              aria-label={option.label}
+              onChange={() => commitValue(option.value)}
+            />
+            <span className="pointer-events-none truncate">{option.label}</span>
+          </label>
         );
       })}
-    </ToggleGroup>
+    </div>
   );
 }
 
@@ -1446,11 +1487,53 @@ function PositionPad({ value, onChange }) {
   );
 }
 
-export function DisplaySettingsSection({
+export function DisplaySettingsControls({
   displaySettings,
   updateDisplaySettings,
-  clipBounds = null,
-  showClip = false
+  onDisplayModeChange = null,
+  modeOptions = DISPLAY_MODE_OPTIONS
+}) {
+  const normalizedDisplaySettings = useMemo(
+    () => normalizeDisplaySettings(displaySettings),
+    [displaySettings]
+  );
+  const setDisplay = (patch) => {
+    updateDisplaySettings?.((current) => ({
+      ...normalizeDisplaySettings(current),
+      ...patch
+    }));
+  };
+  const handleDisplayModeChange = (nextValue) => {
+    if (typeof onDisplayModeChange === "function") {
+      onDisplayModeChange(nextValue);
+      return;
+    }
+    setDisplay({ mode: nextValue });
+  };
+
+  return (
+    <Field label="Mode">
+      <SegmentedControl
+        value={normalizedDisplaySettings.mode}
+        options={modeOptions}
+        onChange={handleDisplayModeChange}
+      />
+    </Field>
+  );
+}
+
+export function DisplaySettingsSection(props) {
+  return (
+    <Section title="Display" value="display">
+      <DisplaySettingsControls {...props} />
+    </Section>
+  );
+}
+
+export function ClipSettingsControls({
+  displaySettings,
+  updateDisplaySettings,
+  clipBounds = null
 }) {
   const normalizedDisplaySettings = useMemo(
     () => normalizeDisplaySettings(displaySettings),
@@ -1485,110 +1568,113 @@ export function DisplaySettingsSection({
       ...(!normalizedClipSettings.enabled && resolvedOffset > 0 ? { enabled: true } : {})
     });
   };
+  const showClipDetails = true;
 
   return (
-    <Section title="Display" value="display">
-      <Field label="Mode">
-        <SegmentedControl
-          value={normalizedDisplaySettings.mode}
-          options={DISPLAY_MODE_OPTIONS}
-          onChange={(nextValue) => setDisplay({ mode: nextValue })}
-        />
-      </Field>
+    <>
+      <ThemeToggleRow
+        label="Enable"
+        checked={normalizedClipSettings.enabled}
+        onChange={(checked) => setClip({ enabled: checked })}
+      />
 
-      {showClip ? (
-        <ControlSubsection title="Clip" hideFirstSeparator={false}>
-          <ThemeToggleRow
-            label="Enable"
-            checked={normalizedClipSettings.enabled}
-            onChange={(checked) => setClip({ enabled: checked })}
-          />
-
-          {AXIS_OPTIONS.map((axis) => {
-            const axisOffset = normalizedClipSettings.offsets?.[axis] ?? DEFAULT_STEP_CLIP_SETTINGS.offsets[axis];
-            const axisSettings = {
-              ...normalizedClipSettings,
-              axis,
-              offset: axisOffset,
-              offsets: {
-                ...normalizedClipSettings.offsets,
-                [axis]: axisOffset
-              }
-            };
-            const boundsForAxis = clipAxisBounds(clipBounds, axis);
-            const axisRange = Math.max(boundsForAxis.max - boundsForAxis.min, 0);
-            const clipPosition = clipAxisPosition(clipBounds, axisSettings);
-            return (
-              <FileSheetSliderField
-                key={axis}
-                label={axis}
-                value={`${formatMm(clipPosition)} mm`}
-                onValueCommit={(nextValue) => {
-                  const nextPosition = parseFileSheetNumberInput(nextValue, {
-                    fallback: clipPosition,
-                    min: boundsForAxis.min,
-                    max: boundsForAxis.max
-                  });
-                  updateClipAxisOffset(
-                    axis,
-                    axisRange > 0 ? (nextPosition - boundsForAxis.min) / axisRange : axisOffset
-                  );
+      {showClipDetails ? (
+        AXIS_OPTIONS.map((axis) => {
+          const axisOffset = normalizedClipSettings.offsets?.[axis] ?? DEFAULT_STEP_CLIP_SETTINGS.offsets[axis];
+          const axisSettings = {
+            ...normalizedClipSettings,
+            axis,
+            offset: axisOffset,
+            offsets: {
+              ...normalizedClipSettings.offsets,
+              [axis]: axisOffset
+            }
+          };
+          const boundsForAxis = clipAxisBounds(clipBounds, axis);
+          const axisRange = Math.max(boundsForAxis.max - boundsForAxis.min, 0);
+          const clipPosition = clipAxisPosition(clipBounds, axisSettings);
+          return (
+            <FileSheetSliderField
+              key={axis}
+              label={axis}
+              value={`${formatMm(clipPosition)} mm`}
+              onValueCommit={(nextValue) => {
+                const nextPosition = parseFileSheetNumberInput(nextValue, {
+                  fallback: clipPosition,
+                  min: boundsForAxis.min,
+                  max: boundsForAxis.max
+                });
+                updateClipAxisOffset(
+                  axis,
+                  axisRange > 0 ? (nextPosition - boundsForAxis.min) / axisRange : axisOffset
+                );
+              }}
+              valueInputProps={{
+                disabled: !axisRange,
+                ariaLabel: `Clip ${axis.toUpperCase()} position`
+              }}
+            >
+              <Slider
+                className={precisionSliderClasses}
+                value={[axisOffset]}
+                min={0}
+                max={1}
+                step={0.001}
+                disabled={!axisRange}
+                onValueChange={(value) => {
+                  const nextOffset = Array.isArray(value) ? value[0] : value;
+                  updateClipAxisOffset(axis, nextOffset);
                 }}
-                valueInputProps={{
-                  disabled: !axisRange,
-                  ariaLabel: `Clip ${axis.toUpperCase()} position`
-                }}
-              >
-                <Slider
-                  className={precisionSliderClasses}
-                  value={[axisOffset]}
-                  min={0}
-                  max={1}
-                  step={0.001}
-                  disabled={!axisRange}
-                  onValueChange={(value) => {
-                    const nextOffset = Array.isArray(value) ? value[0] : value;
-                    updateClipAxisOffset(axis, nextOffset);
-                  }}
-                  aria-label={`Clip ${axis.toUpperCase()} axis`}
-                />
-                <div className="mt-1 flex justify-between text-[10px] text-[var(--ui-text-muted)]">
-                  <span>{formatMm(boundsForAxis.min)}</span>
-                  <span>{formatMm(boundsForAxis.max)}</span>
-                </div>
-              </FileSheetSliderField>
-            );
-          })}
-
-          <FileSheetControlRow>
-            <div className="flex flex-wrap gap-1.5">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className={compactButtonClasses}
-                onClick={() => setClip({ invert: !normalizedClipSettings.invert })}
-                aria-pressed={normalizedClipSettings.invert}
-                title="Flip clip side"
-              >
-                <FlipHorizontal2 className="h-3 w-3" strokeWidth={2} aria-hidden="true" />
-                <span>Flip</span>
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className={compactButtonClasses}
-                onClick={() => setDisplay({ clip: normalizeStepClipSettings(DEFAULT_STEP_CLIP_SETTINGS) })}
-                title="Reset clip plane"
-              >
-                <RotateCcw className="h-3 w-3" strokeWidth={2} aria-hidden="true" />
-                <span>Reset</span>
-              </Button>
-            </div>
-          </FileSheetControlRow>
-        </ControlSubsection>
+                aria-label={`Clip ${axis.toUpperCase()} axis`}
+              />
+              <div className="mt-1 flex justify-between text-[10px] text-[var(--ui-text-muted)]">
+                <span>{formatMm(boundsForAxis.min)}</span>
+                <span>{formatMm(boundsForAxis.max)}</span>
+              </div>
+            </FileSheetSliderField>
+          );
+        })
       ) : null}
+
+      {showClipDetails ? (
+        <FileSheetControlRow>
+          <div className="flex flex-wrap gap-1.5">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className={compactButtonClasses}
+              onClick={() => setClip({ invert: !normalizedClipSettings.invert })}
+              aria-pressed={normalizedClipSettings.invert}
+              title="Flip clip side"
+            >
+              <FlipHorizontal2 className="h-3 w-3" strokeWidth={2} aria-hidden="true" />
+              <span>Flip</span>
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className={compactButtonClasses}
+              onClick={() => setDisplay({ clip: normalizeStepClipSettings(DEFAULT_STEP_CLIP_SETTINGS) })}
+              title="Reset clip plane"
+            >
+              <RotateCcw className="h-3 w-3" strokeWidth={2} aria-hidden="true" />
+              <span>Reset</span>
+            </Button>
+          </div>
+        </FileSheetControlRow>
+      ) : null}
+    </>
+  );
+}
+
+export function ClipSettingsSection(props) {
+  return (
+    <Section title="Clip" value="clip">
+      <FileSheetSectionBody>
+        <ClipSettingsControls {...props} />
+      </FileSheetSectionBody>
     </Section>
   );
 }

--- a/viewer/src/client/workbench/fileSessionState.js
+++ b/viewer/src/client/workbench/fileSessionState.js
@@ -34,12 +34,24 @@ function normalizePositiveNumber(value, fallback = 0) {
   return numericValue > 0 ? numericValue : fallback;
 }
 
+function normalizeNonNegativeNumber(value, fallback = 0) {
+  const numericValue = normalizeNumber(value, fallback);
+  return numericValue >= 0 ? numericValue : fallback;
+}
+
 function normalizeBoolean(value, fallback = false) {
   return typeof value === "boolean" ? value : fallback;
 }
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeStringList(value) {
+  const rawValues = Array.isArray(value)
+    ? value
+    : String(value || "").split(/[\n,]+/u);
+  return rawValues.map((item) => normalizeString(item)).filter(Boolean);
 }
 
 function storageValuesEqual(a, b) {
@@ -181,6 +193,12 @@ function entryStepModuleSignature(entry) {
   ].filter(Boolean).join(":");
 }
 
+function entryCollisionsSignature(entry) {
+  return [
+    normalizeString(entry?.hash)
+  ].filter(Boolean).join(":");
+}
+
 function entryLargeFileSignature(entry) {
   return [
     normalizeString(entry?.kind).toLowerCase(),
@@ -211,6 +229,7 @@ export function fileSessionSignaturesForEntry(entry) {
     tab: entryTabSignature(entry),
     dxf: entryDxfSignature(entry),
     stepModule: entryStepModuleSignature(entry),
+    collisions: entryCollisionsSignature(entry),
     urdf: entryUrdfSignature(entry),
     largeFile: entryLargeFileSignature(entry)
   };
@@ -365,6 +384,42 @@ function normalizeLargeFileSlice(value) {
   };
 }
 
+function normalizeCollisionsSlice(value) {
+  if (!isPlainObject(value)) {
+    return null;
+  }
+  return {
+    enabled: normalizeBoolean(value.enabled, false),
+    selectedPairId: normalizeString(value.selectedPairId),
+    bodyDepth: Math.min(Math.max(Math.round(normalizeNumber(value.bodyDepth, 2)), 1), 12),
+    maxPairs: Math.min(Math.max(Math.round(normalizeNumber(value.maxPairs, 1000)), 1), 100000),
+    clearanceMm: Math.min(normalizeNonNegativeNumber(value.clearanceMm, 0), 100000),
+    contactToleranceMm: Math.min(normalizeNonNegativeNumber(value.contactToleranceMm, 0.0001), 1000),
+    collisionVolumeToleranceMm3: Math.min(normalizeNonNegativeNumber(value.collisionVolumeToleranceMm3, 0.000000001), 1000000000),
+    timeBudgetMs: Math.min(normalizeNonNegativeNumber(value.timeBudgetMs, 0), 3600000),
+    includeContact: normalizeBoolean(value.includeContact, true),
+    includeClearance: normalizeBoolean(value.includeClearance, false),
+    includeSeparated: normalizeBoolean(value.includeSeparated, false),
+    includeAllowed: normalizeBoolean(value.includeAllowed, false),
+    listBodies: normalizeBoolean(value.listBodies, false),
+    noCache: normalizeBoolean(value.noCache, false),
+    setA: normalizeStringList(value.setA),
+    setB: normalizeStringList(value.setB),
+    pairs: normalizeStringList(value.pairs),
+    allowPairs: normalizeStringList(value.allowPairs),
+    exclude: normalizeStringList(value.exclude),
+    collapse: normalizeStringList(value.collapse),
+    showSurfaceReview: normalizeBoolean(value.showSurfaceReview, true),
+    showSurfaceHighlights: normalizeBoolean(value.showSurfaceHighlights, true),
+    showWitnesses: normalizeBoolean(value.showWitnesses, true),
+    showInterferenceVolumes: normalizeBoolean(value.showInterferenceVolumes, false),
+    showBounds: normalizeBoolean(value.showBounds, false),
+    showCollisions: normalizeBoolean(value.showCollisions, true),
+    showContacts: normalizeBoolean(value.showContacts, true),
+    showClearances: normalizeBoolean(value.showClearances, true)
+  };
+}
+
 const FILE_SESSION_SLICE_SCHEMA = Object.freeze({
   display: {
     normalize: normalizeDisplaySlice,
@@ -385,6 +440,11 @@ const FILE_SESSION_SLICE_SCHEMA = Object.freeze({
     normalize: normalizeStepModuleSlice,
     equals: storageValuesEqual,
     signatureKey: "stepModule"
+  },
+  collisions: {
+    normalize: normalizeCollisionsSlice,
+    equals: storageValuesEqual,
+    signatureKey: "collisions"
   },
   urdf: {
     normalize: normalizeUrdfSlice,

--- a/viewer/src/client/workbench/fileSheetSections.js
+++ b/viewer/src/client/workbench/fileSheetSections.js
@@ -8,6 +8,7 @@ export const FILE_SHEET_SECTION_IDS = Object.freeze({
   GCODE_BOUNDS: "bounds",
   STEP_TREE: "tree",
   STEP_PARAMETERS: "parameters",
+  STEP_COLLISIONS: "collisions",
   ROBOT_SDF: "sdf",
   ROBOT_MOTION: "motion",
   ROBOT_JOINTS: "joints",
@@ -18,6 +19,9 @@ export const FILE_SHEET_SECTION_IDS = Object.freeze({
 
 const THEME_SECTION_IDS = Object.freeze([
   FILE_SHEET_SECTION_IDS.THEME_DISPLAY,
+  FILE_SHEET_SECTION_IDS.THEME_APPEARANCE
+]);
+const STEP_THEME_SECTIONS_WITHOUT_DISPLAY_IDS = Object.freeze([
   FILE_SHEET_SECTION_IDS.THEME_APPEARANCE
 ]);
 
@@ -60,7 +64,9 @@ export function renderedFileSheetSectionIds(kind, options = {}) {
         ...(options.hasFileStatus ? [FILE_SHEET_SECTION_IDS.FILE_STATUS] : []),
         FILE_SHEET_SECTION_IDS.STEP_TREE,
         ...(options.hasStepModulePanel ? [FILE_SHEET_SECTION_IDS.STEP_PARAMETERS] : []),
-        ...THEME_SECTION_IDS,
+        FILE_SHEET_SECTION_IDS.THEME_DISPLAY,
+        FILE_SHEET_SECTION_IDS.STEP_COLLISIONS,
+        ...STEP_THEME_SECTIONS_WITHOUT_DISPLAY_IDS,
         FILE_SHEET_SECTION_IDS.FILE_METADATA
       ];
     case "urdf":

--- a/viewer/src/client/workbench/fileSheetSections.test.js
+++ b/viewer/src/client/workbench/fileSheetSections.test.js
@@ -34,6 +34,14 @@ test("rendered file sheet sections include closed-by-default sections", () => {
     "tree",
     "parameters",
     "display",
+    "collisions",
+    "appearance",
+    "metadata"
+  ]);
+  assert.deepEqual(renderedFileSheetSectionIds("step"), [
+    "tree",
+    "display",
+    "collisions",
     "appearance",
     "metadata"
   ]);

--- a/viewer/src/server/httpHandlers.mjs
+++ b/viewer/src/server/httpHandlers.mjs
@@ -114,6 +114,73 @@ function fileAssetRequest(backend, requestUrl, {
   return request;
 }
 
+function optionalNumberParam(searchParams, name) {
+  const raw = searchParams.get(name);
+  if (raw === null || raw === "") {
+    return undefined;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function optionalIntegerParam(searchParams, name) {
+  const raw = searchParams.get(name);
+  if (raw === null || raw === "") {
+    return undefined;
+  }
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+function optionalBooleanParam(searchParams, name) {
+  const raw = searchParams.get(name);
+  if (raw === null || raw === "") {
+    return undefined;
+  }
+  const normalized = String(raw).trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+function repeatedStringParam(searchParams, name) {
+  return searchParams.getAll(name)
+    .map((value) => String(value || "").trim())
+    .filter(Boolean);
+}
+
+function collisionOptionsFromSearchParams(searchParams) {
+  const options = {
+    clearanceMm: optionalNumberParam(searchParams, "clearanceMm") ?? optionalNumberParam(searchParams, "clearance"),
+    contactToleranceMm: optionalNumberParam(searchParams, "contactToleranceMm") ?? optionalNumberParam(searchParams, "contactTolerance"),
+    collisionVolumeToleranceMm3: optionalNumberParam(searchParams, "collisionVolumeToleranceMm3") ?? optionalNumberParam(searchParams, "collisionVolumeTolerance"),
+    maxPairs: optionalIntegerParam(searchParams, "maxPairs"),
+    timeBudgetMs: optionalNumberParam(searchParams, "timeBudgetMs"),
+    bodyDepth: optionalIntegerParam(searchParams, "bodyDepth"),
+    includeContact: optionalBooleanParam(searchParams, "includeContact"),
+    includeClearance: optionalBooleanParam(searchParams, "includeClearance"),
+    includeSeparated: optionalBooleanParam(searchParams, "includeSeparated"),
+    includeAllowed: optionalBooleanParam(searchParams, "includeAllowed"),
+    listBodies: optionalBooleanParam(searchParams, "listBodies"),
+    noCache: optionalBooleanParam(searchParams, "noCache"),
+    collapse: repeatedStringParam(searchParams, "collapse"),
+    exclude: repeatedStringParam(searchParams, "exclude"),
+    setA: repeatedStringParam(searchParams, "setA"),
+    setB: repeatedStringParam(searchParams, "setB"),
+    pairs: repeatedStringParam(searchParams, "pair"),
+    allowPairs: repeatedStringParam(searchParams, "allowPair"),
+  };
+  return Object.fromEntries(
+    Object.entries(options).filter(([, value]) => (
+      Array.isArray(value) ? value.length > 0 : value !== undefined
+    ))
+  );
+}
+
 function sendBufferDownload(res, {
   body,
   filename,
@@ -392,6 +459,45 @@ export function createCadViewerApiMiddleware({
         sendJson(res, 200, await backend.readStepSourceStatus(request));
       } catch (error) {
         sendJson(res, 400, {
+          error: errorMessage(error),
+        });
+      }
+      return;
+    }
+    if (requestUrl.pathname === "/__cad/collisions") {
+      if (req.method !== "POST") {
+        res.setHeader("allow", "POST");
+        sendJson(res, 405, {
+          error: "Use POST to generate collision data",
+        });
+        return;
+      }
+      if (typeof backend.generateCollisions !== "function") {
+        sendJson(res, 501, {
+          error: "Collision generation is not available for this CAD Viewer backend",
+        });
+        return;
+      }
+      try {
+        const catalog = await backend.readCatalog({ rootDir });
+        const request = {
+          fileRef: requestUrl.searchParams.get("file"),
+          rootDir,
+          catalog,
+          options: collisionOptionsFromSearchParams(requestUrl.searchParams),
+        };
+        if (typeof backend.resolveRoot === "function") {
+          request.resolvedRoot = backend.resolveRoot(rootDir);
+        }
+        const result = await backend.generateCollisions(request);
+        sendJson(res, result?.ok ? 200 : 500, {
+          ok: Boolean(result?.ok),
+          error: result?.ok ? "" : String(result?.error || "Collision detection failed."),
+          result: result?.result ?? null,
+        });
+      } catch (error) {
+        sendJson(res, 400, {
+          ok: false,
           error: errorMessage(error),
         });
       }

--- a/viewer/src/server/httpHandlers.test.mjs
+++ b/viewer/src/server/httpHandlers.test.mjs
@@ -276,6 +276,78 @@ test("local asset middleware resolves legacy URDF mesh URLs from referrer file",
   ]);
 });
 
+test("CAD Viewer API middleware generates on-demand collision reports", async () => {
+  const calls = [];
+  const middleware = createCadViewerApiMiddleware({
+    rootDir: "models",
+    backend: {
+      readCatalog: async () => ({ schemaVersion: 4, entries: [{ file: "part.step" }] }),
+      resolveRoot: (rootDir) => ({ rootPath: `/workspace/${rootDir}` }),
+      generateCollisions: async (request) => {
+        calls.push(request);
+        return {
+          ok: true,
+          result: {
+            kind: "cadpy-interference-report",
+            summary: { reportedPairCount: 1 },
+          },
+        };
+      },
+    },
+  });
+  const req = {
+    method: "POST",
+    url: "/__cad/collisions?file=part.step&bodyDepth=2&maxPairs=50&clearanceMm=0.2&contactToleranceMm=0.01&collisionVolumeToleranceMm3=0.1&timeBudgetMs=500&includeContact=1&includeClearance=1&includeSeparated=0&includeAllowed=true&listBodies=false&noCache=1&setA=o1.1&setB=o1.2&pair=o1.1:o1.2&allowPair=o1.1:o1.3&exclude=fixture&collapse=servo",
+  };
+  const res = createResponse();
+
+  await middleware(req, res, () => {});
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(
+    calls.map((call) => ({
+      fileRef: call.fileRef,
+      rootDir: call.rootDir,
+      hasCatalog: Boolean(call.catalog),
+      resolvedRoot: call.resolvedRoot,
+      options: call.options,
+    })),
+    [{
+      fileRef: "part.step",
+      rootDir: "models",
+      hasCatalog: true,
+      resolvedRoot: { rootPath: "/workspace/models" },
+      options: {
+        clearanceMm: 0.2,
+        contactToleranceMm: 0.01,
+        collisionVolumeToleranceMm3: 0.1,
+        maxPairs: 50,
+        timeBudgetMs: 500,
+        bodyDepth: 2,
+        includeContact: true,
+        includeClearance: true,
+        includeSeparated: false,
+        includeAllowed: true,
+        listBodies: false,
+        noCache: true,
+        collapse: ["servo"],
+        exclude: ["fixture"],
+        setA: ["o1.1"],
+        setB: ["o1.2"],
+        pairs: ["o1.1:o1.2"],
+        allowPairs: ["o1.1:o1.3"],
+      },
+    }],
+  );
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: true,
+    error: "",
+    result: {
+      kind: "cadpy-interference-report",
+      summary: { reportedPairCount: 1 },
+    },
+  });
+});
 
 test("CAD Viewer API middleware reveals file assets with POST reveal route", async () => {
   const calls = [];

--- a/viewer/src/server/localAssetBackend.mjs
+++ b/viewer/src/server/localAssetBackend.mjs
@@ -17,6 +17,10 @@ import {
 } from "cadjs/lib/generationStatus.mjs";
 import { pathIsInside } from "cadjs/lib/pathUtils.mjs";
 import { ensureStepTopologyArtifact } from "cadjs/lib/step/stepArtifactCompiler.mjs";
+import {
+  cadPythonEnv,
+  cadPythonExecutable,
+} from "cadjs/lib/step/pythonStepArtifact.mjs";
 
 function toPosixPath(value) {
   return String(value || "").split(path.sep).join("/");
@@ -137,6 +141,117 @@ function stepArtifactGenerationError(result) {
   return "STEP artifact generation failed.";
 }
 
+function appendOption(args, name, value) {
+  if (value === null || value === undefined || value === "") {
+    return;
+  }
+  args.push(name, String(value));
+}
+
+function appendRepeatedOption(args, name, values) {
+  if (!Array.isArray(values)) {
+    return;
+  }
+  for (const value of values) {
+    const normalized = String(value || "").trim();
+    if (normalized) {
+      args.push(name, normalized);
+    }
+  }
+}
+
+export function runCadpyInterference({
+  repoRoot,
+  stepPath,
+  options = {},
+} = {}) {
+  const resolvedRepoRoot = path.resolve(repoRoot || "");
+  const resolvedStepPath = path.resolve(stepPath || "");
+  const args = [
+    "-m",
+    "cadpy.interference",
+    resolvedStepPath,
+    "--format",
+    "json",
+  ];
+  appendOption(args, "--clearance", options.clearanceMm);
+  appendOption(args, "--contact-tolerance", options.contactToleranceMm);
+  appendOption(args, "--collision-volume-tolerance", options.collisionVolumeToleranceMm3);
+  appendOption(args, "--max-pairs", options.maxPairs);
+  appendOption(args, "--time-budget-ms", options.timeBudgetMs);
+  appendOption(args, "--body-depth", options.bodyDepth);
+  appendRepeatedOption(args, "--collapse", options.collapse);
+  appendRepeatedOption(args, "--exclude", options.exclude);
+  appendRepeatedOption(args, "--set-a", options.setA);
+  appendRepeatedOption(args, "--set-b", options.setB);
+  appendRepeatedOption(args, "--pair", options.pairs);
+  appendRepeatedOption(args, "--allow-pair", options.allowPairs);
+  if (options.includeContact !== false) {
+    args.push("--include-contact");
+  }
+  if (options.includeClearance === true) {
+    args.push("--include-clearance");
+  }
+  if (options.includeSeparated === true) {
+    args.push("--include-separated");
+  }
+  if (options.includeAllowed === true) {
+    args.push("--include-allowed");
+  }
+  if (options.listBodies === true) {
+    args.push("--list-bodies");
+  }
+  if (options.noCache === true) {
+    args.push("--no-cache");
+  }
+
+  return new Promise((resolve) => {
+    const child = spawn(cadPythonExecutable(resolvedRepoRoot), args, {
+      cwd: resolvedRepoRoot,
+      env: cadPythonEnv(resolvedRepoRoot),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      resolve({
+        ok: false,
+        stepPath: resolvedStepPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+    child.on("close", (code) => {
+      const output = stdout.trim();
+      const lastJsonLine = output.split(/\r?\n/).reverse().find((line) => line.trim().startsWith("{"));
+      if (code === 0 && lastJsonLine) {
+        try {
+          resolve({
+            ok: true,
+            stepPath: resolvedStepPath,
+            result: JSON.parse(lastJsonLine),
+          });
+          return;
+        } catch {
+          // Fall through to the structured failure below.
+        }
+      }
+      resolve({
+        ok: false,
+        stepPath: resolvedStepPath,
+        exitCode: code,
+        error: (stderr || stdout || `Collision detection exited with code ${code}`).trim(),
+      });
+    });
+  });
+}
 function contentTypeForPath(filePath) {
   const extension = path.extname(filePath).toLowerCase();
   if (extension === ".js" || extension === ".mjs") {
@@ -393,7 +508,10 @@ export function createLocalAssetBackend({
   rootDir = "",
   defaultFile = "",
   githubUrl = "",
+  catalogRefreshIntervalMs = 0,
+  now = () => Date.now(),
   stepArtifactGenerator = ensureStepTopologyArtifact,
+  collisionGenerator = runCadpyInterference,
   sourceFileOpener = defaultSourceFileOpener,
 } = {}) {
   const baseWorkspaceRoot = path.resolve(workspaceRoot || process.cwd());
@@ -401,6 +519,22 @@ export function createLocalAssetBackend({
     ? absoluteFileRef(normalizedRootDir(rootDir, baseWorkspaceRoot))
     : absoluteFileRef(baseWorkspaceRoot);
   const catalogCache = new Map();
+  const catalogCacheTimes = new Map();
+
+  function setCatalogCache(cacheKey, catalog) {
+    catalogCache.set(cacheKey, catalog);
+    catalogCacheTimes.set(cacheKey, Number(now()) || 0);
+    return catalog;
+  }
+
+  function cachedCatalogIsStale(cacheKey) {
+    const interval = Number(catalogRefreshIntervalMs) || 0;
+    if (interval <= 0) {
+      return false;
+    }
+    const updatedAt = Number(catalogCacheTimes.get(cacheKey)) || 0;
+    return (Number(now()) || 0) - updatedAt >= interval;
+  }
 
   function effectiveRootDirForRequest(rootDir = "") {
     return rootDir || defaultRootDir;
@@ -447,6 +581,9 @@ export function createLocalAssetBackend({
     if (!catalogCache.has(cacheKey)) {
       return refreshCatalog({ rootDir: normalizedDir, fileRef: normalizedFile });
     }
+    if (cachedCatalogIsStale(cacheKey)) {
+      return refreshCatalog({ rootDir: normalizedDir, fileRef: normalizedFile });
+    }
     if (normalizedDir && normalizedFile) {
       const resolvedRoot = resolveRoot(normalizedDir);
       const requestedPath = filePathFromRef(normalizedFile, resolvedRoot);
@@ -475,8 +612,7 @@ export function createLocalAssetBackend({
       includeArtifactStatus: false,
     });
     const catalog = absolutizeCatalog(rawCatalog, context);
-    catalogCache.set(`dir:${resolvedRoot.dir}`, catalog);
-    return catalog;
+    return setCatalogCache(`dir:${resolvedRoot.dir}`, catalog);
   }
 
   function replaceCatalogEntry(catalog, fileRef, nextEntry) {
@@ -513,8 +649,7 @@ export function createLocalAssetBackend({
     });
     const fileRef = nextEntry?.file || (rawFileRef ? absoluteFileRef(path.resolve(resolvedRoot.rootPath, rawFileRef)) : absoluteFileRef(filePath));
     const nextCatalog = replaceCatalogEntry(currentCatalog, fileRef, nextEntry);
-    catalogCache.set(`dir:${resolvedRoot.dir}`, nextCatalog);
-    return nextCatalog;
+    return setCatalogCache(`dir:${resolvedRoot.dir}`, nextCatalog);
   }
 
   function refreshCatalogForPythonSource({ rootDir: nextRootDir = defaultRootDir, filePath } = {}) {
@@ -563,8 +698,7 @@ export function createLocalAssetBackend({
         rawEntry ? absolutizeCatalogEntry(rawEntry, context) : null
       );
     }
-    catalogCache.set(`dir:${resolvedRoot.dir}`, nextCatalog);
-    return nextCatalog;
+    return setCatalogCache(`dir:${resolvedRoot.dir}`, nextCatalog);
   }
 
   function refreshCatalogForPath({ rootDir: nextRootDir = defaultRootDir, filePath } = {}) {
@@ -825,6 +959,26 @@ export function createLocalAssetBackend({
     };
   }
 
+  async function generateCollisions({
+    fileRef,
+    options = {},
+    resolvedRoot = resolveRequestRoot({ fileRef }),
+    rootDir: nextRootDir = defaultRootDir,
+    catalog = null,
+  } = {}) {
+    const stepPath = resolveOutputFilePath(fileRef, { resolvedRoot, rootDir: nextRootDir, catalog });
+    const extension = path.extname(stepPath).toLowerCase();
+    if (extension !== ".step" && extension !== ".stp") {
+      throw new Error("Collision detection requires a STEP/STP file");
+    }
+    const context = scanContextForRoot(resolvedRoot);
+    return collisionGenerator({
+      repoRoot: context.scanRepoRoot,
+      stepPath,
+      options,
+    });
+  }
+
   function readStepSourceStatusForFile({ fileRef, resolvedRoot = resolveRequestRoot({ fileRef }), catalog = null } = {}) {
     const { stepPath, sourcePath } = resolveStepSourceStatus(fileRef, { resolvedRoot, catalog });
     const context = scanContextForRoot(resolvedRoot);
@@ -935,6 +1089,7 @@ export function createLocalAssetBackend({
     generationStatusDir,
     isGenerationStatusPath,
     generateStepArtifact,
+    generateCollisions,
     entryForSourcePath,
     assetPathForFileRef,
     writeAsset,

--- a/viewer/src/server/localAssetBackend.test.mjs
+++ b/viewer/src/server/localAssetBackend.test.mjs
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import { createLocalAssetBackend } from "./localAssetBackend.mjs";
+
+const STEP_TOPOLOGY_SCHEMA_VERSION = 2;
 
 async function withTempWorkspace(callback) {
   const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cad-viewer-backend-"));
@@ -13,6 +16,110 @@ async function withTempWorkspace(callback) {
   } finally {
     fs.rmSync(workspaceRoot, { recursive: true, force: true });
   }
+}
+
+function sha256File(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function pad4(buffer, byte = 0) {
+  const padding = (4 - (buffer.length % 4)) % 4;
+  return padding ? Buffer.concat([buffer, Buffer.alloc(padding, byte)]) : buffer;
+}
+
+function topologyGlb({ sourcePath, stepHash }) {
+  let binary = Buffer.alloc(0);
+  const bufferViews = [];
+  function addBufferView(payload) {
+    binary = pad4(binary);
+    const byteOffset = binary.length;
+    binary = Buffer.concat([binary, payload]);
+    const index = bufferViews.length;
+    bufferViews.push({ buffer: 0, byteOffset, byteLength: payload.length });
+    return index;
+  }
+  const edgeRendering = {
+    visibilityClasses: ["feature", "tangent", "seam", "degenerate"],
+    generatedVisibilityClasses: ["feature"],
+    visibilityClassCounts: { feature: 1 },
+    generatedVisibilityClassCounts: { feature: 1 },
+  };
+  const manifest = {
+    schemaVersion: STEP_TOPOLOGY_SCHEMA_VERSION,
+    profile: "index",
+    entryKind: "part",
+    sourceKind: "step",
+    sourcePath,
+    stepHash,
+    edgeRendering,
+  };
+  const indexView = addBufferView(Buffer.from(JSON.stringify(manifest), "utf8"));
+  const surfaceHalfEdgesView = addBufferView(Buffer.alloc(0));
+  const edgeView = addBufferView(Buffer.from(JSON.stringify({
+    schemaVersion: STEP_TOPOLOGY_SCHEMA_VERSION,
+    profile: "surface-edges",
+    sourceKind: "step",
+    sourcePath,
+    stepHash,
+    edgeRendering,
+    buffers: {
+      littleEndian: true,
+      views: {
+        surfaceHalfEdges: {
+          dtype: "uint32",
+          bufferView: surfaceHalfEdgesView,
+          byteOffset: 0,
+          byteLength: 0,
+          count: 0,
+          itemSize: 4,
+        },
+      },
+    },
+  }), "utf8"));
+  const selectorView = addBufferView(Buffer.from(JSON.stringify({
+    schemaVersion: STEP_TOPOLOGY_SCHEMA_VERSION,
+    profile: "selector",
+    sourceKind: "step",
+    sourcePath,
+    stepHash,
+  }), "utf8"));
+  binary = pad4(binary);
+  const gltf = {
+    asset: { version: "2.0" },
+    buffers: [{ byteLength: binary.length }],
+    bufferViews,
+    meshes: [{
+      primitives: [{
+        attributes: {
+          _CAD_EDGE_BARYCENTRIC: 0,
+          _CAD_EDGE_CLASS: 1,
+        },
+      }],
+    }],
+    extensionsUsed: ["STEP_topology"],
+    extensions: {
+      STEP_topology: {
+        schemaVersion: STEP_TOPOLOGY_SCHEMA_VERSION,
+        entryKind: "part",
+        indexView,
+        edgeView,
+        selectorView,
+        encoding: "utf-8",
+      },
+    },
+  };
+  const jsonChunk = pad4(Buffer.from(JSON.stringify(gltf), "utf8"), 0x20);
+  const header = Buffer.alloc(12);
+  const jsonHeader = Buffer.alloc(8);
+  const binHeader = Buffer.alloc(8);
+  header.writeUInt32LE(0x46546c67, 0);
+  header.writeUInt32LE(2, 4);
+  header.writeUInt32LE(12 + 8 + jsonChunk.length + 8 + binary.length, 8);
+  jsonHeader.writeUInt32LE(jsonChunk.length, 0);
+  jsonHeader.write("JSON", 4, "latin1");
+  binHeader.writeUInt32LE(binary.length, 0);
+  binHeader.write("BIN\0", 4, "latin1");
+  return Buffer.concat([header, jsonHeader, jsonChunk, binHeader, binary]);
 }
 
 function writeStepWithSourceMetadata(filePath, sourcePath) {
@@ -182,6 +289,29 @@ test("local backend refreshes requested files against a cached dynamic root cata
       backend.readCatalog({ rootDir: modelRoot, fileRef: "first.stl" }).entries.map((entry) => entry.rootRelativeFile),
       ["second.stl"]
     );
+  });
+});
+
+test("local backend can auto-refresh cached catalogs on reads", async () => {
+  await withTempWorkspace((workspaceRoot) => {
+    const modelRoot = path.join(workspaceRoot, "models");
+    fs.mkdirSync(modelRoot, { recursive: true });
+    fs.writeFileSync(path.join(modelRoot, "first.stl"), "solid first\nendsolid first\n");
+    let currentTime = 1000;
+    const backend = createLocalAssetBackend({
+      workspaceRoot,
+      rootDir: "models",
+      catalogRefreshIntervalMs: 100,
+      now: () => currentTime,
+    });
+
+    assert.deepEqual(backend.readCatalog().entries.map((entry) => entry.rootRelativeFile), ["first.stl"]);
+
+    fs.writeFileSync(path.join(modelRoot, "second.stl"), "solid second\nendsolid second\n");
+    assert.deepEqual(backend.readCatalog().entries.map((entry) => entry.rootRelativeFile), ["first.stl"]);
+
+    currentTime = 1100;
+    assert.deepEqual(backend.readCatalog().entries.map((entry) => entry.rootRelativeFile), ["first.stl", "second.stl"]);
   });
 });
 
@@ -394,6 +524,79 @@ test("local backend rejects artifact regeneration for non-STEP files", async () 
   });
 });
 
+test("local backend regenerates copied STEP files when Python metadata source is unavailable", async () => {
+  await withTempWorkspace(async (workspaceRoot) => {
+    const modelRoot = path.join(workspaceRoot, "models");
+    fs.mkdirSync(path.join(modelRoot, "copied"), { recursive: true });
+    const stepPath = path.join(modelRoot, "copied", "robot_arm.step");
+    writeStepWithSourceMetadata(stepPath, "models/robots/tom/robot_arm.py");
+    const backend = createLocalAssetBackend({
+      workspaceRoot,
+      rootDir: "models",
+      stepArtifactGenerator: async (request) => {
+        assert.equal(request.stepPath, stepPath);
+        assert.equal(request.sourcePath, "");
+        assert.equal(request.skipStepWrite, false);
+        return { ok: true, validation: { ok: true } };
+      },
+    });
+    const catalog = backend.refreshCatalog();
+    const entry = catalog.entries.find((candidate) => candidate.rootRelativeFile === "copied/robot_arm.step");
+
+    assert.equal(entry.sourceKind, "step");
+    assert.equal(entry.artifact, undefined);
+
+    const result = await backend.generateStepArtifact({
+      fileRef: "copied/robot_arm.step",
+      catalog,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.stepPath, stepPath);
+  });
+});
+
+test("local backend generates collisions for STEP files on demand", async () => {
+  await withTempWorkspace(async (workspaceRoot) => {
+    const modelRoot = path.join(workspaceRoot, "models");
+    const stepPath = path.join(modelRoot, "part.step");
+    const calls = [];
+    fs.mkdirSync(modelRoot, { recursive: true });
+    fs.writeFileSync(stepPath, "ISO-10303-21;\nEND-ISO-10303-21;\n");
+    const backend = createLocalAssetBackend({
+      workspaceRoot,
+      rootDir: "models",
+      collisionGenerator: async (request) => {
+        calls.push(request);
+        return {
+          ok: true,
+          result: {
+            kind: "cadpy-interference-report",
+            summary: { reportedPairCount: 0 },
+          },
+        };
+      },
+    });
+    const catalog = backend.refreshCatalog();
+
+    const result = await backend.generateCollisions({
+      fileRef: "part.step",
+      catalog,
+      options: { bodyDepth: 2, maxPairs: 50 },
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.result, {
+      kind: "cadpy-interference-report",
+      summary: { reportedPairCount: 0 },
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].repoRoot, workspaceRoot);
+    assert.equal(calls[0].stepPath, stepPath);
+    assert.deepEqual(calls[0].options, { bodyDepth: 2, maxPairs: 50 });
+  });
+});
+
 test("local backend reports missing Python-backed STEP files dynamically", async () => {
   await withTempWorkspace((workspaceRoot) => {
     const modelRoot = path.join(workspaceRoot, "models");
@@ -493,6 +696,42 @@ test("local backend resolves generated GLB artifact assets from catalog URLs", a
     assert.equal(access.path, artifactPath);
     assert.equal(access.filename, ".part.step.glb");
     assert.equal(access.contentType, "model/gltf-binary");
+    assert.throws(
+      () => backend.resolveFileAssetAccess({
+        fileRef: "part.step",
+        asset: "analysis",
+        catalog,
+      }),
+      /Unsupported file asset/
+    );
+  });
+});
+
+test("local backend resolves catalog asset URLs when rootDir is absolute", async () => {
+  await withTempWorkspace((workspaceRoot) => {
+    const modelRoot = path.join(workspaceRoot, "models");
+    fs.mkdirSync(modelRoot, { recursive: true });
+    const stepPath = path.join(modelRoot, "part.step");
+    const artifactPath = path.join(modelRoot, ".part.step.glb");
+    fs.writeFileSync(stepPath, "ISO-10303-21;\nEND-ISO-10303-21;\n");
+    fs.writeFileSync(artifactPath, topologyGlb({
+      sourcePath: "models/part.step",
+      stepHash: sha256File(stepPath),
+    }));
+    const backend = createLocalAssetBackend({ workspaceRoot, rootDir: modelRoot });
+    const catalog = backend.refreshCatalog();
+    const resolvedRoot = backend.resolveRoot(modelRoot);
+
+    const artifact = backend.resolveFileAssetAccess({
+      fileRef: "part.step",
+      asset: "artifact",
+      rootDir: modelRoot,
+      resolvedRoot,
+      catalog,
+    });
+
+    assert.equal(artifact.file, artifactPath);
+    assert.equal(artifact.path, artifactPath);
   });
 });
 

--- a/viewer/vite.config.mjs
+++ b/viewer/vite.config.mjs
@@ -126,6 +126,33 @@ function isGenerationStatusFilePath(filePath) {
   return name.startsWith(".") && name.endsWith(".generation.lock.json");
 }
 
+function devPackageSourceCachePlugin() {
+  const sourcePackagePathPattern = /^\/packages\/(?:cadjs|cadpy|cadpy_metadata)\/src\//;
+  return {
+    name: "cad-viewer-dev-package-source-cache",
+    apply: "serve",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const pathname = String(req.url || "").split(/[?#]/, 1)[0];
+        if (!sourcePackagePathPattern.test(pathname)) {
+          next();
+          return;
+        }
+
+        const originalSetHeader = res.setHeader.bind(res);
+        res.setHeader = (name, value) => {
+          if (String(name || "").toLowerCase() === "cache-control") {
+            return originalSetHeader(name, "no-store");
+          }
+          return originalSetHeader(name, value);
+        };
+        res.setHeader("Cache-Control", "no-store");
+        next();
+      });
+    },
+  };
+}
+
 function cadCatalogPlugin({ enableStepArtifactBackend = false } = {}) {
   const activeDirectories = new Map();
   const refreshTimers = new Map();
@@ -334,6 +361,7 @@ export default defineConfig(({ command }) => ({
   root: viewerAppRoot,
   envPrefix: "VIEWER_",
   plugins: [
+    devPackageSourceCachePlugin(),
     react(),
     cadCatalogPlugin({ enableStepArtifactBackend: command === "serve" }),
     serverLifetimePlugin(),


### PR DESCRIPTION
## Summary

- Add CAD Python interference analysis and CLI support for STEP assembly collision checks.
- Store optional analysis payloads alongside STEP topology data in generated GLB artifacts.
- Add viewer controls for collision/transparent display modes, pair-focused analysis review, clipping, and local artifact regeneration behavior.

## Impact

This PR intentionally isolates the still-iterating collision/interference tooling from the assembly-helper work.

## Validation

- `scripts/test/test-python.sh`
- `npm --prefix packages/cadjs test`
- `npm --prefix viewer run test`
- `npm --prefix viewer run build`
- `scripts/dev/setup-symlinks.sh --check`
- `scripts/test/test-global.sh`