### PR TITLE
Install implicitjs dependencies during publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -217,6 +217,7 @@ jobs:
         if: steps.gate.outputs.should_publish == 'true'
         run: |
           npm ci --prefix packages/cadjs
+          npm ci --prefix packages/implicitjs
           npm ci --prefix viewer
           npm ci --prefix docs
 


### PR DESCRIPTION
Adds the standalone implicitjs package install step to the Publish workflow before running the full code test suite. This keeps the 0.2.1 publish path aligned with the Test workflow after the implicitjs split.