### PR TITLE
[codex] Fix implicit CAD snapshot browser launch

### DIFF
--- a/packages/implicitjs/scripts/snapshot.mjs
+++ b/packages/implicitjs/scripts/snapshot.mjs
@@ -715,6 +715,14 @@ async function withSnapshotTimeout(promise, timeoutSeconds, label = "snapshot") 
   }
 }
 
+export function chromiumLaunchOptions() {
+  return {
+    headless: true,
+    timeout: RENDER_BROWSER_STARTUP_TIMEOUT_MS,
+    args: [],
+  };
+}
+
 class BatchSnapshotRenderer {
   constructor() {
     this.browser = null;
@@ -734,11 +742,7 @@ class BatchSnapshotRenderer {
           `Implicit CAD snapshot requires the JavaScript playwright package. Install implicitjs dependencies and run playwright install chromium if needed. ${error instanceof Error ? error.message : String(error)}`
         );
       });
-      this.browser = await chromium.launch({
-        headless: true,
-        timeout: RENDER_BROWSER_STARTUP_TIMEOUT_MS,
-        args: ["--single-process"],
-      });
+      this.browser = await chromium.launch(chromiumLaunchOptions());
       this.context = await this.browser.newContext({
         viewport: { width: DEFAULT_RENDER_WIDTH, height: DEFAULT_RENDER_HEIGHT },
         deviceScaleFactor: 1,

--- a/packages/implicitjs/scripts/snapshot.test.mjs
+++ b/packages/implicitjs/scripts/snapshot.test.mjs
@@ -9,6 +9,7 @@ import {
   RENDER_HTML_PATH,
   SNAPSHOT_ORIGIN,
   SnapshotError,
+  chromiumLaunchOptions,
   loadJobFromOptions,
   parseSnapshotArgs,
   resolveRenderJobPacket,
@@ -241,4 +242,8 @@ test("snapshot routes are package-owned and self-contained", () => {
     () => resolveSnapshotRouteFile(`${SNAPSHOT_ORIGIN}/__render_asset/orb.implicit.js`),
     SnapshotError
   );
+});
+
+test("snapshot renderer does not force Chromium single-process mode", () => {
+  assert.notEqual(chromiumLaunchOptions().args?.includes("--single-process"), true);
 });


### PR DESCRIPTION
Fixes #46

## Summary

- Stop launching implicit-cad headless snapshots with Chromium `--single-process`.
- Add a regression test for the implicitjs snapshot launch options so the Windows WebGL crash mode does not return.

## Root Cause

The implicit CAD snapshot CLI still forced Playwright Chromium into single-process mode, matching the previously fixed CAD snapshot issue. On Windows headless Chromium, that can break WebGL context creation during the render.

## Validation

- `npm --prefix packages/implicitjs test`
- `git diff --check`
- `scripts/dev/setup-symlinks.sh --check`
- `scripts/bundle/bundle.sh --check`