### PR TITLE
[codex] Fix SDF mesh URI resolution and primitives

### DIFF
--- a/packages/cadjs/src/lib/urdf/parseSdf.js
+++ b/packages/cadjs/src/lib/urdf/parseSdf.js
@@ -56,6 +56,22 @@ function parseNumberList(value, count, fallback, context) {
   return parsed;
 }
 
+function parseRequiredNumberList(value, count, context) {
+  const text = String(value || "").trim();
+  if (!text) {
+    throw new Error(`${context} must contain ${count} numeric values`);
+  }
+  return parseNumberList(text, count, new Array(count).fill(0), context);
+}
+
+function parsePositiveNumberText(value, context) {
+  const number = Number(String(value || "").trim());
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error(`${context} must be positive`);
+  }
+  return number;
+}
+
 function translationTransform(x, y, z) {
   return [
     1, 0, 0, x,
@@ -149,10 +165,67 @@ function normalizeAbsoluteUrl(url) {
   return new URL(String(url || "/"), globalThis.window?.location?.href || "http://localhost/").toString();
 }
 
+function normalizeFileRefSegments(value) {
+  const rawValue = String(value || "").replace(/\\/g, "/");
+  const absolute = rawValue.startsWith("/");
+  const parts = [];
+  for (const part of rawValue.split("/")) {
+    if (!part || part === ".") {
+      continue;
+    }
+    if (part === "..") {
+      if (parts.length && parts[parts.length - 1] !== "..") {
+        parts.pop();
+      } else if (!absolute) {
+        parts.push(part);
+      }
+      continue;
+    }
+    parts.push(part);
+  }
+  return `${absolute ? "/" : ""}${parts.join("/")}`;
+}
+
+function dirnameFileRef(value) {
+  const normalized = String(value || "").replace(/\\/g, "/");
+  const index = normalized.lastIndexOf("/");
+  return index >= 0 ? normalized.slice(0, index + 1) : "";
+}
+
+function resolveLocalAssetFileRef(sourceFileRef, filename) {
+  const rawFilename = String(filename || "").trim();
+  if (!rawFilename || /^[a-z][a-z0-9+.-]*:/i.test(rawFilename)) {
+    return "";
+  }
+  if (rawFilename.startsWith("/")) {
+    return normalizeFileRefSegments(rawFilename);
+  }
+  return normalizeFileRefSegments(`${dirnameFileRef(sourceFileRef)}${rawFilename}`);
+}
+
+function resolveCadAssetMeshUrl(uri, sourceUrl) {
+  const source = new URL(normalizeAbsoluteUrl(sourceUrl));
+  if (source.pathname !== "/__cad/asset") {
+    return "";
+  }
+  const sourceFileRef = source.searchParams.get("file") || "";
+  const meshFileRef = resolveLocalAssetFileRef(sourceFileRef, uri);
+  if (!meshFileRef) {
+    return "";
+  }
+  const resolved = new URL("/__cad/asset", source);
+  resolved.searchParams.set("file", meshFileRef);
+  return `${resolved.pathname}${resolved.search}`;
+}
+
 function resolveMeshUrl(uri, sourceUrl) {
   const rawUri = String(uri || "").trim();
   if (!rawUri) {
     throw new Error("SDF mesh URI is required");
+  }
+  const assetUrl = resolveCadAssetMeshUrl(rawUri, sourceUrl);
+  if (assetUrl) {
+    return assetUrl;
   }
   const normalizedSourceUrl = normalizeAbsoluteUrl(sourceUrl);
   let resolvedUrl;
@@ -231,13 +304,65 @@ function occurrenceIdFromSdfName(value) {
   return match ? `o${match[1].replace(/_/g, ".")}` : "";
 }
 
+function parsePrimitiveGeometry(geometryElement, context) {
+  const boxElement = childElementsByTag(geometryElement, "box")[0] || null;
+  if (boxElement) {
+    const size = parseRequiredNumberList(childText(boxElement, "size"), 3, `${context} box size`);
+    if (size.some((value) => value <= 0)) {
+      throw new Error(`${context} box size values must be positive`);
+    }
+    return {
+      type: "box",
+      size
+    };
+  }
+
+  const cylinderElement = childElementsByTag(geometryElement, "cylinder")[0] || null;
+  if (cylinderElement) {
+    return {
+      type: "cylinder",
+      radius: parsePositiveNumberText(childText(cylinderElement, "radius"), `${context} cylinder radius`),
+      length: parsePositiveNumberText(childText(cylinderElement, "length"), `${context} cylinder length`)
+    };
+  }
+
+  const sphereElement = childElementsByTag(geometryElement, "sphere")[0] || null;
+  if (sphereElement) {
+    return {
+      type: "sphere",
+      radius: parsePositiveNumberText(childText(sphereElement, "radius"), `${context} sphere radius`)
+    };
+  }
+
+  return null;
+}
+
 function parseMeshInstance(containerElement, { linkName, kind, index, sourceUrl }) {
   const labelKind = kind === "collision" ? "collision" : "visual";
   const instanceId = String(containerElement?.getAttribute("name") || "").trim();
   const pose = parsePose(containerElement, `SDF link ${linkName} ${labelKind} ${index}`);
   const geometryElement = childElementsByTag(containerElement, "geometry")[0] || null;
   const meshElement = geometryElement ? childElementsByTag(geometryElement, "mesh")[0] : null;
+  const color = materialColorFromElement(
+    childElementsByTag(containerElement, "material")[0] || null,
+    `SDF link ${linkName} ${labelKind} ${index}`
+  );
   if (!meshElement) {
+    const primitive = geometryElement
+      ? parsePrimitiveGeometry(geometryElement, `SDF link ${linkName} ${labelKind} ${index}`)
+      : null;
+    if (primitive) {
+      return {
+        id: `${linkName}:${kind[0]}${index}`,
+        label: primitive.type,
+        instanceId,
+        occurrenceId: occurrenceIdFromSdfName(instanceId) || occurrenceIdFromSdfName(linkName),
+        primitive,
+        color,
+        localTransform: pose.transform,
+        pose
+      };
+    }
     const geometryKind = geometryElement ? (elementName(childElements(geometryElement)[0]) || "unknown") : "missing";
     return {
       id: `${linkName}:${kind[0]}${index}`,
@@ -245,7 +370,7 @@ function parseMeshInstance(containerElement, { linkName, kind, index, sourceUrl 
       instanceId,
       occurrenceId: occurrenceIdFromSdfName(instanceId) || occurrenceIdFromSdfName(linkName),
       meshUrl: "",
-      color: "",
+      color,
       localTransform: pose.transform,
       pose,
       unsupportedGeometry: geometryKind
@@ -259,7 +384,7 @@ function parseMeshInstance(containerElement, { linkName, kind, index, sourceUrl 
       instanceId,
       occurrenceId: occurrenceIdFromSdfName(instanceId) || occurrenceIdFromSdfName(linkName),
       meshUrl: "",
-      color: "",
+      color,
       localTransform: pose.transform,
       pose,
       unsupportedGeometry: "mesh"
@@ -278,10 +403,7 @@ function parseMeshInstance(containerElement, { linkName, kind, index, sourceUrl 
     instanceId,
     occurrenceId: occurrenceIdFromSdfName(instanceId) || occurrenceIdFromSdfName(linkName),
     meshUrl: resolveMeshUrl(uri, sourceUrl || "/"),
-    color: materialColorFromElement(
-      childElementsByTag(containerElement, "material")[0] || null,
-      `SDF link ${linkName} ${labelKind} ${index}`
-    ),
+    color,
     localTransform: multiplyTransforms(pose.transform, meshScaleTransform),
     pose,
     scaleTransform: meshScaleTransform

--- a/packages/cadjs/src/lib/urdf/parseSdf.js
+++ b/packages/cadjs/src/lib/urdf/parseSdf.js
@@ -215,6 +215,10 @@ function resolveCadAssetMeshUrl(uri, sourceUrl) {
   }
   const resolved = new URL("/__cad/asset", source);
   resolved.searchParams.set("file", meshFileRef);
+  const sourceDirRef = normalizeFileRefSegments(dirnameFileRef(sourceFileRef));
+  if (sourceDirRef) {
+    resolved.searchParams.set("dir", sourceDirRef);
+  }
   return `${resolved.pathname}${resolved.search}`;
 }
 

--- a/packages/cadjs/src/lib/urdf/parseSdf.test.js
+++ b/packages/cadjs/src/lib/urdf/parseSdf.test.js
@@ -178,7 +178,7 @@ test("parseSdf resolves local CAD asset mesh URIs relative to the SDF file", () 
 
   assert.equal(
     sdfData.links[0].visuals[0].meshUrl,
-    "/__cad/asset?file=%2Fworkspace%2Fmodels%2Fdiffbot%2Fmeshes%2Fchassis.stl"
+    "/__cad/asset?file=%2Fworkspace%2Fmodels%2Fdiffbot%2Fmeshes%2Fchassis.stl&dir=%2Fworkspace%2Fmodels%2Fdiffbot"
   );
 });
 

--- a/packages/cadjs/src/lib/urdf/parseSdf.test.js
+++ b/packages/cadjs/src/lib/urdf/parseSdf.test.js
@@ -162,6 +162,80 @@ test("parseSdf reads SO101-style model-level SDF robot data", () => {
   assert.equal(sdfData.srdf, null);
 });
 
+test("parseSdf resolves local CAD asset mesh URIs relative to the SDF file", () => {
+  const root = sdfRoot([
+    el("model", { name: "diffbot" }, [
+      el("link", { name: "base_link" }, [
+        meshVisual("base_link", "meshes/chassis.stl")
+      ])
+    ])
+  ]);
+
+  const sdfData = parseWithRoot(
+    root,
+    "/__cad/asset?file=%2Fworkspace%2Fmodels%2Fdiffbot%2Fdiffbot.sdf&v=abc123"
+  );
+
+  assert.equal(
+    sdfData.links[0].visuals[0].meshUrl,
+    "/__cad/asset?file=%2Fworkspace%2Fmodels%2Fdiffbot%2Fmeshes%2Fchassis.stl"
+  );
+});
+
+test("parseSdf accepts primitive visual and collision geometry", () => {
+  const root = sdfRoot([
+    el("model", { name: "primitive_robot" }, [
+      el("link", { name: "base_link" }, [
+        el("visual", { name: "box_visual" }, [
+          textEl("pose", "0.025 0 0.003 0 0 0"),
+          el("geometry", {}, [
+            el("box", {}, [
+              textEl("size", "0.17 0.13 0.006")
+            ])
+          ]),
+          el("material", {}, [
+            textEl("diffuse", "0.72 0.78 0.82 1")
+          ])
+        ]),
+        el("visual", { name: "wheel_visual" }, [
+          el("geometry", {}, [
+            el("cylinder", {}, [
+              textEl("radius", "0.04"),
+              textEl("length", "0.012")
+            ])
+          ])
+        ]),
+        el("collision", { name: "body_collision" }, [
+          el("geometry", {}, [
+            el("sphere", {}, [
+              textEl("radius", "0.09")
+            ])
+          ])
+        ])
+      ])
+    ])
+  ]);
+
+  const sdfData = parseWithRoot(root);
+
+  assert.deepEqual(sdfData.links[0].visuals[0].primitive, {
+    type: "box",
+    size: [0.17, 0.13, 0.006]
+  });
+  assert.equal(sdfData.links[0].visuals[0].color, "#b8c7d1");
+  assert.deepEqual(sdfData.links[0].visuals[1].primitive, {
+    type: "cylinder",
+    radius: 0.04,
+    length: 0.012
+  });
+  assert.deepEqual(sdfData.links[0].collisions[0].primitive, {
+    type: "sphere",
+    radius: 0.09
+  });
+  assert.equal(sdfData.sdf.unsupportedVisualCount, 0);
+  assert.equal(sdfData.sdf.unsupportedCollisionCount, 0);
+});
+
 test("parseSdf preserves CAD occurrence ids encoded in visual names", () => {
   const root = sdfRoot([
     el("model", { name: "sample" }, [
@@ -432,7 +506,7 @@ test("parseSdf keeps unsupported geometry as static placeholders", () => {
           el("geometry", {}, [el("mesh")])
         ]),
         el("collision", {}, [
-          el("geometry", {}, [el("box")])
+          el("geometry", {}, [el("plane")])
         ])
       ])
     ])
@@ -441,7 +515,7 @@ test("parseSdf keeps unsupported geometry as static placeholders", () => {
   assert.equal(sdfData.sdf.unsupportedVisualCount, 1);
   assert.equal(sdfData.sdf.unsupportedCollisionCount, 1);
   assert.equal(sdfData.links[0].visuals[0].unsupportedGeometry, "mesh");
-  assert.equal(sdfData.links[0].collisions[0].unsupportedGeometry, "box");
+  assert.equal(sdfData.links[0].collisions[0].unsupportedGeometry, "plane");
 });
 
 test("parseSdf rejects unsupported pose frames", () => {


### PR DESCRIPTION
Fixes #47

## Summary

- Resolve relative SDF mesh URIs served through `/__cad/asset?file=...` against the SDF file path, matching URDF local asset behavior.
- Parse SDF `box`, `cylinder`, and `sphere` geometry into the existing primitive visual schema so primitive-only SDF models render instead of showing unsupported placeholders.
- Add parser coverage for both local asset mesh URI resolution and SDF primitive visuals/collisions.

## Root Cause

SDF mesh paths were resolved with generic URL semantics against the asset endpoint URL, which dropped the source file directory context and produced paths like `/__cad/meshes/x.stl`. SDF primitive elements were also treated as unsupported geometry placeholders even though the viewer already supports the same primitive mesh schema for URDF.

## Validation

- `npm --prefix packages/cadjs test -- src/lib/urdf/parseSdf.test.js`
- `CAD_PYTHON=/Users/jakefitz/text-to-cad/.venv/bin/python npm --prefix packages/cadjs test`
- `npm --prefix viewer run test`
- `npm --prefix viewer run build`
- `git diff --check`
- `scripts/dev/setup-symlinks.sh --check`
- `scripts/bundle/bundle.sh --check`