### PR TITLE
[codex] Fix hosted robot asset loading

### DIFF
--- a/packages/cadjs/src/lib/urdf/parseSdf.js
+++ b/packages/cadjs/src/lib/urdf/parseSdf.js
@@ -149,6 +149,22 @@ function normalizeAbsoluteUrl(url) {
   return new URL(String(url || "/"), globalThis.window?.location?.href || "http://localhost/").toString();
 }
 
+function urlHasExplicitOrigin(value) {
+  try {
+    const url = new URL(String(value || ""));
+    return Boolean(url.origin && url.origin !== "null");
+  } catch {
+    return false;
+  }
+}
+
+function resolvedMeshUrlString(resolvedUrl, { sourceUrl }) {
+  if (urlHasExplicitOrigin(sourceUrl)) {
+    return resolvedUrl.toString();
+  }
+  return `${resolvedUrl.pathname}${resolvedUrl.search}`;
+}
+
 function resolveMeshUrl(uri, sourceUrl) {
   const rawUri = String(uri || "").trim();
   if (!rawUri) {
@@ -163,7 +179,7 @@ function resolveMeshUrl(uri, sourceUrl) {
   } else {
     resolvedUrl = new URL(rawUri, normalizedSourceUrl);
   }
-  return `${resolvedUrl.pathname}${resolvedUrl.search}`;
+  return resolvedMeshUrlString(resolvedUrl, { sourceUrl });
 }
 
 function labelForMeshUri(uri) {

--- a/packages/cadjs/src/lib/urdf/parseSdf.test.js
+++ b/packages/cadjs/src/lib/urdf/parseSdf.test.js
@@ -162,6 +162,25 @@ test("parseSdf reads SO101-style model-level SDF robot data", () => {
   assert.equal(sdfData.srdf, null);
 });
 
+test("parseSdf preserves remote origins when resolving hosted mesh URIs", () => {
+  const root = sdfRoot([
+    el("model", { name: "hosted_robot" }, [
+      link("base_link")
+    ])
+  ]);
+
+  const sdfData = parseWithRoot(root, "https://blob.example.test/models2/robots/so101/robot.sdf");
+
+  assert.equal(
+    sdfData.links[0].visuals[0].meshUrl,
+    "https://blob.example.test/models2/robots/so101/meshes/base_link.stl"
+  );
+  assert.equal(
+    sdfData.links[0].collisions[0].meshUrl,
+    "https://blob.example.test/models2/robots/so101/meshes/base_link_collision.stl"
+  );
+});
+
 test("parseSdf preserves CAD occurrence ids encoded in visual names", () => {
   const root = sdfRoot([
     el("model", { name: "sample" }, [

--- a/packages/cadjs/src/lib/urdf/parseUrdf.js
+++ b/packages/cadjs/src/lib/urdf/parseUrdf.js
@@ -98,6 +98,30 @@ function normalizeAbsoluteUrl(url) {
   return new URL(url, globalThis.window?.location?.href || "http://localhost/").toString();
 }
 
+function urlHasExplicitOrigin(value) {
+  try {
+    const url = new URL(String(value || ""));
+    return Boolean(url.origin && url.origin !== "null");
+  } catch {
+    return false;
+  }
+}
+
+function assetRefHasExplicitOrigin(value) {
+  const rawValue = String(value || "").trim();
+  if (!rawValue || rawValue.startsWith("package://")) {
+    return false;
+  }
+  return urlHasExplicitOrigin(rawValue);
+}
+
+function resolvedMeshUrlString(resolvedUrl, { filename, sourceUrl }) {
+  if (urlHasExplicitOrigin(sourceUrl) || assetRefHasExplicitOrigin(filename)) {
+    return resolvedUrl.toString();
+  }
+  return `${resolvedUrl.pathname}${resolvedUrl.search}`;
+}
+
 function normalizeFileRefSegments(value) {
   const rawValue = String(value || "").replace(/\\/g, "/");
   const absolute = rawValue.startsWith("/");
@@ -163,7 +187,7 @@ function resolveMeshUrl(filename, sourceUrl) {
   } else {
     resolvedUrl = new URL(filename, normalizedSourceUrl);
   }
-  return `${resolvedUrl.pathname}${resolvedUrl.search}`;
+  return resolvedMeshUrlString(resolvedUrl, { filename, sourceUrl });
 }
 
 function labelForMeshFilename(filename) {

--- a/packages/cadjs/src/lib/urdf/parseUrdf.test.js
+++ b/packages/cadjs/src/lib/urdf/parseUrdf.test.js
@@ -87,6 +87,36 @@ test("parseUrdf resolves relative mesh paths through local CAD asset URLs", () =
   );
 });
 
+test("parseUrdf preserves remote origins when resolving hosted mesh paths", () => {
+  const robot = new FakeElement("robot", { name: "tom" }, [
+    new FakeElement("link", { name: "base_link" }, [
+      new FakeElement("visual", {}, [
+        new FakeElement("geometry", {}, [
+          new FakeElement("mesh", { filename: "STL/sts3250.stl" })
+        ])
+      ]),
+      new FakeElement("visual", {}, [
+        new FakeElement("geometry", {}, [
+          new FakeElement("mesh", { filename: "https://cdn.example.test/meshes/tool.stl" })
+        ])
+      ])
+    ])
+  ]);
+
+  const urdfData = withFakeDomParser(new FakeDocument(robot), () => parseUrdf("<robot />", {
+    sourceUrl: "https://blob.example.test/models2/robots/tom/robot_arm.urdf"
+  }));
+
+  assert.equal(
+    urdfData.links[0].visuals[0].meshUrl,
+    "https://blob.example.test/models2/robots/tom/STL/sts3250.stl"
+  );
+  assert.equal(
+    urdfData.links[0].visuals[1].meshUrl,
+    "https://cdn.example.test/meshes/tool.stl"
+  );
+});
+
 test("parseUrdf accepts primitive box visuals", () => {
   const robot = new FakeElement("robot", { name: "primitive_robot" }, [
     new FakeElement("material", { name: "aluminum" }, [

--- a/viewer/src/server/vercelApi.mjs
+++ b/viewer/src/server/vercelApi.mjs
@@ -82,16 +82,6 @@ export async function handleHostedCadApi(req, res, {
     return;
   }
 
-  const blobConfig = vercelBlobConfigFromEnv(env);
-  if (req.method === "GET" && normalizedCadPath === "/__cad/catalog" && blobConfig.catalogUrl) {
-    res.statusCode = 307;
-    res.setHeader("location", blobConfig.catalogUrl);
-    res.setHeader("cache-control", "no-store");
-    res.setHeader("access-control-allow-origin", "*");
-    res.end("");
-    return;
-  }
-
   const originalUrl = req.url || "/";
   const originalRequestUrl = new URL(originalUrl, "http://localhost");
   originalRequestUrl.searchParams.delete("dir");

--- a/viewer/src/server/vercelApi.test.mjs
+++ b/viewer/src/server/vercelApi.test.mjs
@@ -96,15 +96,17 @@ test("hosted CAD API ignores local dir query params", async () => {
 });
 
 
-test("hosted CAD API redirects catalog reads to public Blob URLs when configured", async () => {
+test("hosted CAD API serves catalog through the backend when a public Blob URL is configured", async () => {
+  const calls = [];
   const backend = {
     kind: "vercel-blob",
     catalogPath: "models2/catalog-0.1.3.json",
-    readCatalog: async () => {
-      throw new Error("catalog should be served by public Blob redirect");
+    readCatalog: async (request) => {
+      calls.push(request);
+      return { schemaVersion: 4, entries: [{ file: "robots/tom/robot_arm.urdf" }] };
     },
   };
-  const req = { method: "GET", url: "/api/cad/catalog" };
+  const req = { method: "GET", url: "/api/cad/catalog?file=robots%2Ftom%2Frobot_arm.urdf" };
   const res = createResponse();
 
   await handleHostedCadApi(req, res, {
@@ -118,13 +120,16 @@ test("hosted CAD API redirects catalog reads to public Blob URLs when configured
     },
   });
 
-  assert.equal(res.statusCode, 307);
-  assert.equal(
-    res.getHeader("location"),
-    "https://tbc5qqrytrzknlqz.public.blob.vercel-storage.com/models2/catalog-0.1.3.json"
-  );
-  assert.equal(res.getHeader("cache-control"), "no-store");
-  assert.equal(res.getHeader("access-control-allow-origin"), "*");
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.getHeader("location"), undefined);
+  assert.equal(res.getHeader("content-type"), "application/json; charset=utf-8");
+  assert.deepEqual(calls, [
+    { rootDir: "", fileRef: "robots/tom/robot_arm.urdf" },
+  ]);
+  assert.deepEqual(JSON.parse(res.body), {
+    schemaVersion: 4,
+    entries: [{ file: "robots/tom/robot_arm.urdf" }],
+  });
 });
 
 


### PR DESCRIPTION
## Summary

Fixes the hosted CAD demo failure for URDF/SDF robot assets by keeping catalog reads same-origin and preserving remote origins while resolving robot mesh URLs.

## Root Cause

The hosted API redirected catalog GETs directly to the public Vercel Blob catalog URL. That Blob request is currently being challenged by Vercel, so browser fetch fails before the selected robot file loads.

Separately, URDF/SDF relative mesh paths from absolute Blob-hosted robot files were being collapsed to path-only URLs. The browser then fetched the CAD Viewer app HTML from `demo.cadskills.xyz` as if it were STL data, producing the invalid typed array length error.

## Changes

- Serve hosted catalog reads through the same-origin backend instead of redirecting to the public Blob catalog URL.
- Preserve explicit origins when resolving URDF mesh filenames from remote source URLs.
- Preserve explicit origins when resolving SDF mesh URIs from remote source URLs.
- Add regression coverage for hosted URDF/SDF mesh URL resolution and hosted catalog serving.

## Validation

- `node --test packages/cadjs/src/lib/urdf/parseUrdf.test.js packages/cadjs/src/lib/urdf/parseSdf.test.js`
- `node --test viewer/src/server/vercelApi.test.mjs`
- `git diff --check`