### PR TITLE
[codex] Fix viewer tree breadcrumbs and isolation

### DIFF
--- a/packages/cadjs/src/lib/assembly/meshData.js
+++ b/packages/cadjs/src/lib/assembly/meshData.js
@@ -168,26 +168,20 @@ export function assemblyInspectionNode(root, nodeId) {
   return findAssemblyNode(root, normalizeAssemblyInspectionNodeId(root, nodeId)) || root;
 }
 
+function directChildAssemblyNodeIds(node) {
+  return (Array.isArray(node?.children) ? node.children : [])
+    .map((child) => String(child?.id || "").trim())
+    .filter(Boolean);
+}
+
 export function selectableAssemblyNodeIdsForInspection(root, nodeId) {
   const inspectedNode = assemblyInspectionNode(root, nodeId);
-  if (String(inspectedNode?.nodeType || "").trim() !== "assembly") {
-    return [];
-  }
-  return (Array.isArray(inspectedNode?.children) ? inspectedNode.children : [])
-    .map((node) => String(node?.id || "").trim())
-    .filter(Boolean);
+  return directChildAssemblyNodeIds(inspectedNode);
 }
 
 export function treeSelectableAssemblyNodeIdsForInspection(root, nodeId) {
   const inspectedNode = assemblyInspectionNode(root, nodeId);
-  if (!inspectedNode) {
-    return [];
-  }
-  const rootId = rootAssemblyInspectionNodeId(root);
-  const inspectedNodeId = normalizeAssemblyInspectionNodeId(root, nodeId);
-  return flattenAssemblyNodes(inspectedNode)
-    .map((node) => String(node?.id || "").trim())
-    .filter((id) => id && id !== rootId && id !== inspectedNodeId);
+  return directChildAssemblyNodeIds(inspectedNode);
 }
 
 export function focusedLeafPartIdsForAssemblyInspection(root, nodeId) {

--- a/packages/cadjs/src/lib/assembly/meshData.test.js
+++ b/packages/cadjs/src/lib/assembly/meshData.test.js
@@ -475,6 +475,22 @@ test("assembly inspection helpers keep one inspected node and limit selectable c
         ]
       },
       {
+        id: "compound_part",
+        nodeType: "part",
+        children: [
+          {
+            id: "leaf_c",
+            nodeType: "part",
+            children: []
+          },
+          {
+            id: "leaf_d",
+            nodeType: "part",
+            children: []
+          }
+        ]
+      },
+      {
         id: "sibling",
         nodeType: "part",
         children: []
@@ -488,18 +504,21 @@ test("assembly inspection helpers keep one inspected node and limit selectable c
   assert.equal(normalizeAssemblyInspectionNodeId(root, "leaf_a"), "leaf_a");
   assert.equal(assemblyInspectionNode(root, "module")?.id, "module");
 
-  assert.deepEqual(selectableAssemblyNodeIdsForInspection(root, ""), ["module", "sibling"]);
+  assert.deepEqual(selectableAssemblyNodeIdsForInspection(root, ""), ["module", "compound_part", "sibling"]);
   assert.deepEqual(selectableAssemblyNodeIdsForInspection(root, "module"), ["leaf_a", "leaf_b"]);
+  assert.deepEqual(selectableAssemblyNodeIdsForInspection(root, "compound_part"), ["leaf_c", "leaf_d"]);
   assert.deepEqual(selectableAssemblyNodeIdsForInspection(root, "leaf_a"), []);
   assert.equal(selectableAssemblyNodeIdsForInspection(root, "module").includes("sibling"), false);
 
-  assert.deepEqual(treeSelectableAssemblyNodeIdsForInspection(root, ""), ["module", "leaf_a", "leaf_b", "sibling"]);
+  assert.deepEqual(treeSelectableAssemblyNodeIdsForInspection(root, ""), ["module", "compound_part", "sibling"]);
   assert.deepEqual(treeSelectableAssemblyNodeIdsForInspection(root, "module"), ["leaf_a", "leaf_b"]);
+  assert.deepEqual(treeSelectableAssemblyNodeIdsForInspection(root, "compound_part"), ["leaf_c", "leaf_d"]);
   assert.deepEqual(treeSelectableAssemblyNodeIdsForInspection(root, "leaf_a"), []);
   assert.equal(treeSelectableAssemblyNodeIdsForInspection(root, "module").includes("sibling"), false);
 
   assert.deepEqual(focusedLeafPartIdsForAssemblyInspection(root, ""), []);
   assert.deepEqual(focusedLeafPartIdsForAssemblyInspection(root, "module"), ["leaf_a", "leaf_b"]);
+  assert.deepEqual(focusedLeafPartIdsForAssemblyInspection(root, "compound_part"), ["leaf_c", "leaf_d"]);
   assert.deepEqual(focusedLeafPartIdsForAssemblyInspection(root, "leaf_a"), ["leaf_a"]);
 });
 

--- a/packages/cadjs/src/lib/step/stepTree.js
+++ b/packages/cadjs/src/lib/step/stepTree.js
@@ -24,6 +24,10 @@ function basename(value) {
   return normalized.split(/[\\/]/).filter(Boolean).pop() || normalized;
 }
 
+function componentLabelFromPartLabel(value) {
+  return normalizeString(value).replace(/\.(?:step|stp)$/i, "") || "STEP part";
+}
+
 export function stepTreeNodeId(node) {
   return normalizeString(node?.id || node?.occurrenceId);
 }
@@ -275,6 +279,24 @@ function buildSyntheticOccurrenceNode({ partId, occurrenceId, children }) {
   };
 }
 
+function buildTopologyFolderNode({ partNode, partId, children }) {
+  const label = componentLabelFromPartLabel(stepTreeNodeLabel(partNode));
+  return {
+    id: topologyNodeId(partId, "folder", "faces-edges"),
+    nodeType: "topology-folder",
+    displayName: label,
+    name: label,
+    detail: "",
+    topologyReferenceId: "",
+    displaySelector: "",
+    partId,
+    selectionPartId: partId,
+    leafPartIds: [STEP_MODEL_RENDER_PART_ID],
+    visualOnly: true,
+    children
+  };
+}
+
 function topologySelectorAliases(value) {
   const normalizedValue = normalizeString(value);
   if (!normalizedValue) {
@@ -343,11 +365,27 @@ function flattenRedundantTopologyOccurrenceNodes(partNode, topologyChildren) {
   ));
 }
 
+function maybeWrapSinglePartTopologyFolder(partNode, topologyChildren) {
+  const children = Array.isArray(topologyChildren) ? topologyChildren : [];
+  if (
+    !children.length ||
+    normalizeString(partNode?.nodeType) !== "part" ||
+    stepTreeNodeId(partNode) !== STEP_MODEL_ROOT_ID
+  ) {
+    return children;
+  }
+  return [buildTopologyFolderNode({
+    partNode,
+    partId: STEP_MODEL_ROOT_ID,
+    children
+  })];
+}
+
 function topologyReferencePartId(reference, fallbackPartId) {
   return normalizeString(reference?.partId) || normalizeString(fallbackPartId);
 }
 
-function addStepTreeTopologyPartTarget(targets, seenTargets, partId, occurrenceId) {
+function addStepTreeTopologyPartTarget(targets, seenTargets, partId, occurrenceId, priority = 0) {
   const normalizedPartId = normalizeString(partId);
   const normalizedOccurrenceId = normalizeString(occurrenceId);
   if (!normalizedPartId || !normalizedOccurrenceId) {
@@ -360,7 +398,8 @@ function addStepTreeTopologyPartTarget(targets, seenTargets, partId, occurrenceI
   seenTargets.add(key);
   targets.push({
     partId: normalizedPartId,
-    occurrenceId: normalizedOccurrenceId
+    occurrenceId: normalizedOccurrenceId,
+    priority: Number.isFinite(Number(priority)) ? Number(priority) : 0
   });
 }
 
@@ -385,16 +424,19 @@ function collectStepTreeTopologyPartTargets(root) {
       continue;
     }
 
-    addStepTreeTopologyPartTarget(targets, seenTargets, partId, partId);
-    addStepTreeTopologyPartTarget(targets, seenTargets, partId, node?.occurrenceId);
-    addStepTreeTopologyPartTarget(targets, seenTargets, partId, node?.sourceOccurrenceId);
-    addStepTreeTopologyPartTarget(targets, seenTargets, partId, node?.sourceRootTargetOccurrenceId);
+    addStepTreeTopologyPartTarget(targets, seenTargets, partId, partId, 0);
+    addStepTreeTopologyPartTarget(targets, seenTargets, partId, node?.occurrenceId, 0);
     for (const leafPartId of stepTreeNodeLeafPartIds(node)) {
-      addStepTreeTopologyPartTarget(targets, seenTargets, partId, leafPartId);
+      addStepTreeTopologyPartTarget(targets, seenTargets, partId, leafPartId, 1);
     }
+    addStepTreeTopologyPartTarget(targets, seenTargets, partId, node?.sourceOccurrenceId, 2);
+    addStepTreeTopologyPartTarget(targets, seenTargets, partId, node?.sourceRootTargetOccurrenceId, 2);
   }
 
-  return targets.sort((a, b) => b.occurrenceId.length - a.occurrenceId.length);
+  return targets.sort((a, b) => (
+    b.occurrenceId.length - a.occurrenceId.length ||
+    a.priority - b.priority
+  ));
 }
 
 function occurrenceMatchesStepTreePartTarget(occurrenceId, targetOccurrenceId) {
@@ -531,7 +573,10 @@ export function buildStepTreeRootWithTopology({ root = null, references = [], fa
     const id = stepTreeNodeId(node);
     const children = stepTreeNodeChildren(node).map((child) => cloneWithTopology(child));
     const topologyChildren = normalizeString(node?.nodeType) === "part"
-      ? flattenRedundantTopologyOccurrenceNodes(node, topologyChildrenByPart.get(id) || [])
+      ? maybeWrapSinglePartTopologyFolder(
+          node,
+          flattenRedundantTopologyOccurrenceNodes(node, topologyChildrenByPart.get(id) || [])
+        )
       : [];
     if (!children.length && !topologyChildren.length) {
       return node;

--- a/packages/cadjs/src/lib/step/stepTree.test.js
+++ b/packages/cadjs/src/lib/step/stepTree.test.js
@@ -430,6 +430,7 @@ test("STEP tree can assign topology references to assembly parts by occurrence i
       {
         id: "servo-part",
         occurrenceId: "o1.3.2",
+        sourceOccurrenceId: "o1.4",
         nodeType: "part",
         displayName: "servo",
         children: []
@@ -529,9 +530,22 @@ test("STEP tree flattens redundant topology occurrence rows for single STEP root
     ]
   });
 
+  const folder = augmented.children[0];
+  assert.equal(folder.nodeType, "topology-folder");
+  assert.equal(folder.displayName, "base_plate");
+  assert.equal(folder.visualOnly, true);
+  assert.deepEqual(folder.leafPartIds, [STEP_MODEL_RENDER_PART_ID]);
   assert.deepEqual(
-    augmented.children.map((child) => [child.nodeType, child.displaySelector]),
+    folder.children.map((child) => [child.nodeType, child.displaySelector]),
     [["topology-face", "o1.f1"]]
+  );
+  assert.deepEqual(
+    flattenVisibleStepTreeRows(augmented, [folder.id], { omitRoot: true })
+      .map((row) => [row.nodeType, row.label, row.depth]),
+    [
+      ["topology-folder", "base_plate", 0],
+      ["topology-face", "Face f1", 1]
+    ]
   );
 });
 

--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -13,7 +13,7 @@ import {
 } from "./workbench/ThemeSettingsPopover";
 import MeshFileSheet from "./workbench/MeshFileSheet";
 import ImplicitFileSheet from "./workbench/ImplicitFileSheet";
-import StepFileSheet, { STEP_TREE_ROOT_ITEM_LIMIT } from "./workbench/StepFileSheet";
+import StepFileSheet from "./workbench/StepFileSheet";
 import StatusToast from "./workbench/StatusToast";
 import UrdfFileSheet from "./workbench/UrdfFileSheet";
 import ViewerAlertDialog from "./workbench/ViewerAlertDialog";
@@ -288,7 +288,6 @@ import {
   STEP_MODEL_ROOT_ID,
   STEP_MODEL_RENDER_PART_ID,
   STEP_TREE_TOPOLOGY_NODE_PREFIX,
-  stepTreeRootChildIndexForNode,
   stepTreeNodeChildren
 } from "cadjs/lib/step/stepTree";
 import {
@@ -782,9 +781,6 @@ function focusedAssemblyInteractionNodeId(root, nodeIds) {
     }
     const path = assemblyPathToNode(root, normalizedNodeId);
     const node = path[path.length - 1] || null;
-    if (String(node?.nodeType || "").trim() !== "assembly") {
-      continue;
-    }
     const children = Array.isArray(node?.children) ? node.children : [];
     if (!children.length || path.length <= bestDepth) {
       continue;
@@ -824,7 +820,7 @@ function collectTopologyWrapperExpansionIds(node) {
     const childId = stepTreeNodeIdForWorkspace(child);
     const childType = String(child?.nodeType || "").trim();
     const children = stepTreeNodeChildren(child);
-    if (childType.startsWith("topology-") && childId && children.length) {
+    if (childType.startsWith("topology-") && childId && children.length && child?.visualOnly !== true) {
       expansionIds.push(childId);
     }
     for (let index = children.length - 1; index >= 0; index -= 1) {
@@ -834,13 +830,23 @@ function collectTopologyWrapperExpansionIds(node) {
   return expansionIds;
 }
 
-function collectStepTreeRevealExpansionIds(root, nodeId, { expandSelf = false } = {}) {
+function collectStepTreeRevealExpansionIds(root, nodeId, {
+  expandSelf = false,
+  includeVisualOnlyAncestors = true
+} = {}) {
   const normalizedNodeId = String(nodeId || "").trim();
   if (!root || !normalizedNodeId) {
     return [];
   }
   const node = findStepTreeNodeForWorkspace(root, normalizedNodeId);
-  const expansionIds = collectStepTreeAncestorIds(root, normalizedNodeId);
+  const expansionIds = collectStepTreeAncestorIds(root, normalizedNodeId)
+    .filter((id) => {
+      if (includeVisualOnlyAncestors) {
+        return true;
+      }
+      const ancestor = findStepTreeNodeForWorkspace(root, id);
+      return ancestor?.visualOnly !== true;
+    });
   if (expandSelf && node && stepTreeNodeChildren(node).length) {
     expansionIds.push(normalizedNodeId, ...collectTopologyWrapperExpansionIds(node));
   }
@@ -1146,7 +1152,6 @@ export default function CadWorkspace({
   const [selectedWholeEntryCadRefToken, setSelectedWholeEntryCadRefToken] = useState("");
   const [expandedStepTreeNodeIds, setExpandedStepTreeNodeIds] = useState([]);
   const [activeTreeNodeScrollKey, setActiveTreeNodeScrollKey] = useState("");
-  const [stepTreeRootShowMore, setStepTreeRootShowMore] = useState(false);
   const [hiddenPartIds, setHiddenPartIds] = useState([]);
   const [isolatedAssemblyNodeIds, setIsolatedAssemblyNodeIds] = useState([]);
   const [viewerContextMenu, setViewerContextMenu] = useState(null);
@@ -2802,22 +2807,24 @@ export default function CadWorkspace({
     isAssemblyView
   ]);
   const assemblyCurrentNodeId = assemblyRootNodeId;
-  const assemblyCurrentNode = useMemo(
-    () => findAssemblyNode(assemblyRoot, assemblyCurrentNodeId) || assemblyRoot,
-    [assemblyCurrentNodeId, assemblyRoot]
-  );
   const focusedAssemblyInteractionId = useMemo(
     () => (isAssemblyView ? focusedAssemblyInteractionNodeId(assemblyRoot, focusedAssemblyNodeIds) : ""),
     [assemblyRoot, focusedAssemblyNodeIds, isAssemblyView]
   );
-  const assemblyInteractionNodeId = focusedAssemblyInteractionId || assemblyCurrentNodeId;
+  const assemblyInteractionNodeId = focusedAssemblyInteractionId || (
+    focusedAssemblyNodeIds.length ? "" : assemblyCurrentNodeId
+  );
   const assemblyInteractionNode = useMemo(
-    () => findAssemblyNode(assemblyRoot, assemblyInteractionNodeId) || assemblyRoot,
+    () => (assemblyInteractionNodeId ? findAssemblyNode(assemblyRoot, assemblyInteractionNodeId) || assemblyRoot : null),
     [assemblyInteractionNodeId, assemblyRoot]
+  );
+  const assemblyInteractionNodeChildren = useMemo(
+    () => (Array.isArray(assemblyInteractionNode?.children) ? assemblyInteractionNode.children : []),
+    [assemblyInteractionNode]
   );
   const selectableAssemblyNodeIds = useMemo(
     () => {
-      if (!isAssemblyView) {
+      if (!isAssemblyView || !assemblyInteractionNodeId) {
         return [];
       }
       const focusedNodeIdSet = new Set(focusedAssemblyNodeIds);
@@ -2841,13 +2848,13 @@ export default function CadWorkspace({
     [treeSelectableAssemblyNodeIds]
   );
   const assemblyParts = useMemo(() => {
-    return String(assemblyInteractionNode?.nodeType || "").trim() === "assembly"
-      ? (Array.isArray(assemblyInteractionNode?.children) ? assemblyInteractionNode.children : []).map((node) => ({
+    return assemblyInteractionNodeChildren.length
+      ? assemblyInteractionNodeChildren.map((node) => ({
         ...node,
         leafPartIds: descendantLeafPartIds(node)
       }))
       : [];
-  }, [assemblyInteractionNode]);
+  }, [assemblyInteractionNodeChildren]);
   const assemblyPickPartIdMap = useMemo(() => {
     return buildAssemblyLeafToNodePickMap(assemblyParts);
   }, [assemblyParts]);
@@ -3141,11 +3148,15 @@ export default function CadWorkspace({
     }
     setDxfBendSettings((current) => normalizeDxfBendSettings(selectedDxfData, current));
   }, [selectedDxfData, selectedDxfFileRef]);
-  const focusedAssemblyTopologyActive = Boolean(isAssemblyView && focusedAssemblyNodeIds.length);
+  const assemblyInteractionNodeHasChildren = assemblyInteractionNodeChildren.length > 0;
+  const focusedAssemblyTopologyActive = Boolean(
+    isAssemblyView &&
+    focusedAssemblyNodeIds.length &&
+    !assemblyInteractionNodeHasChildren
+  );
   const viewerInAssemblyMode =
     isAssemblyView &&
-    !focusedAssemblyTopologyActive &&
-    String(assemblyCurrentNode?.nodeType || "assembly").trim() === "assembly";
+    assemblyInteractionNodeHasChildren;
   const viewerMode = viewerInAssemblyMode ? "assembly" : "part";
   const drawModeActive = selectedEntrySourceFormat === RENDER_FORMAT.STEP && tabToolMode === TAB_TOOL_MODE.DRAW;
   const selectionCountBase = selectedPartIds.length + selectedReferenceIds.length + selectedMateIds.length;
@@ -3756,7 +3767,6 @@ export default function CadWorkspace({
       selectedPartIds,
       inspectedAssemblyNodeId: "",
       expandedStepTreeNodeIds,
-      stepTreeRootShowMore,
       fileSheetOpenSectionIds: effectiveFileSheetOpenSectionIds,
       hiddenPartIds,
       camera: activePerspectiveRef.current,
@@ -3778,7 +3788,6 @@ export default function CadWorkspace({
     referenceQuery,
     selectedPartIds,
     selectedReferenceIds,
-    stepTreeRootShowMore,
     tabToolMode,
   ]);
 
@@ -4018,7 +4027,6 @@ export default function CadWorkspace({
     setSelectedRenderPartIdByAssemblyPartId({});
     setSelectedWholeEntryCadRefToken("");
     setExpandedStepTreeNodeIds(nextTab.expandedStepTreeNodeIds);
-    setStepTreeRootShowMore(nextTab.stepTreeRootShowMore);
     setFileSheetOpenSectionIds(nextTab.fileSheetOpenSectionIds);
     setHiddenPartIds(nextTab.hiddenPartIds);
     setIsolatedAssemblyNodeIds([]);
@@ -5108,7 +5116,9 @@ export default function CadWorkspace({
     setHoveredListReferenceId,
     setHoveredModelReferenceId,
     assemblyParts,
-    validAssemblyPartIds: validAssemblySelectionIds,
+    validAssemblyPartIds: isAssemblyView && focusedAssemblyNodeIds.length
+      ? treeSelectableAssemblyNodeIds
+      : validAssemblySelectionIds,
     validHiddenPartIds: validAssemblyLeafIds,
     selectedPartIdsRef,
     setSelectedPartIds,
@@ -6472,10 +6482,10 @@ export default function CadWorkspace({
   );
   const cadRefQueryParamsForUrlSignature = useMemo(() => (
     selectedEntry
-      ? [
+      ? uniqueStringList([
           ...(selectedWholeEntryCadRefToken ? [selectedWholeEntryCadRefToken] : []),
           ...canonicalCopySelectionLines
-        ].join("\n")
+        ]).join("\n")
       : ""
   ), [canonicalCopySelectionLines, selectedEntry, selectedWholeEntryCadRefToken]);
 
@@ -6629,13 +6639,19 @@ export default function CadWorkspace({
     cadDirectorySessionBootstrappedRef
   ]);
 
-  const expandStepTreeAroundNode = useCallback((nodeId, { expandSelf = false } = {}) => {
+  const expandStepTreeAroundNode = useCallback((nodeId, {
+    expandSelf = false,
+    includeVisualOnlyAncestors = true
+  } = {}) => {
     const normalizedNodeId = String(nodeId || "").trim();
     const treeRootForExpansion = displayStepTreeRoot || stepTreeRoot;
     if (!normalizedNodeId || !treeRootForExpansion) {
       return;
     }
-    const idsToExpand = collectStepTreeRevealExpansionIds(treeRootForExpansion, normalizedNodeId, { expandSelf });
+    const idsToExpand = collectStepTreeRevealExpansionIds(treeRootForExpansion, normalizedNodeId, {
+      expandSelf,
+      includeVisualOnlyAncestors
+    });
     if (!idsToExpand.length) {
       return;
     }
@@ -7621,13 +7637,16 @@ export default function CadWorkspace({
       setCopyStatus("No selector ref is available for this node");
       return;
     }
+    const wholeStepEntryReference = !topology && !isAssemblyView && normalizedId === STEP_MODEL_ROOT_ID
+      ? buildWholeStepEntryCopyReference(selectedEntry)
+      : null;
     const reference = topology
       ? stepTreeCopyReferenceMap.get(normalizedId) ||
         effectiveActiveReferenceMap.get(normalizedId) ||
         copyReferenceForRawSelectorSelection(normalizedId, "topology") ||
         null
       : null;
-    const partReference = !topology
+    const partReference = !topology && !wholeStepEntryReference
       ? stepTreeCopyReferenceMap.get(normalizedId) ||
         copyReferenceForStepTreeNodeSelection(
           copyableStepTreeNodeForWorkspace({
@@ -7652,6 +7671,7 @@ export default function CadWorkspace({
       : null;
     const { lines } = copyPayloadWithSelectedIdFallback(buildSelectionCopyPayload({
       references: [
+        ...(wholeStepEntryReference ? [wholeStepEntryReference] : []),
         ...(reference ? [reference] : []),
         ...(partReference ? [partReference] : [])
       ],
@@ -7677,6 +7697,7 @@ export default function CadWorkspace({
     assemblyPartMap,
     displayStepTreeRoot,
     effectiveActiveReferenceMap,
+    isAssemblyView,
     selectedEntry,
     stepTreeCopyReferenceMap,
     stepTreeRoot
@@ -8271,53 +8292,18 @@ export default function CadWorkspace({
   ]);
   const activeStepTreeNodeId = selectedPartIds[selectedPartIds.length - 1] ||
     activeReferenceTreeNodeId;
-  const stepTreeRootRevealNodeIds = useMemo(() => uniqueStringList([
-    ...selectedPartIds,
-    activeReferencePartTreeNodeId
-  ]), [
-    activeReferencePartTreeNodeId,
-    selectedPartIds
-  ]);
   useEffect(() => {
     if (!isStepView || !activeReferenceTreeNodeId || activeReferenceTreeNodeId === activeReferencePartTreeNodeId) {
       return;
     }
-    expandStepTreeAroundNode(activeReferenceTreeNodeId);
+    expandStepTreeAroundNode(activeReferenceTreeNodeId, {
+      includeVisualOnlyAncestors: false
+    });
   }, [
     activeReferencePartTreeNodeId,
     activeReferenceTreeNodeId,
     expandStepTreeAroundNode,
     isStepView
-  ]);
-  useEffect(() => {
-    if (!stepTreeRoot || !isStepView) {
-      return;
-    }
-    const rootItemCount = stepTreeNodeChildren(stepTreeRoot).length;
-    if (!isAssemblyView || rootItemCount <= STEP_TREE_ROOT_ITEM_LIMIT) {
-      if (stepTreeRootShowMore) {
-        setStepTreeRootShowMore(false);
-      }
-      return;
-    }
-    if (stepTreeRootShowMore) {
-      return;
-    }
-    const hiddenSelectedNodeId = stepTreeRootRevealNodeIds.find((nodeId) => (
-      stepTreeRootChildIndexForNode(stepTreeRoot, nodeId) >= STEP_TREE_ROOT_ITEM_LIMIT
-    ));
-    if (!hiddenSelectedNodeId) {
-      return;
-    }
-    setStepTreeRootShowMore(true);
-    expandStepTreeAroundNode(hiddenSelectedNodeId, { expandSelf: true });
-  }, [
-    expandStepTreeAroundNode,
-    isAssemblyView,
-    isStepView,
-    stepTreeRoot,
-    stepTreeRootRevealNodeIds,
-    stepTreeRootShowMore
   ]);
   const canUndoDrawing = drawingUndoStack.length > 0;
   const canRedoDrawing = drawingRedoStack.length > 0;
@@ -8432,6 +8418,7 @@ export default function CadWorkspace({
           referenceSelectionDeferred={selectedTopologyDeferredByCost}
           viewPlaneOffsetRight={viewportFrameInsets.right + 16}
           viewerMode={viewerMode}
+          assemblyPickingActive={viewerInAssemblyMode}
           assemblyParts={viewerAssemblyRenderParts}
           hiddenPartIds={viewerHiddenPartIds}
           selectedPartIds={viewerSelectedPartIds}
@@ -8699,8 +8686,6 @@ export default function CadWorkspace({
                 stepTreeRoot={displayStepTreeRoot}
                 assemblyMates={selectedAssemblyMates}
                 expandedTreeNodeIds={expandedStepTreeNodeIds}
-                stepTreeRootShowMore={stepTreeRootShowMore}
-                onStepTreeRootShowMoreChange={setStepTreeRootShowMore}
                 selectedPartIds={selectedPartIds}
                 selectedReferenceIds={selectedReferenceIds}
                 selectedMateIds={selectedMateIds}

--- a/viewer/src/client/components/workbench/CadRenderPane.js
+++ b/viewer/src/client/components/workbench/CadRenderPane.js
@@ -204,6 +204,7 @@ export default function CadRenderPane({
   referenceSelectionDeferred = false,
   viewPlaneOffsetRight = 16,
   viewerMode,
+  assemblyPickingActive = false,
   assemblyParts,
   hiddenPartIds,
   selectedPartIds,
@@ -414,6 +415,7 @@ export default function CadRenderPane({
               topologySelectionUnavailable,
               topologySelectionDeferred,
               viewerMode,
+              assemblyPickingActive,
               focusedPartIds
             })}
           renderPartsIndividually={urdfMode ? true : (renderPartsIndividually || Boolean(resolvedStepParameters?.definition))}

--- a/viewer/src/client/components/workbench/CadWorkspaceTopBar.js
+++ b/viewer/src/client/components/workbench/CadWorkspaceTopBar.js
@@ -3,7 +3,6 @@ import {
   Bot,
   Boxes,
   Check,
-  ChevronDown,
   CircleCheck,
   Code,
   Copy,
@@ -72,22 +71,13 @@ import FileAccessContextMenu from "./FileAccessContextMenu";
 import {
   fileKey,
   listSidebarItems,
-  sidebarDirectoryIdForEntry,
-  sidebarDirectoryPath
 } from "@/workbench/sidebar";
+import {
+  buildBreadcrumbNodes,
+  collapsedBreadcrumbNodes,
+  directoryTitle
+} from "@/workbench/breadcrumbs";
 import viewerPackage from "../../../../package.json";
-
-function collapsedBreadcrumbNodes(nodes) {
-  if (nodes.length <= 4) {
-    return nodes.map((node) => ({ type: "node", node }));
-  }
-
-  return [
-    { type: "node", node: nodes[0] },
-    { type: "ellipsis", label: "...", nodes: nodes.slice(1, -2) },
-    ...nodes.slice(-2).map((node) => ({ type: "node", node }))
-  ];
-}
 
 function fileSheetLabel(fileSheetKind) {
   if (fileSheetKind === "dxf") {
@@ -162,66 +152,6 @@ const ENTRY_ICON_COMPONENTS = {
 
 function iconForEntry(entry, sourceFormat, status) {
   return ENTRY_ICON_COMPONENTS[entryIconKind(entry, { sourceFormat, status })] || Package;
-}
-
-function directoryTitle(directory) {
-  return String(directory?.id || directory?.name || "Directory");
-}
-
-function buildBreadcrumbNodes({
-  directoryTree,
-  selectedEntry,
-  selectedFileLabel,
-  selectedFileTitle
-}) {
-  if (!directoryTree) {
-    if (selectedEntry) {
-      return [{
-        type: "entry",
-        label: selectedFileLabel,
-        title: selectedFileTitle,
-        entry: selectedEntry,
-        menuDirectory: null
-      }];
-    }
-    return [{
-      type: "placeholder",
-      label: selectedFileLabel,
-      title: selectedFileTitle,
-      menuDirectory: null
-    }];
-  }
-
-  if (!selectedEntry) {
-    return [{
-      type: "placeholder",
-      label: selectedFileLabel,
-      title: selectedFileTitle,
-      menuDirectory: directoryTree
-    }];
-  }
-
-  const directoryId = sidebarDirectoryIdForEntry(selectedEntry);
-  const directoryPath = sidebarDirectoryPath(directoryTree, directoryId);
-  const directoryNodes = directoryPath.filter((directory) => String(directory.id || "").trim()).map((directory) => ({
-    type: "directory",
-    id: String(directory.id || ""),
-    label: String(directory.name || "Folder"),
-    title: directoryTitle(directory),
-    directory,
-    menuDirectory: directory
-  }));
-
-  return [
-    ...directoryNodes,
-    {
-      type: "entry",
-      label: selectedFileLabel,
-      title: selectedFileTitle,
-      entry: selectedEntry,
-      menuDirectory: null
-    }
-  ];
 }
 
 function BreadcrumbEntryMenuItem({
@@ -394,6 +324,8 @@ function DropdownMenuScrollArea({ children }) {
 
 function BreadcrumbDirectorySubMenu({
   directory,
+  label = "",
+  title: titleProp = "",
   selectedKey,
   onSelectEntry,
   sidebarLabelForEntry,
@@ -414,7 +346,8 @@ function BreadcrumbDirectorySubMenu({
   onRevealFileAsset,
   onCopyFileAssetReference
 }) {
-  const title = directoryTitle(directory);
+  const labelText = String(label || directory?.name || "Folder");
+  const title = String(titleProp || directoryTitle(directory));
 
   return (
     <DropdownMenuSub>
@@ -423,7 +356,7 @@ function BreadcrumbDirectorySubMenu({
         title={title}
       >
         <Folder className="size-3.5 shrink-0" aria-hidden="true" />
-        <span className="block min-w-0 flex-1 truncate">{String(directory?.name || "Folder")}</span>
+        <span className="block min-w-0 flex-1 truncate">{labelText}</span>
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="w-max max-w-80">
         <DropdownMenuScrollArea>
@@ -483,7 +416,7 @@ function BreadcrumbNodeDropdown({
 }) {
   const label = String(node?.label || "");
   const title = String(node?.title || label);
-  const menuDirectory = node?.type === "directory" || node?.type === "placeholder"
+  const menuDirectory = node?.type === "directory" || node?.type === "placeholder" || node?.type === "entry"
     ? node?.menuDirectory || null
     : null;
   const canBrowse = !!menuDirectory && listSidebarItems(menuDirectory).length > 0;
@@ -527,30 +460,56 @@ function BreadcrumbNodeDropdown({
     );
   }
 
+  const triggerButton = (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex min-w-0 items-center gap-2 rounded-sm text-xs font-medium transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        current
+          ? "max-w-[min(36rem,55vw)] text-foreground"
+          : "max-w-32 text-muted-foreground"
+      )}
+      aria-label={`Browse ${label}`}
+      aria-current={current ? "page" : undefined}
+      title={title}
+      onPointerDown={(event) => {
+        if (event.button !== 0) {
+          event.preventDefault();
+        }
+      }}
+    >
+      <span className="block min-w-0 truncate">{label}</span>
+      {current && node?.type === "entry" ? (
+        <FilenameLoadStatus activity={filenameLoadActivity} />
+      ) : null}
+    </button>
+  );
+  const dropdownTrigger = (
+    <DropdownMenuTrigger asChild>
+      {triggerButton}
+    </DropdownMenuTrigger>
+  );
+  const trigger = node?.type === "entry" && node?.entry ? (
+    <FileAccessContextMenu
+      entry={node.entry}
+      stepSourceStatus={selectedStepSourceStatus}
+      canRevealFileAssets={canRevealFileAssets}
+      canCopyFileAssetLinks={canCopyFileAssetLinks}
+      canCopyFileAssetPaths={canCopyFileAssetPaths}
+      busyKey={fileAccessBusyKey}
+      onDownloadFileAsset={onDownloadFileAsset}
+      onExportImplicitFile={onExportImplicitFile}
+      onRevealFileAsset={onRevealFileAsset}
+      onRevealInExplorerView={onRevealInExplorerView}
+      onCopyFileAssetReference={onCopyFileAssetReference}
+    >
+      {dropdownTrigger}
+    </FileAccessContextMenu>
+  ) : dropdownTrigger;
+
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className={cn(
-            "inline-flex min-w-0 items-center gap-2 rounded-sm text-xs font-medium transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            current
-              ? "max-w-[min(36rem,55vw)] text-foreground"
-              : "max-w-32 text-muted-foreground"
-          )}
-          aria-label={`Browse ${label}`}
-          aria-current={current ? "page" : undefined}
-          title={title}
-        >
-          <span className="block min-w-0 truncate">{label}</span>
-          {current && node?.type === "entry" ? (
-            <FilenameLoadStatus activity={filenameLoadActivity} />
-          ) : null}
-          {node?.type === "placeholder" ? (
-            <ChevronDown className="size-3.5 shrink-0 opacity-70" aria-hidden="true" />
-          ) : null}
-        </button>
-      </DropdownMenuTrigger>
+      {trigger}
       <DropdownMenuContent align="start" sideOffset={6} className="w-max max-w-80">
         <DropdownMenuScrollArea>
           <BreadcrumbDirectoryMenuItems
@@ -622,11 +581,13 @@ function BreadcrumbEllipsisDropdown({
       <DropdownMenuContent align="start" sideOffset={6} className="w-max max-w-80">
         <DropdownMenuScrollArea>
           {hiddenNodes.map((node, index) => {
-            if (node.type === "directory" && node.directory) {
+            if (node.type === "directory" && (node.menuDirectory || node.directory)) {
               return (
                 <BreadcrumbDirectorySubMenu
                   key={`${node.type}:${node.id}:${index}`}
-                  directory={node.directory}
+                  directory={node.menuDirectory || node.directory}
+                  label={node.label}
+                  title={node.title}
                   selectedKey={selectedKey}
                   onSelectEntry={onSelectEntry}
                   sidebarLabelForEntry={sidebarLabelForEntry}

--- a/viewer/src/client/components/workbench/StepFileSheet.js
+++ b/viewer/src/client/components/workbench/StepFileSheet.js
@@ -57,7 +57,6 @@ const treeDepthGuideOffsetPx = 14;
 const treeDepthMaxPx = 128;
 const treeSectionId = "tree";
 const treeRevealScrollPaddingTopPx = 120;
-export const STEP_TREE_ROOT_ITEM_LIMIT = 15;
 const STEP_MODULE_ANIMATION_SPEED_MIN = 0.1;
 const STEP_MODULE_ANIMATION_SPEED_MAX = 3;
 
@@ -538,8 +537,6 @@ export default function StepFileSheet({
   stepTreeRoot,
   assemblyMates = [],
   expandedTreeNodeIds,
-  stepTreeRootShowMore = false,
-  onStepTreeRootShowMoreChange,
   selectedPartIds,
   selectedReferenceIds = [],
   selectedMateIds = [],
@@ -613,17 +610,11 @@ export default function StepFileSheet({
     isAssemblyView ||
     stepTreeNodeId(treeRoot) === STEP_MODEL_ROOT_ID
   );
-  const rootTreeItemCount = elideRootTreeRow ? treeRootChildren.length : 0;
-  const rootTreeHasOverflow = rootTreeItemCount > STEP_TREE_ROOT_ITEM_LIMIT;
-  const showAllRootTreeItems = !rootTreeHasOverflow || stepTreeRootShowMore === true;
-  const hiddenRootTreeItemCount = Math.max(rootTreeItemCount - STEP_TREE_ROOT_ITEM_LIMIT, 0);
   const visibleRows = useMemo(
     () => flattenVisibleStepTreeRows(treeRoot, expandedTreeNodeIds, {
-      omitRoot: elideRootTreeRow,
-      rootChildLimit: STEP_TREE_ROOT_ITEM_LIMIT,
-      showAllRootChildren: showAllRootTreeItems
+      omitRoot: elideRootTreeRow
     }),
-    [elideRootTreeRow, expandedTreeNodeIds, showAllRootTreeItems, treeRoot]
+    [elideRootTreeRow, expandedTreeNodeIds, treeRoot]
   );
   const visibleRowIdsSignature = useMemo(
     () => visibleRows.map((row) => String(row?.id || "")).join("\n"),
@@ -662,11 +653,16 @@ export default function StepFileSheet({
   const activeTreeNodeId = String(activeReferenceTreeRow?.id || rawActiveTreeNodeId || "").trim();
   const activeTreeRow = useMemo(
     () => activeTreeNodeId
-      ? visibleRows.find((row) => String(row?.id || "").trim() === activeTreeNodeId) || null
+      ? visibleRows.find((row) => (
+          String(row?.id || "").trim() === activeTreeNodeId ||
+          String(row?.node?.selectionPartId || "").trim() === activeTreeNodeId
+        )) || null
       : null,
     [activeTreeNodeId, visibleRows]
   );
-  const activeTreeNodeIsTopology = Boolean(topologyTreeRowType(activeTreeRow));
+  const activeTreeNodeIsTopology = activeTreeRow?.node?.visualOnly === true
+    ? false
+    : Boolean(topologyTreeRowType(activeTreeRow));
   const isolateActive = focusedNodeIdSet.size > 0;
   const showTreeVisibilityControls = isAssemblyView === true;
   const treeSectionOpen = Array.isArray(openSectionIds) && openSectionIds.includes(treeSectionId);
@@ -691,6 +687,10 @@ export default function StepFileSheet({
       const rowId = String(row?.id || "").trim();
       if (rowId) {
         map.set(rowId, row);
+      }
+      const selectionRowId = String(row?.node?.selectionPartId || "").trim();
+      if (selectionRowId && !map.has(selectionRowId)) {
+        map.set(selectionRowId, row);
       }
     }
     return map;
@@ -804,9 +804,13 @@ export default function StepFileSheet({
 
               {hasAssemblyTree
                 ? visibleRows.map((row, rowIndex) => {
-                  const topologyType = topologyTreeRowType(row);
+                  const visualOnlyRow = row?.node?.visualOnly === true;
+                  const topologyType = visualOnlyRow ? "" : topologyTreeRowType(row);
                   const topologyRow = Boolean(topologyType);
+                  const rowId = String(row.id || "").trim();
+                  const selectionRowId = String(row.node?.selectionPartId || row.id || "").trim();
                   const topologyReferenceId = String(row.topologyReferenceId || "").trim();
+                  const topologyPartId = topologyRow ? String(row.node?.partId || "").trim() : "";
                   const selectableTopologyRow = Boolean(topologyType) &&
                     topologyReferenceId &&
                     typeof onSelectReferenceNode === "function";
@@ -815,14 +819,21 @@ export default function StepFileSheet({
                   const rowAriaLabel = stepTreeRowAriaLabel(row, topologyType, rowDetail);
                   const selected = topologyRow
                     ? selectedReferenceIdSet.has(topologyReferenceId)
-                    : selectedIds.includes(row.id);
-                  const insideIsolation = !isolatedTreeRowIds || isolatedTreeRowIds.has(String(row.id || "").trim());
-                  const focused = !topologyRow && focusedNodeIdSet.has(String(row.id || "").trim());
+                    : selectedIds.includes(selectionRowId);
+                  const topologyInsideSelectablePart = topologyRow && topologyPartId && (
+                    isolatedTreeRowIds?.has(topologyPartId) ||
+                    focusedNodeIdSet.has(topologyPartId) ||
+                    selectableNodeIdSet?.has(topologyPartId)
+                  );
+                  const insideIsolation = !isolatedTreeRowIds ||
+                    isolatedTreeRowIds.has(rowId) ||
+                    topologyInsideSelectablePart;
+                  const focused = !topologyRow && focusedNodeIdSet.has(rowId);
                   const topologyShapeOfFocusedPart = topologyType === "shape" &&
                     focusedNodeIdSet.has(String(row.node?.partId || "").trim());
                   const selectable = topologyRow
                     ? selectableTopologyRow && insideIsolation && !topologyShapeOfFocusedPart
-                    : insideIsolation && !focused && (!selectableNodeIdSet || selectableNodeIdSet.has(row.id) || selected);
+                    : insideIsolation && !focused && (!selectableNodeIdSet || selectableNodeIdSet.has(selectionRowId) || selected);
                   const hidden = hiddenTreeRowIds.has(String(row.id || "").trim());
                   const isolationMuted = isolateActive && !insideIsolation;
                   const rowSelectionDisabled = treeSelectionDisabled || hidden || !selectable;
@@ -830,7 +841,7 @@ export default function StepFileSheet({
                   const hovered = !hidden && !rowSelectionDisabled && (
                     topologyRow
                       ? topologyReferenceId && normalizedHoveredReferenceId === topologyReferenceId
-                      : hoveredPartId === row.id
+                      : hoveredPartId === selectionRowId
                   );
                   const rowDisabledReason = treeSelectionTitle ||
                     (!selectable
@@ -861,7 +872,7 @@ export default function StepFileSheet({
                     if (topologyRow) {
                       onSelectReferenceNode?.(topologyReferenceId, { multiSelect });
                     } else {
-                      onSelectTreeNode?.(row.id, { multiSelect });
+                      onSelectTreeNode?.(selectionRowId, { multiSelect });
                     }
                   };
                   const handleRowHoverStart = () => {
@@ -874,7 +885,7 @@ export default function StepFileSheet({
                       }
                       return;
                     }
-                    onHoverTreeNode?.(row.id);
+                    onHoverTreeNode?.(selectionRowId);
                   };
                   const handleRowHoverEnd = () => {
                     if (topologyRow) {
@@ -961,7 +972,7 @@ export default function StepFileSheet({
                       .filter(Boolean)
                     : [];
                   const actionNodeIds = !topologyRow
-                    ? (selectedContextNodeIds.length ? selectedContextNodeIds : [String(row.id || "").trim()].filter(Boolean))
+                    ? (selectedContextNodeIds.length ? selectedContextNodeIds : [selectionRowId].filter(Boolean))
                     : [];
                   const actionRows = actionNodeIds
                     .map((nodeId) => visibleRowById.get(nodeId) || null)
@@ -983,7 +994,7 @@ export default function StepFileSheet({
                     typeof onToggleTreeNode !== "function";
                   const collapseAllDisabled = expandedExpandableTreeNodeIds.length < 1 ||
                     typeof onToggleTreeNode !== "function";
-                  const copyReferenceTargetId = topologyRow ? topologyReferenceId : row.id;
+                  const copyReferenceTargetId = topologyRow ? topologyReferenceId : selectionRowId;
                   return (
                     <div key={row.id} className="relative min-w-0 max-w-full">
                       <StepTreeDepthGuides depth={row.depth} />
@@ -997,9 +1008,15 @@ export default function StepFileSheet({
                               ref={(node) => {
                                 if (node) {
                                   rowRefs.current.set(row.id, node);
+                                  if (selectionRowId && selectionRowId !== row.id) {
+                                    rowRefs.current.set(selectionRowId, node);
+                                  }
                                   return;
                                 }
                                 rowRefs.current.delete(row.id);
+                                if (selectionRowId && selectionRowId !== row.id) {
+                                  rowRefs.current.delete(selectionRowId);
+                                }
                               }}
                               role="treeitem"
                               aria-expanded={row.hasChildren ? row.expanded : undefined}
@@ -1302,27 +1319,6 @@ export default function StepFileSheet({
                 </>
               ) : null}
               </div>
-
-              {rootTreeHasOverflow ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    compactButtonClasses,
-                    "mt-1 h-7 w-full justify-start rounded-md px-2 text-[11px] text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-                  )}
-                  onClick={() => {
-                    onStepTreeRootShowMoreChange?.(!showAllRootTreeItems);
-                  }}
-                  aria-expanded={showAllRootTreeItems}
-                  title={showAllRootTreeItems
-                    ? `Show first ${STEP_TREE_ROOT_ITEM_LIMIT} root items`
-                    : `Show ${hiddenRootTreeItemCount} more root ${hiddenRootTreeItemCount === 1 ? "item" : "items"}`}
-                >
-                  <span>{showAllRootTreeItems ? "Show less" : "Show more"}</span>
-                </Button>
-              ) : null}
             </div>
         </FileSheetSection>
 

--- a/viewer/src/client/components/workbench/hooks/useCadWorkspaceSelectors.js
+++ b/viewer/src/client/components/workbench/hooks/useCadWorkspaceSelectors.js
@@ -44,7 +44,8 @@ export function useCadWorkspaceSelectors({
   const isInspectingAssemblyPart =
     isAssemblyView &&
     Boolean(inspectedAssemblyPartId) &&
-    String(inspectedAssemblyPart?.nodeType || "").trim() === "part";
+    String(inspectedAssemblyPart?.nodeType || "").trim() === "part" &&
+    !(Array.isArray(inspectedAssemblyPart?.children) && inspectedAssemblyPart.children.length > 0);
   const inspectedAssemblyPartReferences = useMemo(
     () => (Array.isArray(inspectedAssemblyPartTopologyReferences) ? inspectedAssemblyPartTopologyReferences : []),
     [inspectedAssemblyPartTopologyReferences]

--- a/viewer/src/client/workbench/assemblyIsolation.js
+++ b/viewer/src/client/workbench/assemblyIsolation.js
@@ -80,6 +80,9 @@ export function selectableTreeNodeIdsForIsolation(root, isolatedNodeIds, rootId)
   const validNodeIds = (nodes) => flattenAssemblyNodes(nodes)
     .map((node) => String(node?.id || "").trim())
     .filter((nodeId) => nodeId && nodeId !== rootNodeId);
+  const childNodeIds = (node) => (Array.isArray(node?.children) ? node.children : [])
+    .map((child) => String(child?.id || "").trim())
+    .filter((nodeId) => nodeId && nodeId !== rootNodeId);
   const normalizedIsolatedNodeIds = minimalAssemblyIsolationNodeIds(root, isolatedNodeIds, {
     rootId
   });
@@ -89,10 +92,7 @@ export function selectableTreeNodeIdsForIsolation(root, isolatedNodeIds, rootId)
   const selectable = new Set();
   for (const nodeId of normalizedIsolatedNodeIds) {
     const node = findAssemblyNode(root, nodeId);
-    for (const selectableNodeId of validNodeIds(node)) {
-      if (selectableNodeId === nodeId) {
-        continue;
-      }
+    for (const selectableNodeId of childNodeIds(node)) {
       selectable.add(selectableNodeId);
     }
   }

--- a/viewer/src/client/workbench/assemblyIsolation.test.js
+++ b/viewer/src/client/workbench/assemblyIsolation.test.js
@@ -22,7 +22,13 @@ const root = {
         {
           id: "part_a2",
           nodeType: "part",
-          children: []
+          children: [
+            {
+              id: "part_a2_leaf",
+              nodeType: "part",
+              children: []
+            }
+          ]
         }
       ]
     },
@@ -45,10 +51,14 @@ test("minimal assembly isolation keeps only the highest selected ancestor", () =
   );
 });
 
-test("tree selection during isolate excludes isolate roots but keeps descendants selectable", () => {
+test("tree selection during isolate only keeps direct children selectable", () => {
   assert.deepEqual(
     selectableTreeNodeIdsForIsolation(root, ["assembly_a", "part_a1"], "root"),
     ["part_a1", "part_a2"]
+  );
+  assert.deepEqual(
+    selectableTreeNodeIdsForIsolation(root, ["part_a2"], "root"),
+    ["part_a2_leaf"]
   );
   assert.deepEqual(
     selectableTreeNodeIdsForIsolation(root, ["part_a1", "part_b"], "root"),
@@ -56,6 +66,6 @@ test("tree selection during isolate excludes isolate roots but keeps descendants
   );
   assert.deepEqual(
     selectableTreeNodeIdsForIsolation(root, [], "root"),
-    ["assembly_a", "part_a1", "part_a2", "part_b"]
+    ["assembly_a", "part_a1", "part_a2", "part_a2_leaf", "part_b"]
   );
 });

--- a/viewer/src/client/workbench/breadcrumbs.js
+++ b/viewer/src/client/workbench/breadcrumbs.js
@@ -1,0 +1,93 @@
+import {
+  sidebarDirectoryIdForEntry,
+  sidebarDirectoryPath
+} from "./sidebar.js";
+
+export function collapsedBreadcrumbNodes(nodes) {
+  if (!Array.isArray(nodes) || nodes.length <= 4) {
+    return (Array.isArray(nodes) ? nodes : []).map((node) => ({ type: "node", node }));
+  }
+
+  return [
+    { type: "node", node: nodes[0] },
+    { type: "ellipsis", label: "...", nodes: nodes.slice(1, -2) },
+    ...nodes.slice(-2).map((node) => ({ type: "node", node }))
+  ];
+}
+
+export function directoryTitle(directory) {
+  return String(directory?.id || directory?.name || "Directory");
+}
+
+function parentDirectoryForPath(directoryPath, index) {
+  if (!Array.isArray(directoryPath) || index < 0 || index >= directoryPath.length) {
+    return null;
+  }
+  return index > 0 ? directoryPath[index - 1] : directoryPath[index] || null;
+}
+
+export function buildBreadcrumbNodes({
+  directoryTree,
+  selectedEntry,
+  selectedFileLabel,
+  selectedFileTitle
+}) {
+  if (!directoryTree) {
+    if (selectedEntry) {
+      return [{
+        type: "entry",
+        label: selectedFileLabel,
+        title: selectedFileTitle,
+        entry: selectedEntry,
+        menuDirectory: null
+      }];
+    }
+    return [{
+      type: "placeholder",
+      label: selectedFileLabel,
+      title: selectedFileTitle,
+      menuDirectory: null
+    }];
+  }
+
+  if (!selectedEntry) {
+    return [{
+      type: "placeholder",
+      label: selectedFileLabel,
+      title: selectedFileTitle,
+      menuDirectory: directoryTree
+    }];
+  }
+
+  const directoryId = sidebarDirectoryIdForEntry(selectedEntry);
+  const directoryPath = sidebarDirectoryPath(directoryTree, directoryId);
+  const directoryNodes = directoryPath
+    .map((directory, index) => {
+      const id = String(directory?.id || "").trim();
+      if (!id) {
+        return null;
+      }
+      return {
+        type: "directory",
+        id,
+        label: String(directory?.name || "Folder"),
+        title: directoryTitle(directory),
+        directory,
+        menuDirectory: parentDirectoryForPath(directoryPath, index)
+      };
+    })
+    .filter(Boolean);
+
+  const containingDirectory = directoryPath[directoryPath.length - 1] || directoryTree;
+
+  return [
+    ...directoryNodes,
+    {
+      type: "entry",
+      label: selectedFileLabel,
+      title: selectedFileTitle,
+      entry: selectedEntry,
+      menuDirectory: containingDirectory
+    }
+  ];
+}

--- a/viewer/src/client/workbench/breadcrumbs.test.js
+++ b/viewer/src/client/workbench/breadcrumbs.test.js
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildSidebarDirectoryTree } from "./sidebar.js";
+import {
+  buildBreadcrumbNodes,
+  collapsedBreadcrumbNodes
+} from "./breadcrumbs.js";
+
+test("breadcrumb dropdown directories target adjacent siblings", () => {
+  const selectedEntry = {
+    file: "assemblies/robot/arm/base.step",
+    kind: "part",
+    source: { format: "step", path: "assemblies/robot/arm/base.step" }
+  };
+  const tree = buildSidebarDirectoryTree([
+    selectedEntry,
+    {
+      file: "assemblies/robot/arm/forearm.step",
+      kind: "part",
+      source: { format: "step", path: "assemblies/robot/arm/forearm.step" }
+    },
+    {
+      file: "assemblies/robot/wrist.step",
+      kind: "part",
+      source: { format: "step", path: "assemblies/robot/wrist.step" }
+    },
+    {
+      file: "assemblies/fixtures/clamp.step",
+      kind: "part",
+      source: { format: "step", path: "assemblies/fixtures/clamp.step" }
+    },
+    {
+      file: "benchmarks/block.step",
+      kind: "part",
+      source: { format: "step", path: "benchmarks/block.step" }
+    }
+  ], { rootName: "models" });
+
+  const nodes = buildBreadcrumbNodes({
+    directoryTree: tree,
+    selectedEntry,
+    selectedFileLabel: "base.step",
+    selectedFileTitle: "assemblies/robot/arm/base.step"
+  });
+
+  assert.deepEqual(
+    nodes.map((node) => `${node.type}:${node.id || node.label}`),
+    [
+      "directory:assemblies",
+      "directory:assemblies/robot",
+      "directory:assemblies/robot/arm",
+      "entry:base.step"
+    ]
+  );
+  assert.equal(nodes[0].menuDirectory.id, "");
+  assert.equal(nodes[1].menuDirectory.id, "assemblies");
+  assert.equal(nodes[2].menuDirectory.id, "assemblies/robot");
+  assert.equal(nodes[3].menuDirectory.id, "assemblies/robot/arm");
+  assert.deepEqual(
+    nodes[3].menuDirectory.entries.map((entry) => entry.file).sort(),
+    [
+      "assemblies/robot/arm/base.step",
+      "assemblies/robot/arm/forearm.step"
+    ]
+  );
+});
+
+test("breadcrumb helpers support collapsed paths", () => {
+  const items = collapsedBreadcrumbNodes([
+    { label: "models" },
+    { label: "assemblies" },
+    { label: "robot" },
+    { label: "arm" },
+    { label: "base.step" }
+  ]);
+
+  assert.equal(items.length, 4);
+  assert.equal(items[1].type, "ellipsis");
+  assert.deepEqual(items[1].nodes.map((node) => node.label), ["assemblies", "robot"]);
+});

--- a/viewer/src/client/workbench/referenceSelection.js
+++ b/viewer/src/client/workbench/referenceSelection.js
@@ -1,6 +1,7 @@
 import { buildCadRefToken, parseCadRefSelector, parseCadRefToken, sortCadRefSelectors } from "cadjs/lib/cadRefs.js";
 import { entryReferenceAssetSignature } from "cadjs/lib/entryAssets.js";
 import { buildSelectorRuntime } from "cadjs/lib/selectors/runtime.js";
+import { STEP_MODEL_ROOT_ID } from "cadjs/lib/step/stepTree.js";
 import { cadPathForEntry, fileKey } from "./sidebar.js";
 
 const ASSEMBLY_MATE_SELECTOR_RE = /^m\d+$/;
@@ -534,6 +535,10 @@ export function resolveCadRefSelection({
   const selectedPartIds = [];
   const selectedMateIds = [];
   const expandedAssemblyPartIds = [];
+
+  if (request.hasWholeEntryToken && !isAssemblyView) {
+    selectedPartIds.push(STEP_MODEL_ROOT_ID);
+  }
 
   for (const selector of request.selectors) {
     const parsedSelector = parseCadRefSelector(selector);

--- a/viewer/src/client/workbench/referenceSelection.test.js
+++ b/viewer/src/client/workbench/referenceSelection.test.js
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { STEP_MODEL_ROOT_ID } from "cadjs/lib/step/stepTree.js";
 import {
   buildAssemblyPartCopyText,
   buildAssemblyMateCopyText,
@@ -151,6 +152,18 @@ test("copy helpers merge selector refs and keep plain fallback lines", () => {
   assert.equal(buildSelectionCopyButtonLabel(["#o1.7.1.s1 cube_top_pad solid volume=490"]), "Copy #o1.7.1.s1");
   assert.equal(canonicalCadRefCopyText("#o1.7.1.f4 plane area=35"), "#o1.7.1.f4");
   assert.equal(buildSelectionCopyButtonLabel([]), "Copy refs");
+});
+
+test("whole-entry refs select the single STEP root row", () => {
+  const resolved = resolveCadRefSelection({
+    cadRefs: ["#"],
+    entry: STEP_ENTRY,
+    isAssemblyView: false
+  });
+  assert.equal(resolved.hasWholeEntryToken, true);
+  assert.deepEqual(resolved.selectedPartIds, [STEP_MODEL_ROOT_ID]);
+  assert.deepEqual(resolved.selectedReferenceIds, []);
+  assert.deepEqual(resolved.selectedMateIds, []);
 });
 
 test("selector ref query helpers classify and resolve selected references and parts", () => {

--- a/viewer/src/client/workbench/viewerPickMode.js
+++ b/viewer/src/client/workbench/viewerPickMode.js
@@ -7,6 +7,7 @@ export function viewerPickModeForRenderPane({
   topologySelectionUnavailable = false,
   topologySelectionDeferred = false,
   viewerMode = "",
+  assemblyPickingActive = false,
   focusedPartIds = ""
 } = {}) {
   if (topologySelectionPending || topologySelectionUnavailable || topologySelectionDeferred) {
@@ -15,7 +16,13 @@ export function viewerPickModeForRenderPane({
   if (dxfMode || pathPreviewMode) {
     return VIEWER_PICK_MODE.NONE;
   }
-  if (viewerMode === "assembly" && !String(focusedPartIds || "").trim()) {
+  if (
+    viewerMode === "assembly" &&
+    (
+      assemblyPickingActive ||
+      !String(focusedPartIds || "").trim()
+    )
+  ) {
     return VIEWER_PICK_MODE.ASSEMBLY;
   }
   return VIEWER_PICK_MODE.AUTO;

--- a/viewer/src/client/workbench/viewerPickMode.test.js
+++ b/viewer/src/client/workbench/viewerPickMode.test.js
@@ -21,6 +21,17 @@ test("viewer pick mode switches focused assemblies to topology picking", () => {
   );
 });
 
+test("viewer pick mode keeps focused assemblies pickable when child components are active", () => {
+  assert.equal(
+    viewerPickModeForRenderPane({
+      viewerMode: "assembly",
+      assemblyPickingActive: true,
+      focusedPartIds: "o1.4"
+    }),
+    VIEWER_PICK_MODE.ASSEMBLY
+  );
+});
+
 test("viewer pick mode switches multi-focused assemblies to topology picking", () => {
   assert.equal(
     viewerPickModeForRenderPane({


### PR DESCRIPTION
## Summary

- Update breadcrumb clicks to open sibling dropdowns, remove breadcrumb chevrons, and keep the file breadcrumb context menu on right-click.
- Remove the broken STEP tree "See more" control.
- Fix isolated assembly selection so direct children stay hoverable/selectable, including nested subassemblies.
- Wrap single STEP part faces/edges under a component-style row that is collapsed by default and selectable like normal tree rows.

## Validation

- `npm --prefix packages/cadjs test -- src/lib/step/stepTree.test.js src/lib/assembly/meshData.test.js`
- `npm --prefix viewer run test -- src/client/workbench/referenceSelection.test.js src/client/workbench/breadcrumbs.test.js src/client/workbench/viewerPickMode.test.js src/client/workbench/assemblyIsolation.test.js`
- `npm --prefix viewer run build`
- In-app browser smoke on `base_plate.step` for selected/collapsed wrapper-row behavior.
- Pre-commit hook ran bundle/runtime freshness checks and viewer build during commit.

## Notes

The worktree still has unstaged `models/**` changes from the setup/environment hydration step; they are intentionally not included in this PR.