### PR TITLE
Add --json flag to agent:start for Claude Preview integration

### DIFF
--- a/skills/cad-viewer/SKILL.md
+++ b/skills/cad-viewer/SKILL.md
@@ -67,6 +67,29 @@ rerun the same command with the needed permission/escalation.
 - Do not stop an existing Viewer server unless the user asks.
 - If Viewer startup fails, report the failure and continue with the owning skill's non-GUI validation or artifacts.
 
+## Claude Preview
+
+The viewer port is dynamic — it is chosen at startup and may differ across
+worktrees. To integrate with the Claude Preview tool, add `--json` to the
+`agent:start` command:
+
+```bash
+npm --prefix scripts/viewer run agent:start -- --host 127.0.0.1 --dir <absolute-model-root> --shutdown-after 12h --json
+```
+
+The launcher writes a JSON result line to stdout after the human-readable lines.
+Parse it by taking the last line of stdout that begins with `{`:
+
+```json
+{"url":"http://127.0.0.1:<port>/?dir=<absolute-model-root>","port":<port>,"action":"reuse"}
+```
+
+`action` is `"reuse"` when an existing server was reused and is immediately
+ready, or `"start"` when a new server process was spawned and may still be
+initializing. For a `"start"` result, probe `GET /__cad/server` on the base
+URL (e.g. `http://127.0.0.1:<port>/__cad/server`) until it returns HTTP 200
+before passing the `url` value to the Claude Preview tool.
+
 ## References
 
 - Read `references/development.md` when the user asks to modify, debug, or

--- a/viewer/scripts/start-agent-viewer.mjs
+++ b/viewer/scripts/start-agent-viewer.mjs
@@ -110,6 +110,7 @@ export function parseAgentStartArgs(argv = [], { fsImpl = fs } = {}) {
     directory: "",
     shutdownAfterMs: null,
     portScanLimit: defaultPortScanLimit,
+    jsonResult: false,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -142,6 +143,10 @@ export function parseAgentStartArgs(argv = [], { fsImpl = fs } = {}) {
       options.shutdownAfterMs = parseServerLifetimeMs(value, arg);
       options.forwardedArgs.push(arg, value);
       index += 1;
+      continue;
+    }
+    if (arg === "--json") {
+      options.jsonResult = true;
       continue;
     }
     options.forwardedArgs.push(arg);
@@ -643,6 +648,7 @@ export async function resolveAgentStartLaunch({
       git,
       directory: parsed.directory,
       viewerUrl: agentViewerUrl(portResolution.baseUrl, parsed.directory),
+      jsonResult: parsed.jsonResult,
     };
   }
 
@@ -659,6 +665,7 @@ export async function resolveAgentStartLaunch({
     git,
     directory: parsed.directory,
     viewerUrl: agentViewerUrl(portResolution.baseUrl, parsed.directory),
+    jsonResult: parsed.jsonResult,
     command: buildAgentStartCommand({
       mode,
       packageRoot,
@@ -682,6 +689,9 @@ export async function runAgentStart(options = {}) {
     console.log(`CAD Viewer already running at ${launch.viewerUrl}`);
     console.log(`CAD Viewer URL: ${launch.viewerUrl}`);
     console.log(`CAD Viewer git: ${launch.git || "none"}`);
+    if (launch.jsonResult) {
+      console.log(JSON.stringify({ url: launch.viewerUrl, port: launch.port, action: "reuse" }));
+    }
     return null;
   }
 
@@ -689,6 +699,9 @@ export async function runAgentStart(options = {}) {
   console.log(`Starting CAD Viewer ${command.mode} server at ${launch.viewerUrl}`);
   console.log(`CAD Viewer URL: ${launch.viewerUrl}`);
   console.log(`CAD Viewer git: ${launch.git || "none"}`);
+  if (launch.jsonResult) {
+    console.log(JSON.stringify({ url: launch.viewerUrl, port: launch.port, action: "start" }));
+  }
   const child = spawn(command.command, command.args, {
     cwd: command.cwd,
     env: command.env,

--- a/viewer/scripts/start-agent-viewer.test.mjs
+++ b/viewer/scripts/start-agent-viewer.test.mjs
@@ -56,8 +56,18 @@ test("parseAgentStartArgs consumes launcher mode and preserves server flags", as
       directory,
       shutdownAfterMs: twelveHoursMs,
       portScanLimit: 64,
+      jsonResult: false,
     }
   );
+});
+
+test("parseAgentStartArgs --json sets jsonResult and is not forwarded to the server", async (t) => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "cad-viewer-agent-start-directory-"));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+
+  const result = parseAgentStartArgs(["--dir", directory, "--host", "127.0.0.1", "--json"]);
+  assert.equal(result.jsonResult, true);
+  assert.ok(!result.forwardedArgs.includes("--json"), "--json must not be forwarded to the server");
 });
 
 test("forwardedDefaultRootDir reads and strips default directory flags", () => {


### PR DESCRIPTION
## Summary

- **Problem**: The viewer port is dynamic (scans from 4178 per worktree), so there was no reliable way to hand the viewer URL to `mcp__Claude_Preview__preview_start` — agents had to grep human-readable output.
- **Fix**: Add `--json` flag to `agent:start`. When set, the launcher emits a machine-readable JSON line after the human-readable output: `{"url":"...","port":N,"action":"reuse"|"start"}`.
- **Docs**: Added a `## Claude Preview` section to `skills/cad-viewer/SKILL.md` documenting the flag, the JSON line format, and the `action:"start"` readiness probe pattern (`GET /__cad/server` until HTTP 200).

The `--json` flag is consumed by the launcher and never forwarded to the Vite dev or production server process.

## Test plan

- [ ] `--json` not present → existing output unchanged, no JSON line emitted
- [ ] `--json` present, reuse path → JSON line appears after `CAD Viewer git:` line, after `activateAgentViewerDirectory` confirms server is ready
- [ ] `--json` present, start path → JSON line appears after `CAD Viewer git:` line, before child process spawns
- [ ] CI `Test` job passes (global policy, JS, Python tests)
- [ ] CI `Production Bundle` job rebuilds `plugins/cad/skills/` from source including updated `SKILL.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)