### PR TITLE
Stop hosted viewer catalog reads from tripping Blob abuse mitigation

### DIFF
--- a/viewer/docs/backend.md
+++ b/viewer/docs/backend.md
@@ -102,6 +102,16 @@ deployments construct it in read-only mode: the hosted API reads the catalog and
 serves public Blob assets, but it does not write Blob objects or regenerate STEP
 artifacts.
 
+Hosted catalog reads are deliberately conservative about Blob traffic.
+Sustained per-request fetches of the public catalog URL from shared serverless
+egress IPs trip Vercel's abuse mitigation with intermittent `403 Forbidden`
+responses, so the hosted backend caches the parsed catalog in-function for 60
+seconds (serving the last good catalog if a refresh fails), hosted
+`/__cad/catalog` responses carry `s-maxage`/`stale-while-revalidate`
+cache-control so the Vercel CDN absorbs client polling, and hosted viewer
+builds poll the catalog every 60 seconds instead of the local 2-second
+development cadence.
+
 Expected deployment shape:
 
 - Build the frontend normally.

--- a/viewer/src/client/workbench/cadManifestStore.js
+++ b/viewer/src/client/workbench/cadManifestStore.js
@@ -4,6 +4,9 @@ import {
 } from "./cadViewerDirectorySession.mjs";
 
 const CAD_CATALOG_REFRESH_INTERVAL_MS = 2_000;
+// Hosted catalogs only change when a publish uploads a new catalog.json, so
+// hosted builds poll slowly instead of hammering the serverless catalog route.
+const HOSTED_CAD_CATALOG_REFRESH_INTERVAL_MS = 60_000;
 const CAD_CATALOG_FETCH_TIMEOUT_MS = 10_000;
 const CAD_GENERATION_STATUS_REFRESH_INTERVAL_MS = 750;
 const CAD_DIR_QUERY_PARAM = "dir";
@@ -16,6 +19,12 @@ function viewerAssetBackendFromEnv() {
 
 export function cadViewerUsesHostedCatalog(assetBackend = viewerAssetBackendFromEnv()) {
   return HOSTED_CATALOG_BACKENDS.has(String(assetBackend || "").trim().toLowerCase());
+}
+
+export function cadCatalogRefreshIntervalMs(assetBackend = viewerAssetBackendFromEnv()) {
+  return cadViewerUsesHostedCatalog(assetBackend)
+    ? HOSTED_CAD_CATALOG_REFRESH_INTERVAL_MS
+    : CAD_CATALOG_REFRESH_INTERVAL_MS;
 }
 
 function normalizeCadManifest(manifest) {
@@ -61,7 +70,9 @@ let currentSnapshot = {
 let refreshRequestId = 0;
 let refreshInFlight = null;
 let generationRefreshInFlight = null;
-let generationStatusUnavailable = false;
+// Hosted read-only backends never run local CAD generation, so skip the
+// generation-status route instead of polling it into 501 responses.
+let generationStatusUnavailable = cadViewerUsesHostedCatalog();
 let refreshLoopStarted = false;
 
 currentManifestSignature = JSON.stringify(currentSnapshot.manifest);
@@ -421,7 +432,7 @@ if (typeof window !== "undefined") {
       if (document.visibilityState !== "hidden") {
         refreshSilently();
       }
-    }, CAD_CATALOG_REFRESH_INTERVAL_MS);
+    }, cadCatalogRefreshIntervalMs());
     window.setInterval(() => {
       if (document.visibilityState !== "hidden") {
         refreshCadGenerationStatus();

--- a/viewer/src/client/workbench/cadManifestStore.test.js
+++ b/viewer/src/client/workbench/cadManifestStore.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  cadCatalogRefreshIntervalMs,
   cadViewerUsesHostedCatalog,
   readActiveCadDir
 } from "./cadManifestStore.js";
@@ -81,4 +82,10 @@ test("hosted catalog mode ignores local directory query state", () => {
     setHref("http://viewer.test/?file=robots%2Fnext.step");
     assert.equal(readActiveCadDir({ assetBackend: "vercel-blob" }), "");
   });
+});
+
+test("cadCatalogRefreshIntervalMs slows polling for hosted catalog backends", () => {
+  assert.equal(cadCatalogRefreshIntervalMs("vercel-blob"), 60_000);
+  assert.equal(cadCatalogRefreshIntervalMs("local-fs"), 2_000);
+  assert.equal(cadCatalogRefreshIntervalMs(""), 2_000);
 });

--- a/viewer/src/server/httpHandlers.mjs
+++ b/viewer/src/server/httpHandlers.mjs
@@ -16,10 +16,10 @@ export function contentTypeForStaticAsset(filePath) {
   return STATIC_CONTENT_TYPES.get(path.extname(String(filePath || "")).toLowerCase()) || "";
 }
 
-export function sendJson(res, statusCode, payload) {
+export function sendJson(res, statusCode, payload, { cacheControl = "no-store" } = {}) {
   res.statusCode = statusCode;
   res.setHeader("content-type", "application/json; charset=utf-8");
-  res.setHeader("cache-control", "no-store");
+  res.setHeader("cache-control", cacheControl || "no-store");
   res.end(JSON.stringify(payload));
 }
 
@@ -201,6 +201,7 @@ export function createCadViewerApiMiddleware({
   onCatalogActivated = () => {},
   onDirectoryActivated = () => {},
   rootDir,
+  catalogCacheControl = "",
 } = {}) {
   if (!backend) {
     throw new Error("createCadViewerApiMiddleware requires backend");
@@ -261,7 +262,7 @@ export function createCadViewerApiMiddleware({
         } else if (activeRootDir && typeof backend.resolveRoot === "function") {
           onCatalogActivated(backend.resolveRoot(activeRootDir), { rootDir: activeRootDir, fileRef: activeFileRef });
         }
-        sendJson(res, 200, catalog);
+        sendJson(res, 200, catalog, { cacheControl: catalogCacheControl });
       } catch (error) {
         sendJson(res, 400, {
           error: errorMessage(error),

--- a/viewer/src/server/vercelApi.mjs
+++ b/viewer/src/server/vercelApi.mjs
@@ -39,6 +39,16 @@ export function hostedViewerPublicUrlFromEnv(env = process.env) {
 }
 
 
+// Hosted catalog reads are cached in-function and at the CDN so steady client
+// polling does not hammer the public Blob endpoint; sustained per-request Blob
+// fetches from shared serverless egress IPs trip Vercel's abuse mitigation
+// with intermittent 403s.
+export const HOSTED_CATALOG_CACHE_TTL_MS = 60_000;
+export const HOSTED_CATALOG_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=60, stale-while-revalidate=600, stale-if-error=86400";
+
+let sharedHostedBackend = null;
+
 export function createHostedCadBackendFromEnv(env = process.env) {
   const assetBackend = normalizeViewerAssetBackend(
     envValue(env, "VIEWER_ASSET_BACKEND"),
@@ -50,7 +60,15 @@ export function createHostedCadBackendFromEnv(env = process.env) {
   return createVercelBlobAssetBackend({
     ...vercelBlobConfigFromEnv(env),
     readOnly: true,
+    catalogCacheTtlMs: HOSTED_CATALOG_CACHE_TTL_MS,
   });
+}
+
+function sharedHostedCadBackendFromEnv() {
+  if (!sharedHostedBackend) {
+    sharedHostedBackend = createHostedCadBackendFromEnv();
+  }
+  return sharedHostedBackend;
 }
 
 
@@ -73,7 +91,7 @@ export function buildHostedViewerServerInfo({
 
 export async function handleHostedCadApi(req, res, {
   cadPath,
-  backend = createHostedCadBackendFromEnv(),
+  backend = sharedHostedCadBackendFromEnv(),
   env = process.env,
 } = {}) {
   const normalizedCadPath = String(cadPath || "").trim();
@@ -93,6 +111,7 @@ export async function handleHostedCadApi(req, res, {
       enableStepArtifactBackend: false,
       claimDisabledStepArtifactRoute: true,
       preferFileDownloadRedirects: true,
+      catalogCacheControl: HOSTED_CATALOG_CACHE_CONTROL,
       serverInfo: () => buildHostedViewerServerInfo({ backend, env, rootDir: "" }),
     });
     await middleware(req, res, () => {

--- a/viewer/src/server/vercelApi.test.mjs
+++ b/viewer/src/server/vercelApi.test.mjs
@@ -229,3 +229,39 @@ test("hosted viewer public URL is derived from Vercel system environment", () =>
     "",
   );
 });
+
+test("hosted CAD API serves CDN-cacheable catalog responses and no-store errors", async () => {
+  let failReads = false;
+  const backend = {
+    kind: "vercel-blob",
+    catalogPath: "demo/catalog.json",
+    readCatalog: async () => {
+      if (failReads) {
+        throw new Error("Failed to read Vercel Blob catalog: 403 Forbidden");
+      }
+      return { schemaVersion: 4, entries: [] };
+    },
+  };
+
+  const okRes = createResponse();
+  await handleHostedCadApi({ method: "GET", url: "/api/cad/catalog" }, okRes, {
+    cadPath: "/__cad/catalog",
+    backend,
+    env: { VIEWER_ASSET_BACKEND: "vercel-blob" },
+  });
+  assert.equal(okRes.statusCode, 200);
+  assert.equal(
+    okRes.getHeader("cache-control"),
+    "public, max-age=0, s-maxage=60, stale-while-revalidate=600, stale-if-error=86400",
+  );
+
+  failReads = true;
+  const errorRes = createResponse();
+  await handleHostedCadApi({ method: "GET", url: "/api/cad/catalog" }, errorRes, {
+    cadPath: "/__cad/catalog",
+    backend,
+    env: { VIEWER_ASSET_BACKEND: "vercel-blob" },
+  });
+  assert.equal(errorRes.statusCode, 400);
+  assert.equal(errorRes.getHeader("cache-control"), "no-store");
+});

--- a/viewer/src/server/vercelBlobAssetBackend.mjs
+++ b/viewer/src/server/vercelBlobAssetBackend.mjs
@@ -258,16 +258,20 @@ export function createVercelBlobAssetBackend({
   fetchImpl = globalThis.fetch,
   token = process.env.VIEWER_VERCEL_BLOB_READ_WRITE_TOKEN || process.env.BLOB_READ_WRITE_TOKEN,
   readOnly = false,
+  catalogCacheTtlMs = 0,
 } = {}) {
   const normalizedPrefix = normalizePrefix(prefix);
   const normalizedCatalogPath = joinBlobPath(normalizedPrefix, catalogPath || "catalog.json");
   const resolvedCatalogUrl = catalogUrl || publicBlobUrlForRef(prefix, catalogPath || "catalog.json");
+  let cachedCatalog = null;
+  let cachedCatalogAt = 0;
+  let catalogFetchInFlight = null;
 
   async function blobClient() {
     return loadBlobClient(client);
   }
 
-  async function readCatalog() {
+  async function fetchCatalog() {
     if (resolvedCatalogUrl) {
       return normalizeVercelBlobCatalog(await readJsonFromUrl(resolvedCatalogUrl, { fetchImpl }));
     }
@@ -293,6 +297,38 @@ export function createVercelBlobAssetBackend({
       throw new Error(`Vercel Blob catalog not found: ${normalizedCatalogPath}`);
     }
     return normalizeVercelBlobCatalog(await readJsonFromUrl(catalogBlob.url, { fetchImpl }));
+  }
+
+  async function fetchCatalogCached({ force = false } = {}) {
+    if (!(catalogCacheTtlMs > 0)) {
+      return fetchCatalog();
+    }
+    if (!force && cachedCatalog && Date.now() - cachedCatalogAt < catalogCacheTtlMs) {
+      return cachedCatalog;
+    }
+    if (!catalogFetchInFlight) {
+      catalogFetchInFlight = fetchCatalog().finally(() => {
+        catalogFetchInFlight = null;
+      });
+    }
+    try {
+      const catalog = await catalogFetchInFlight;
+      cachedCatalog = catalog;
+      cachedCatalogAt = Date.now();
+      return catalog;
+    } catch (error) {
+      if (cachedCatalog) {
+        console.warn(
+          `Serving cached Vercel Blob catalog after read failure: ${error instanceof Error ? error.message : String(error)}`
+        );
+        return cachedCatalog;
+      }
+      throw error;
+    }
+  }
+
+  async function readCatalog() {
+    return fetchCatalogCached();
   }
 
   async function writeAsset({ fileRef, body, contentType = "application/octet-stream" } = {}) {
@@ -323,7 +359,7 @@ export function createVercelBlobAssetBackend({
   }
 
   async function refreshCatalog() {
-    return readCatalog();
+    return fetchCatalogCached({ force: true });
   }
 
   async function urlForBlobRef(fileRef) {

--- a/viewer/src/server/vercelBlobAssetBackend.mjs
+++ b/viewer/src/server/vercelBlobAssetBackend.mjs
@@ -221,13 +221,30 @@ async function loadBlobClient(client) {
   }
 }
 
+async function blobErrorDetail(response) {
+  const requestId = normalizeString(response.headers?.get?.("x-vercel-id"));
+  let body = "";
+  try {
+    body = normalizeString(await response.text()).slice(0, 200);
+  } catch {
+    body = "";
+  }
+  return [
+    requestId ? `request ${requestId}` : "",
+    body,
+  ].filter(Boolean).join(": ");
+}
+
 async function readJsonFromUrl(url, { fetchImpl = globalThis.fetch } = {}) {
   if (!fetchImpl) {
     throw new Error("Vercel Blob backend requires fetch to read catalog URLs");
   }
   const response = await fetchImpl(url);
   if (!response.ok) {
-    throw new Error(`Failed to read Vercel Blob catalog: ${response.status} ${response.statusText}`);
+    const detail = await blobErrorDetail(response);
+    throw new Error(
+      `Failed to read Vercel Blob catalog: ${response.status} ${response.statusText}${detail ? ` (${detail})` : ""}`
+    );
   }
   return response.json();
 }

--- a/viewer/src/server/vercelBlobAssetBackend.test.mjs
+++ b/viewer/src/server/vercelBlobAssetBackend.test.mjs
@@ -507,3 +507,116 @@ test("Vercel Blob backend can be constructed read-only for hosted deployments", 
     url: "https://blob.test/models2/catalog.json",
   });
 });
+
+test("Vercel Blob backend caches catalog reads inside the TTL", async () => {
+  const fetchCalls = [];
+  const backend = createVercelBlobAssetBackend({
+    prefix: "demo",
+    catalogUrl: "https://blob.test/demo/catalog.json",
+    catalogCacheTtlMs: 60_000,
+    fetchImpl: async (url) => {
+      fetchCalls.push(url);
+      return {
+        ok: true,
+        json: async () => ({ schemaVersion: 4, entries: [{ file: "parts/bracket.step" }] }),
+      };
+    },
+  });
+
+  const first = await backend.readCatalog();
+  const second = await backend.readCatalog();
+  assert.deepEqual(first, { schemaVersion: 4, entries: [{ file: "parts/bracket.step" }] });
+  assert.equal(second, first);
+  assert.equal(fetchCalls.length, 1);
+});
+
+test("Vercel Blob backend shares one in-flight catalog fetch across concurrent reads", async () => {
+  let fetchCount = 0;
+  let releaseFetch;
+  const fetchGate = new Promise((resolve) => {
+    releaseFetch = resolve;
+  });
+  const backend = createVercelBlobAssetBackend({
+    prefix: "demo",
+    catalogUrl: "https://blob.test/demo/catalog.json",
+    catalogCacheTtlMs: 60_000,
+    fetchImpl: async () => {
+      fetchCount += 1;
+      await fetchGate;
+      return {
+        ok: true,
+        json: async () => ({ schemaVersion: 4, entries: [] }),
+      };
+    },
+  });
+
+  const reads = Promise.all([backend.readCatalog(), backend.readCatalog(), backend.readCatalog()]);
+  releaseFetch();
+  await reads;
+  assert.equal(fetchCount, 1);
+});
+
+test("Vercel Blob backend serves the cached catalog when a refresh fails", async () => {
+  let failFetches = false;
+  let fetchCount = 0;
+  const backend = createVercelBlobAssetBackend({
+    prefix: "demo",
+    catalogUrl: "https://blob.test/demo/catalog.json",
+    catalogCacheTtlMs: 1,
+    fetchImpl: async () => {
+      fetchCount += 1;
+      if (failFetches) {
+        return { ok: false, status: 403, statusText: "Forbidden" };
+      }
+      return {
+        ok: true,
+        json: async () => ({ schemaVersion: 4, entries: [{ file: "parts/bracket.step" }] }),
+      };
+    },
+  });
+
+  const fresh = await backend.readCatalog();
+  failFetches = true;
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  const stale = await backend.readCatalog();
+  assert.equal(stale, fresh);
+  assert.equal(fetchCount, 2);
+});
+
+test("Vercel Blob backend surfaces catalog failures when no cached catalog exists", async () => {
+  const backend = createVercelBlobAssetBackend({
+    prefix: "demo",
+    catalogUrl: "https://blob.test/demo/catalog.json",
+    catalogCacheTtlMs: 60_000,
+    fetchImpl: async () => ({ ok: false, status: 403, statusText: "Forbidden" }),
+  });
+
+  await assert.rejects(
+    () => backend.readCatalog(),
+    /Failed to read Vercel Blob catalog: 403 Forbidden/
+  );
+});
+
+test("Vercel Blob backend refreshCatalog bypasses the catalog TTL cache", async () => {
+  let fetchCount = 0;
+  const backend = createVercelBlobAssetBackend({
+    prefix: "demo",
+    catalogUrl: "https://blob.test/demo/catalog.json",
+    catalogCacheTtlMs: 60_000,
+    fetchImpl: async () => {
+      fetchCount += 1;
+      return {
+        ok: true,
+        json: async () => ({ schemaVersion: 4, entries: [], fetchCount }),
+      };
+    },
+  });
+
+  await backend.readCatalog();
+  const refreshed = await backend.refreshCatalog();
+  assert.equal(refreshed.fetchCount, 2);
+  assert.equal(fetchCount, 2);
+  const cached = await backend.readCatalog();
+  assert.equal(cached, refreshed);
+  assert.equal(fetchCount, 2);
+});


### PR DESCRIPTION
## Problem

demo.cad.fun / demo.cadskills.xyz intermittently showed `CAD catalog unavailable: Failed to read Vercel Blob catalog: 403 Forbidden` even after the Blob prefix/catalog env vars were corrected (a 6-minute probe saw 115/120 requests fail while the same public catalog URL returned 200 elsewhere).

The hosted API fetched the public Blob catalog URL on **every** `/__cad/catalog` invocation, and the viewer client polls that route every 2 seconds (plus `/__cad/generation-status` every 750ms, which always 501s on hosted). That is ~43k robotic fetches/day per open tab from shared serverless egress IPs — a pattern Vercel's abuse/bot mitigation intermittently blocks with 403 at the Blob edge.

## Fix

- **Blob backend catalog cache**: parse-once cache with a 60s TTL and in-flight dedupe; if a refresh fails, serve the last good catalog and log a warning instead of erroring.
- **Backend reuse**: hosted API entrypoints share one backend per function instance so the cache survives across invocations.
- **CDN caching**: hosted `/__cad/catalog` 200s now send `public, max-age=0, s-maxage=60, stale-while-revalidate=600, stale-if-error=86400` so the Vercel edge absorbs client polling without invoking the function; error responses stay `no-store`. Local dev responses are unchanged (`no-store`).
- **Client cadence**: hosted builds (`VIEWER_ASSET_BACKEND=vercel-blob`) poll the catalog every 60s instead of 2s and skip the generation-status route entirely; local dev keeps the 2s cadence.

Net effect: steady-state Blob origin fetches drop from ~0.5/s per tab to at most one per minute per function instance, and brief Blob-edge 403 streaks are masked by the stale-cache + CDN layers.

## Testing

- `npm --prefix viewer run test` — 371/371 pass (new tests cover TTL caching, in-flight dedupe, stale-on-error, refresh bypass, hosted cache-control headers, and hosted polling interval).
- `npm --prefix viewer run build` — clean.
- `scripts/bundle/bundle.sh --check` — all bundle outputs up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
