### PR TITLE
Add orthographic projection mode to CAD Viewer

### DIFF
--- a/packages/cadjs/src/lib/perspective.js
+++ b/packages/cadjs/src/lib/perspective.js
@@ -7,6 +7,24 @@ function normalizePerspectiveMetadataValue(value) {
   return String(value || "").trim();
 }
 
+export const CAMERA_PROJECTION = Object.freeze({
+  PERSPECTIVE: "perspective",
+  ORTHOGRAPHIC: "orthographic"
+});
+
+export function normalizeCameraProjection(value, fallback = CAMERA_PROJECTION.PERSPECTIVE) {
+  const normalizedValue = String(value || "").trim().toLowerCase();
+  if (normalizedValue === CAMERA_PROJECTION.ORTHOGRAPHIC) {
+    return CAMERA_PROJECTION.ORTHOGRAPHIC;
+  }
+  if (normalizedValue === CAMERA_PROJECTION.PERSPECTIVE) {
+    return CAMERA_PROJECTION.PERSPECTIVE;
+  }
+  return fallback === CAMERA_PROJECTION.ORTHOGRAPHIC
+    ? CAMERA_PROJECTION.ORTHOGRAPHIC
+    : CAMERA_PROJECTION.PERSPECTIVE;
+}
+
 export function clonePerspectiveVector(vector) {
   return cloneCameraVector(vector);
 }
@@ -28,6 +46,9 @@ export function clonePerspectiveSnapshot(snapshot) {
   };
   if (Object.prototype.hasOwnProperty.call(snapshot, "zoom")) {
     clonedSnapshot.zoom = normalizeCameraZoom(snapshot.zoom, 1);
+  }
+  if (Object.prototype.hasOwnProperty.call(snapshot, "projection")) {
+    clonedSnapshot.projection = normalizeCameraProjection(snapshot.projection);
   }
   const modelKey = normalizePerspectiveMetadataValue(snapshot.modelKey);
   const sceneScaleMode = normalizePerspectiveMetadataValue(snapshot.sceneScaleMode);
@@ -98,6 +119,7 @@ export function perspectiveSnapshotEqual(a, b, epsilon = 1e-4) {
     perspectiveVectorEqual(a.target, b.target, epsilon) &&
     perspectiveVectorEqual(a.up, b.up, epsilon) &&
     Math.abs(normalizeCameraZoom(a.zoom, 1) - normalizeCameraZoom(b.zoom, 1)) <= epsilon &&
+    normalizeCameraProjection(a.projection) === normalizeCameraProjection(b.projection) &&
     normalizePerspectiveMetadataValue(a.modelKey) === normalizePerspectiveMetadataValue(b.modelKey) &&
     normalizePerspectiveMetadataValue(a.sceneScaleMode) === normalizePerspectiveMetadataValue(b.sceneScaleMode) &&
     normalizePerspectiveMetadataValue(a.coordinateSystem) === normalizePerspectiveMetadataValue(b.coordinateSystem)

--- a/packages/cadjs/src/lib/perspective.test.js
+++ b/packages/cadjs/src/lib/perspective.test.js
@@ -3,6 +3,10 @@ import test from "node:test";
 
 import {
   annotatePerspectiveSnapshot,
+  CAMERA_PROJECTION,
+  clonePerspectiveSnapshot,
+  normalizeCameraProjection,
+  perspectiveSnapshotEqual,
   perspectiveSnapshotMatchesScene,
   resolvePerspectiveSnapshot
 } from "./perspective.js";
@@ -72,5 +76,37 @@ test("perspective snapshots match scene metadata when present", () => {
       coordinateSystem: "cad-z-up-v1"
     }),
     true
+  );
+});
+
+test("perspective snapshots preserve and compare camera projection", () => {
+  assert.equal(normalizeCameraProjection("ORTHOGRAPHIC"), CAMERA_PROJECTION.ORTHOGRAPHIC);
+  assert.equal(normalizeCameraProjection("unknown"), CAMERA_PROJECTION.PERSPECTIVE);
+  assert.equal(normalizeCameraProjection("unknown", CAMERA_PROJECTION.ORTHOGRAPHIC), CAMERA_PROJECTION.ORTHOGRAPHIC);
+
+  assert.deepEqual(
+    clonePerspectiveSnapshot({
+      ...PERSPECTIVE_A,
+      projection: "orthographic"
+    }),
+    {
+      ...PERSPECTIVE_A,
+      projection: CAMERA_PROJECTION.ORTHOGRAPHIC
+    }
+  );
+
+  assert.equal(
+    perspectiveSnapshotEqual(PERSPECTIVE_A, {
+      ...PERSPECTIVE_A,
+      projection: CAMERA_PROJECTION.PERSPECTIVE
+    }),
+    true
+  );
+  assert.equal(
+    perspectiveSnapshotEqual(PERSPECTIVE_A, {
+      ...PERSPECTIVE_A,
+      projection: CAMERA_PROJECTION.ORTHOGRAPHIC
+    }),
+    false
   );
 });

--- a/scripts/bundle/skills/bundle-cad-viewer.sh
+++ b/scripts/bundle/skills/bundle-cad-viewer.sh
@@ -17,7 +17,8 @@ VIEWER_CADPY_DIR="$VIEWER_DIR/packages/cadpy"
 VIEWER_IMPLICITJS_DIR="$VIEWER_DIR/packages/implicitjs"
 RUNTIME_DIR="$REPO_ROOT/skills/cad-viewer/scripts/viewer"
 CHECK_DIR="${CAD_VIEWER_RUNTIME_CHECK_DIR:-${RENDER_VIEWER_RUNTIME_CHECK_DIR:-$REPO_ROOT/tmp/cad-viewer-runtime-check}}"
-ESBUILD_BIN="$VIEWER_DIR/node_modules/.bin/esbuild"
+VIEWER_PACKAGE_MANAGER="${CAD_VIEWER_PACKAGE_MANAGER:-}"
+ESBUILD_BIN="${CAD_VIEWER_ESBUILD_BIN:-}"
 RELEASE_VERSION="$(tr -d '[:space:]' < "$REPO_ROOT/plugins/cad/VERSION")"
 
 usage() {
@@ -33,7 +34,7 @@ Options:
   --check     Bundle into tmp/ and fail if viewer package copies or
               skills/cad-viewer/scripts/viewer are stale.
   --clean     Remove generated package copies and temporary check directories first.
-  --no-build  Reuse the current viewer/dist instead of running npm run build.
+  --no-build  Reuse the current viewer/dist instead of rebuilding the viewer.
               The existing dist must already include client sourcemaps.
   -h, --help  Show this help.
 EOF
@@ -77,6 +78,55 @@ require_command() {
     echo "$1 is required to build the CAD Viewer runtime." >&2
     exit 1
   fi
+}
+
+resolve_viewer_package_manager() {
+  if [ -n "$VIEWER_PACKAGE_MANAGER" ]; then
+    echo "$VIEWER_PACKAGE_MANAGER"
+    return
+  fi
+  if command -v pnpm >/dev/null 2>&1; then
+    echo "pnpm"
+    return
+  fi
+  echo "npm"
+}
+
+run_viewer_build() {
+  local package_manager
+  package_manager="$(resolve_viewer_package_manager)"
+  require_command "$package_manager"
+  case "$package_manager" in
+    pnpm)
+      CI=true pnpm --dir "$VIEWER_DIR" run build --sourcemap true
+      ;;
+    npm)
+      npm --prefix "$VIEWER_DIR" run build -- --sourcemap true
+      ;;
+    *)
+      echo "Unsupported CAD Viewer package manager: $package_manager" >&2
+      echo "Set CAD_VIEWER_PACKAGE_MANAGER to pnpm or npm." >&2
+      exit 1
+      ;;
+  esac
+}
+
+resolve_esbuild_bin() {
+  if [ -n "$ESBUILD_BIN" ]; then
+    echo "$ESBUILD_BIN"
+    return
+  fi
+  if [ -x "$VIEWER_DIR/node_modules/.bin/esbuild" ]; then
+    echo "$VIEWER_DIR/node_modules/.bin/esbuild"
+    return
+  fi
+  local pnpm_esbuild_bin
+  pnpm_esbuild_bin="$(find "$VIEWER_DIR/node_modules/.pnpm" -path '*/node_modules/esbuild/bin/esbuild' -type f -perm -111 -print -quit 2>/dev/null || true)"
+  if [ -n "$pnpm_esbuild_bin" ]; then
+    echo "$pnpm_esbuild_bin"
+    return
+  fi
+  echo "$VIEWER_DIR/node_modules/.bin/esbuild"
 }
 
 require_client_sourcemaps() {
@@ -271,6 +321,20 @@ build_viewer_packages() {
   echo "Bundled ${VIEWER_IMPLICITJS_DIR#$REPO_ROOT/}"
 }
 
+ensure_viewer_cadjs_node_module_subpaths() {
+  local cadjs_node_module="$VIEWER_DIR/node_modules/cadjs"
+  if [ ! -d "$cadjs_node_module" ]; then
+    return
+  fi
+  local subpath
+  for subpath in common lib; do
+    if [ -d "$VIEWER_CADJS_DIR/src/$subpath" ] && [ ! -e "$cadjs_node_module/$subpath/stepSidecars.mjs" ] && [ ! -e "$cadjs_node_module/$subpath/pathUtils.mjs" ]; then
+      rm -rf "$cadjs_node_module/$subpath"
+      ln -s "$VIEWER_CADJS_DIR/src/$subpath" "$cadjs_node_module/$subpath"
+    fi
+  done
+}
+
 check_viewer_packages() {
   check_cadjs_package
   check_cadpy_package
@@ -367,7 +431,7 @@ build_runtime() {
 
   (
     cd "$REPO_ROOT"
-    "$ESBUILD_BIN" "$VIEWER_DIR/src/server/server.mjs" \
+    "$(resolve_esbuild_bin)" "$VIEWER_DIR/src/server/server.mjs" \
       --bundle \
       --format=esm \
       --platform=node \
@@ -403,7 +467,6 @@ check_runtime() {
   echo "CAD Viewer runtime is up to date."
 }
 
-require_command npm
 require_command rsync
 require_path "$CADJS_PACKAGE_DIR/package.json" "cadjs package"
 require_path "$CADJS_PACKAGE_DIR/src" "cadjs source"
@@ -412,7 +475,7 @@ require_path "$CADPY_PACKAGE_DIR/src/cadpy" "cadpy source"
 require_path "$IMPLICITJS_PACKAGE_DIR/package.json" "implicitjs package"
 require_path "$IMPLICITJS_PACKAGE_DIR/src" "implicitjs source"
 require_path "$VIEWER_DIR/package.json" "viewer package"
-require_path "$ESBUILD_BIN" "viewer esbuild binary; run npm install --prefix viewer"
+require_path "$(resolve_esbuild_bin)" "viewer esbuild binary; install viewer dependencies"
 
 if [ "$MODE" = "check" ]; then
   check_viewer_packages
@@ -429,7 +492,8 @@ if [ "$CLEAN" -eq 1 ]; then
 fi
 
 if [ "$BUILD" -eq 1 ]; then
-  npm --prefix "$VIEWER_DIR" run build -- --sourcemap true
+  ensure_viewer_cadjs_node_module_subpaths
+  run_viewer_build
 fi
 
 require_path "$VIEWER_DIR/dist/index.html" "viewer production bundle"

--- a/viewer/src/client/components/CadViewer.js
+++ b/viewer/src/client/components/CadViewer.js
@@ -8,7 +8,9 @@ import { copyImageBlobToClipboard } from "@/ui/clipboard";
 import { triggerBlobDownload } from "@/ui/download";
 import {
   annotatePerspectiveSnapshot,
+  CAMERA_PROJECTION,
   clonePerspectiveSnapshot,
+  normalizeCameraProjection,
   perspectiveSnapshotEqual,
   perspectiveSnapshotMatchesScene,
   resolvePerspectiveSnapshot
@@ -737,6 +739,53 @@ function getFitDistanceForBoundingSphere(camera, radius, sceneScaleMode, frameAs
   return safeRadius / Math.sin(limitingHalfFov);
 }
 
+function runtimeCameraProjection(runtime) {
+  return normalizeCameraProjection(
+    runtime?.projection || (runtime?.camera?.isOrthographicCamera ? CAMERA_PROJECTION.ORTHOGRAPHIC : CAMERA_PROJECTION.PERSPECTIVE)
+  );
+}
+
+function syncRuntimeCameraClipPlanes(runtime, near, far) {
+  for (const camera of [runtime?.perspectiveCamera, runtime?.orthographicCamera].filter(Boolean)) {
+    camera.near = near;
+    camera.far = far;
+    camera.updateProjectionMatrix?.();
+  }
+}
+
+function getOrthographicHalfHeightForBoundingSphere(radius, sceneScaleMode, frameMetrics = {}) {
+  const safeRadius = Math.max(radius * AUTO_ZOOM_PADDING, getSceneScaleSettings(sceneScaleMode).minModelRadius);
+  const frameAspect = Math.max(Number(frameMetrics.aspect) || 1, 1e-3);
+  const viewportHeight = Math.max(Number(frameMetrics.height) || 1, 1);
+  const framedHeight = Math.max(Number(frameMetrics.framedHeight) || viewportHeight, 1);
+  return (safeRadius / Math.min(frameAspect, 1)) * (viewportHeight / framedHeight);
+}
+
+function syncOrthographicCameraFrame(runtime, radius, sceneScaleMode, frameMetrics = null) {
+  const camera = runtime?.orthographicCamera;
+  if (!camera?.isOrthographicCamera) {
+    return;
+  }
+  const metrics = frameMetrics || getViewportFrameMetrics(runtime, runtime?.frameInsetsRef?.current);
+  camera.userData.cadHalfHeight = getOrthographicHalfHeightForBoundingSphere(radius, sceneScaleMode, metrics);
+  runtime.syncCameraViewport?.(camera, metrics.width, metrics.height);
+}
+
+function frameRuntimeCameraForBoundingSphere(runtime, radius, sceneScaleMode, frameMetrics) {
+  const activeCamera = runtime?.camera;
+  const fitCamera = activeCamera?.isPerspectiveCamera
+    ? activeCamera
+    : runtime?.perspectiveCamera || activeCamera;
+  const fitDistance = getFitDistanceForBoundingSphere(fitCamera, radius, sceneScaleMode, frameMetrics.aspect);
+  if (activeCamera?.isOrthographicCamera) {
+    syncOrthographicCameraFrame(runtime, radius, sceneScaleMode, frameMetrics);
+  } else {
+    activeCamera?.updateProjectionMatrix?.();
+  }
+  applyCameraFrameInsets(runtime, runtime?.frameInsetsRef?.current, { updateProjection: false });
+  return fitDistance;
+}
+
 function transitionCameraToBounds(runtime, bounds, sceneScaleMode, frameInsets, {
   durationMs = AUTO_ZOOM_SPEED_MS.DEFAULT,
   easing = AUTO_ZOOM_TRANSITION_EASING,
@@ -749,8 +798,11 @@ function transitionCameraToBounds(runtime, bounds, sceneScaleMode, frameInsets, 
     return false;
   }
   const frameMetrics = getViewportFrameMetrics(runtime, frameInsets);
+  const frameCamera = runtime.camera?.isPerspectiveCamera
+    ? runtime.camera
+    : runtime.perspectiveCamera || runtime.camera;
   const frame = autoZoomFrameForBounds(runtime.THREE, {
-    camera: runtime.camera,
+    camera: frameCamera,
     controls: runtime.controls,
     bounds,
     modelOffset: runtime.modelGroup?.position,
@@ -764,6 +816,9 @@ function transitionCameraToBounds(runtime, bounds, sceneScaleMode, frameInsets, 
   if (!frame) {
     return false;
   }
+  if (runtime.camera?.isOrthographicCamera) {
+    syncOrthographicCameraFrame(runtime, frame.radius, sceneScaleMode, frameMetrics);
+  }
   if (
     runtime.camera.position.distanceToSquared(frame.position) <= 1e-8 &&
     runtime.controls.target.distanceToSquared(frame.target) <= 1e-8 &&
@@ -775,11 +830,53 @@ function transitionCameraToBounds(runtime, bounds, sceneScaleMode, frameInsets, 
     position: [frame.position.x, frame.position.y, frame.position.z],
     target: [frame.target.x, frame.target.y, frame.target.z],
     up: [frame.up.x, frame.up.y, frame.up.z],
-    zoom: frame.zoom
+    zoom: runtime.camera.zoom
   };
   return animate
     ? transitionCameraToPerspectiveSnapshot(runtime, nextPerspective, { durationMs, easing })
     : applyPerspectiveSnapshot(runtime, nextPerspective, { scheduleIdle: false });
+}
+
+function syncRuntimeCameraProjection(runtime, projection, { scheduleIdle = true } = {}) {
+  if (!runtime?.camera || !runtime?.controls) {
+    return false;
+  }
+  const nextProjection = normalizeCameraProjection(projection);
+  const nextCamera = nextProjection === CAMERA_PROJECTION.ORTHOGRAPHIC
+    ? runtime.orthographicCamera
+    : runtime.perspectiveCamera;
+  if (!nextCamera) {
+    return false;
+  }
+  const previousCamera = runtime.camera;
+  if (previousCamera !== nextCamera) {
+    nextCamera.position.copy(previousCamera.position);
+    nextCamera.up.copy(previousCamera.up);
+    nextCamera.near = previousCamera.near;
+    nextCamera.far = previousCamera.far;
+    nextCamera.zoom = Number.isFinite(previousCamera.zoom) && previousCamera.zoom > 0 ? previousCamera.zoom : 1;
+    runtime.camera = nextCamera;
+    runtime.controls.object = nextCamera;
+  }
+  runtime.projection = nextProjection;
+  const frameMetrics = getViewportFrameMetrics(runtime, runtime.frameInsetsRef?.current);
+  if (nextCamera.isOrthographicCamera) {
+    syncOrthographicCameraFrame(
+      runtime,
+      Number.isFinite(Number(runtime.modelRadius)) ? Number(runtime.modelRadius) : 1,
+      runtime.sceneScaleMode,
+      frameMetrics
+    );
+  } else {
+    runtime.syncCameraViewport?.(nextCamera, frameMetrics.width, frameMetrics.height);
+  }
+  applyCameraFrameInsets(runtime, runtime.frameInsetsRef?.current, { updateProjection: false });
+  runtime.controls.update?.();
+  if (scheduleIdle) {
+    runtime.scheduleIdleQuality?.();
+  }
+  runtime.requestRender?.();
+  return true;
 }
 
 function easeInOutCubic(t) {
@@ -816,7 +913,8 @@ function readPerspectiveSnapshot(runtime) {
     position: [runtime.camera.position.x, runtime.camera.position.y, runtime.camera.position.z],
     target: [runtime.controls.target.x, runtime.controls.target.y, runtime.controls.target.z],
     up: [runtime.camera.up.x, runtime.camera.up.y, runtime.camera.up.z],
-    zoom: runtime.camera.zoom
+    zoom: runtime.camera.zoom,
+    projection: runtimeCameraProjection(runtime)
   };
 }
 
@@ -987,6 +1085,9 @@ function applyPerspectiveSnapshot(runtime, perspective, { scheduleIdle = true } 
   }
   cancelCameraTransition(runtime, { scheduleIdle: false });
   clearKeyboardOrbitState(runtime.keyboardOrbitState);
+  if (Object.prototype.hasOwnProperty.call(nextPerspective, "projection")) {
+    syncRuntimeCameraProjection(runtime, nextPerspective.projection, { scheduleIdle: false });
+  }
   runtime.camera.position.set(...nextPerspective.position);
   runtime.controls.target.set(...nextPerspective.target);
   runtime.camera.up.set(...nextPerspective.up);
@@ -1014,6 +1115,9 @@ function transitionCameraToPerspectiveSnapshot(runtime, perspective, {
   }
   cancelCameraTransition(runtime, { scheduleIdle: false });
   clearKeyboardOrbitState(runtime.keyboardOrbitState);
+  if (Object.prototype.hasOwnProperty.call(nextPerspective, "projection")) {
+    syncRuntimeCameraProjection(runtime, nextPerspective.projection, { scheduleIdle: false });
+  }
   const endPosition = new runtime.THREE.Vector3(...nextPerspective.position);
   const endTarget = new runtime.THREE.Vector3(...nextPerspective.target);
   const endUp = new runtime.THREE.Vector3(...nextPerspective.up);
@@ -1477,6 +1581,7 @@ const CadViewer = forwardRef(function CadViewer({
   renderFormat = "",
   perspective = null,
   perspectiveRef = null,
+  projection = CAMERA_PROJECTION.PERSPECTIVE,
   showEdges,
   recomputeNormals,
   theme = BASE_VIEWER_THEME,
@@ -1526,6 +1631,7 @@ const CadViewer = forwardRef(function CadViewer({
 }, ref) {
   const stepParameterRuntime = stepParameters;
   const normalizedSceneScaleMode = normalizeSceneScaleMode(scale || sceneScaleMode);
+  const normalizedProjection = normalizeCameraProjection(projection);
   const meshGeometrySource = meshData?.geometrySource && typeof meshData.geometrySource === "object"
     ? meshData.geometrySource
     : meshData;
@@ -2554,6 +2660,18 @@ const CadViewer = forwardRef(function CadViewer({
     if (!runtime) {
       return;
     }
+    if (!syncRuntimeCameraProjection(runtime, normalizedProjection)) {
+      return;
+    }
+    emitPerspectiveChange(runtime);
+    syncViewPlaneOrientation(runtime);
+  }, [normalizedProjection, viewerReadyTick]);
+
+  useEffect(() => {
+    const runtime = runtimeRef.current;
+    if (!runtime) {
+      return;
+    }
 
     applySceneBackground(runtime, viewerTheme, normalizedThemeSettings.background);
     runtime.renderer.toneMappingExposure = Math.max(normalizedThemeSettings.lighting.toneMappingExposure, 0.05);
@@ -2860,7 +2978,7 @@ const CadViewer = forwardRef(function CadViewer({
 
     clearDisplayedModel();
 
-    const { camera, controls } = runtime;
+    const { controls } = runtime;
     const hasFillRotation = normalizedThemeSettings.materials.cycleColors === true &&
       Array.isArray(normalizedThemeSettings.materials.fillColors) &&
       normalizedThemeSettings.materials.fillColors.length > 1;
@@ -3084,9 +3202,7 @@ const CadViewer = forwardRef(function CadViewer({
     modelGroup.updateMatrixWorld(true);
     edgesGroup.updateMatrixWorld(true);
 
-    camera.near = Math.max(radius / 1200, 0.01);
-    camera.far = Math.max(radius * 600, 2000);
-    camera.updateProjectionMatrix();
+    syncRuntimeCameraClipPlanes(runtime, Math.max(radius / 1200, 0.01), Math.max(radius * 600, 2000));
     applyCameraFrameInsets(runtime, viewportFrameInsetsRef.current, { updateProjection: false });
     controls.minDistance = Math.max(radius / 2200, 0.02);
     controls.maxDistance = Math.max(radius * 140, 50);
@@ -3110,11 +3226,12 @@ const CadViewer = forwardRef(function CadViewer({
         ) {
           cancelCameraTransition(runtime);
           const frameMetrics = getViewportFrameMetrics(runtime, viewportFrameInsetsRef.current);
-          const fitDistance = getFitDistanceForBoundingSphere(camera, radius, normalizedSceneScaleMode, frameMetrics.aspect);
+          const camera = runtime.camera;
+          const fitDistance = frameRuntimeCameraForBoundingSphere(runtime, radius, normalizedSceneScaleMode, frameMetrics);
           const viewDirection = new THREE.Vector3(...DEFAULT_VIEW_DIRECTION).normalize();
           camera.zoom = 1;
           camera.up.set(...WORLD_UP);
-          camera.updateProjectionMatrix();
+          frameRuntimeCameraForBoundingSphere(runtime, radius, normalizedSceneScaleMode, frameMetrics);
           applyCameraFrameInsets(runtime, viewportFrameInsetsRef.current, { updateProjection: false });
           camera.position.copy(viewDirection.multiplyScalar(fitDistance));
           controls.target.set(0, 0, 0);

--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -50,7 +50,10 @@ import {
   displayModeIsWireframe,
   normalizeDisplaySettings
 } from "cadjs/lib/displaySettings";
-import { clonePerspectiveSnapshot } from "cadjs/lib/perspective";
+import {
+  clonePerspectiveSnapshot,
+  normalizeCameraProjection
+} from "cadjs/lib/perspective";
 import {
   ASSET_STATUS,
   DRAWING_TOOL,
@@ -195,6 +198,7 @@ import {
   readCadParam,
   readCadRefQueryParams,
   readNavigationCadRefQueryParams,
+  readViewerProjectionParam,
   selectedEntryKeyFromUrl,
   sidebarDirectoryIdForEntry,
   sidebarLabelForEntry,
@@ -202,6 +206,7 @@ import {
   writeCadDirParam,
   writeCadParam,
   writeCadRefQueryParams,
+  writeViewerProjectionParam,
 } from "@/workbench/sidebar";
 import { buildCadRefToken } from "cadjs/lib/cadRefs.js";
 import {
@@ -1234,6 +1239,11 @@ export default function CadWorkspace({
       typeof nextValue === "function" ? nextValue(current) : nextValue
     ));
   }, []);
+  const updateViewerProjection = useCallback((nextValue) => {
+    const normalizedProjection = normalizeCameraProjection(nextValue);
+    setViewerProjection(normalizedProjection);
+    writeViewerProjectionParam(normalizedProjection);
+  }, []);
   const updateImplicitGraphicsSettings = useCallback((nextValue) => {
     setImplicitGraphicsSettings((current) => normalizeImplicitGraphicsSettings(
       typeof nextValue === "function" ? nextValue(current) : nextValue
@@ -1244,6 +1254,7 @@ export default function CadWorkspace({
   const [fileSheetWidthIsCustom, setFileSheetWidthIsCustom] = useState(readInitialFileSheetWidthIsCustom);
   const [drawingTool, setDrawingTool] = useState(DRAWING_TOOL.FREEHAND);
   const [viewerPerspective, setViewerPerspective] = useState(null);
+  const [viewerProjection, setViewerProjection] = useState(readViewerProjectionParam);
   const [tabToolMode, setTabToolMode] = useState(TAB_TOOL_MODE.REFERENCES);
   const [drawingStrokes, setDrawingStrokes] = useState([]);
   const [drawingUndoStack, setDrawingUndoStack] = useState([]);
@@ -4103,6 +4114,9 @@ export default function CadWorkspace({
   const applyTabRecord = useCallback((tabRecord) => {
     const nextTab = createTabRecord(tabRecord?.key || "", tabRecord || {});
     const nextPerspective = clonePerspectiveSnapshot(nextTab.camera);
+    const nextProjection = nextPerspective && Object.prototype.hasOwnProperty.call(nextPerspective, "projection")
+      ? normalizeCameraProjection(nextPerspective.projection)
+      : readViewerProjectionParam();
     selectedFileSheetKeyRef.current = fileSheetSelectionKeyForTab(nextTab.key);
     setDxfThicknessMm(nextTab.dxfThicknessMm);
     setReferenceQuery(nextTab.referenceQuery);
@@ -4130,6 +4144,7 @@ export default function CadWorkspace({
     setDrawingTool(nextTab.drawingTool);
     activePerspectiveRef.current = nextPerspective;
     setViewerPerspective(nextPerspective);
+    setViewerProjection(nextProjection);
     setDrawingStrokes(nextTab.drawingStrokes);
     setDrawingUndoStack(nextTab.drawingUndoStack);
     setDrawingRedoStack(nextTab.drawingRedoStack);
@@ -4167,6 +4182,7 @@ export default function CadWorkspace({
     setDrawingTool(DRAWING_TOOL.FREEHAND);
     activePerspectiveRef.current = null;
     setViewerPerspective(null);
+    setViewerProjection(readViewerProjectionParam());
     setDrawingStrokes([]);
     setDrawingUndoStack([]);
     setDrawingRedoStack([]);
@@ -6355,6 +6371,11 @@ export default function CadWorkspace({
     viewerRef.current?.setPerspective?.(restoredPerspective, { animate: true });
     activePerspectiveRef.current = restoredPerspective;
     setViewerPerspective(restoredPerspective);
+    if (Object.prototype.hasOwnProperty.call(restoredPerspective, "projection")) {
+      const restoredProjection = normalizeCameraProjection(restoredPerspective.projection);
+      setViewerProjection(restoredProjection);
+      writeViewerProjectionParam(restoredProjection);
+    }
     return true;
   }, []);
   const handleBeginUrdfPosePicker = useCallback(() => {
@@ -8236,6 +8257,13 @@ export default function CadWorkspace({
     const normalizedPerspective = clonePerspectiveSnapshot(nextPerspective);
     if (normalizedPerspective) {
       activePerspectiveRef.current = normalizedPerspective;
+      if (Object.prototype.hasOwnProperty.call(normalizedPerspective, "projection")) {
+        const normalizedProjection = normalizeCameraProjection(normalizedPerspective.projection);
+        if (normalizedProjection !== viewerProjection) {
+          setViewerProjection(normalizedProjection);
+          writeViewerProjectionParam(normalizedProjection);
+        }
+      }
       scheduleActiveFileSessionSave();
     }
     const hasPerspectiveDependentDrawings =
@@ -8251,7 +8279,7 @@ export default function CadWorkspace({
     setDrawingStrokes([]);
     setDrawingUndoStack([]);
     setDrawingRedoStack([]);
-  }, [scheduleActiveFileSessionSave]);
+  }, [scheduleActiveFileSessionSave, viewerProjection]);
 
   useCadWorkspaceShortcuts({
     copyStatus,
@@ -8429,6 +8457,8 @@ export default function CadWorkspace({
         <DisplaySettingsSection
           displaySettings={displaySettings}
           updateDisplaySettings={updateDisplaySettings}
+          viewerProjection={viewerProjection}
+          onViewerProjectionChange={updateViewerProjection}
           clipBounds={selectedMeshData?.bounds || null}
           showClip
         />
@@ -8474,6 +8504,7 @@ export default function CadWorkspace({
           selectedDxfKey={selectedDxfPreviewKey}
           missingFileRef={missingFileRef}
           viewerPerspective={viewerPerspective}
+          viewerProjection={viewerProjection}
           viewerPerspectiveRef={activePerspectiveRef}
           themeSettings={resolvedThemeSettings}
           displaySettings={renderDisplaySettings}

--- a/viewer/src/client/components/viewer/hooks/useViewerRuntime.js
+++ b/viewer/src/client/components/viewer/hooks/useViewerRuntime.js
@@ -125,9 +125,33 @@ export function useViewerRuntime({
 
       const scene = new THREE.Scene();
 
-      const camera = new THREE.PerspectiveCamera(48, width / height, 0.1, 50000);
+      const syncCameraViewport = (targetCamera, nextWidth = width, nextHeight = height) => {
+        if (!targetCamera) {
+          return;
+        }
+        const aspect = Math.max(nextWidth, 1) / Math.max(nextHeight, 1);
+        if (targetCamera.isPerspectiveCamera) {
+          targetCamera.aspect = aspect;
+        } else if (targetCamera.isOrthographicCamera) {
+          const halfHeight = Math.max(Number(targetCamera.userData?.cadHalfHeight) || 120, 1e-3);
+          targetCamera.left = -halfHeight * aspect;
+          targetCamera.right = halfHeight * aspect;
+          targetCamera.top = halfHeight;
+          targetCamera.bottom = -halfHeight;
+        }
+        targetCamera.updateProjectionMatrix?.();
+      };
+
+      const perspectiveCamera = new THREE.PerspectiveCamera(48, width / height, 0.1, 50000);
+      const orthographicCamera = new THREE.OrthographicCamera(-120, 120, 120, -120, 0.1, 50000);
+      orthographicCamera.userData.cadHalfHeight = 120;
+      const camera = perspectiveCamera;
       camera.up.set(0, 0, 1);
       camera.position.set(180, -180, 120);
+      orthographicCamera.up.copy(camera.up);
+      orthographicCamera.position.copy(camera.position);
+      syncCameraViewport(perspectiveCamera, width, height);
+      syncCameraViewport(orthographicCamera, width, height);
 
       const renderer = createWebGlRenderer(THREE);
       renderer.outputColorSpace = THREE.SRGBColorSpace;
@@ -340,7 +364,7 @@ export function useViewerRuntime({
           emitPerspectiveChange(runtimeRef.current);
         }
         const previewOrbitActive = !!runtimeRef.current?.previewOrbitEnabled;
-        renderer.render(scene, camera);
+        renderer.render(scene, runtimeRef.current?.camera || camera);
         const nextActiveFace = getActiveViewPlaneFaceId(runtimeRef.current);
         if (nextActiveFace !== activeViewPlaneFaceRef.current) {
           activeViewPlaneFaceRef.current = nextActiveFace;
@@ -393,8 +417,8 @@ export function useViewerRuntime({
         const h = container.clientHeight || 640;
         applyRenderQuality(interactionState.pixelRatioCap);
         renderer.setSize(w, h);
-        camera.aspect = w / h;
-        camera.updateProjectionMatrix();
+        syncCameraViewport(perspectiveCamera, w, h);
+        syncCameraViewport(orthographicCamera, w, h);
         applyCameraFrameInsets?.(runtimeRef.current, frameInsetsRef?.current, { updateProjection: false });
         syncScreenSpaceLineMaterials();
         syncDrawingCanvasSize(runtimeRef.current);
@@ -531,6 +555,10 @@ export function useViewerRuntime({
         THREE,
         scene,
         camera,
+        perspectiveCamera,
+        orthographicCamera,
+        projection: "perspective",
+        syncCameraViewport,
         renderer,
         Line2,
         LineGeometry,

--- a/viewer/src/client/components/workbench/CadRenderPane.js
+++ b/viewer/src/client/components/workbench/CadRenderPane.js
@@ -192,6 +192,7 @@ export default function CadRenderPane({
   selectedDxfKey,
   missingFileRef = "",
   viewerPerspective,
+  viewerProjection,
   viewerPerspectiveRef,
   themeSettings,
   previewMode,
@@ -393,6 +394,7 @@ export default function CadRenderPane({
           modelKey={activeModelKey}
           renderFormat={renderFormat}
           perspective={viewerPerspective}
+          projection={viewerProjection}
           perspectiveRef={viewerPerspectiveRef}
           showEdges={!gcodeMode}
           recomputeNormals={false}

--- a/viewer/src/client/components/workbench/ThemeSettingsPopover.js
+++ b/viewer/src/client/components/workbench/ThemeSettingsPopover.js
@@ -70,6 +70,10 @@ import {
   normalizeExplodedViewSettings
 } from "cadjs/lib/displaySettings";
 import {
+  CAMERA_PROJECTION,
+  normalizeCameraProjection
+} from "cadjs/lib/perspective";
+import {
   buildStepClipPatch,
   clipAxisBounds,
   clipAxisPosition,
@@ -107,6 +111,11 @@ const DISPLAY_MODE_OPTIONS = [
   { value: CAD_DISPLAY_MODE.HIDDEN_LINES_REMOVED, label: "Lines", title: "Visible lines with hidden lines removed" },
   { value: CAD_DISPLAY_MODE.UNSHADED, label: "Flat", title: "Unshaded flat color" },
   { value: CAD_DISPLAY_MODE.WIREFRAME, label: "Wire", title: "Full wireframe" }
+];
+
+const PROJECTION_MODE_OPTIONS = [
+  { value: CAMERA_PROJECTION.PERSPECTIVE, label: "Perspective", title: "Depth projection with vanishing lines" },
+  { value: CAMERA_PROJECTION.ORTHOGRAPHIC, label: "Orthographic", title: "Parallel projection for CAD inspection" }
 ];
 
 const FLOOR_MODE_OPTIONS = [
@@ -1465,6 +1474,8 @@ function PositionPad({ value, onChange }) {
 export function DisplaySettingsSection({
   displaySettings,
   updateDisplaySettings,
+  viewerProjection = CAMERA_PROJECTION.PERSPECTIVE,
+  onViewerProjectionChange,
   clipBounds = null,
   showClip = false
 }) {
@@ -1504,6 +1515,7 @@ export function DisplaySettingsSection({
       };
     });
   };
+  const normalizedViewerProjection = normalizeCameraProjection(viewerProjection);
   const updateClipAxisOffset = (axis, nextOffset) => {
     const numericOffset = Number(nextOffset);
     const resolvedOffset = Number.isFinite(numericOffset) ? numericOffset : 0;
@@ -1633,6 +1645,14 @@ export function DisplaySettingsSection({
           </>
         ) : null}
       </ControlSubsection>
+
+      <Field label="Projection">
+        <SegmentedControl
+          value={normalizedViewerProjection}
+          onChange={onViewerProjectionChange}
+          options={PROJECTION_MODE_OPTIONS}
+        />
+      </Field>
 
       {showClip ? (
         <ControlSubsection title="Clip" hideFirstSeparator={false}>

--- a/viewer/src/client/workbench/sidebar.js
+++ b/viewer/src/client/workbench/sidebar.js
@@ -1,5 +1,9 @@
 import { buildCadRefToken, parseCadRefToken } from "cadjs/lib/cadRefs.js";
 import {
+  CAMERA_PROJECTION,
+  normalizeCameraProjection
+} from "cadjs/lib/perspective.js";
+import {
   readStoredActiveCadDir,
   rememberActiveCadDir
 } from "./cadViewerDirectorySession.mjs";
@@ -8,6 +12,7 @@ import { normalizeViewerDefaultFile } from "../../shared/viewerConfig.mjs";
 const CAD_DIR_QUERY_PARAM = "dir";
 const CAD_QUERY_PARAM = "file";
 const CAD_REF_QUERY_PARAM = "refs";
+const CAD_PROJECTION_QUERY_PARAM = "projection";
 
 export function fileKey(entry) {
   return String(entry?.file || "").trim();
@@ -154,6 +159,28 @@ export function readCadRefQueryParams() {
   }
   const params = new URLSearchParams(window.location.search);
   return normalizeCadRefQueryParams(params.getAll(CAD_REF_QUERY_PARAM));
+}
+
+export function readViewerProjectionParam() {
+  if (typeof window === "undefined") {
+    return CAMERA_PROJECTION.PERSPECTIVE;
+  }
+  const params = new URLSearchParams(window.location.search);
+  return normalizeCameraProjection(params.get(CAD_PROJECTION_QUERY_PARAM));
+}
+
+export function writeViewerProjectionParam(projection, { history = "replace" } = {}) {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  const normalizedProjection = normalizeCameraProjection(projection);
+  const url = new URL(window.location.href);
+  if (normalizedProjection === CAMERA_PROJECTION.ORTHOGRAPHIC) {
+    url.searchParams.set(CAD_PROJECTION_QUERY_PARAM, normalizedProjection);
+  } else {
+    url.searchParams.delete(CAD_PROJECTION_QUERY_PARAM);
+  }
+  return writeUrl(url, { history });
 }
 
 export function cadRefQueryParamsFromUrl(urlValue, baseUrl = "") {

--- a/viewer/src/client/workbench/sidebar.test.js
+++ b/viewer/src/client/workbench/sidebar.test.js
@@ -15,13 +15,15 @@ import {
   normalizeCadRefQueryParams,
   readCadDirParam,
   readNavigationCadRefQueryParams,
+  readViewerProjectionParam,
   sidebarDirectoryPath,
   sidebarDirectoryIdForEntry,
   sidebarLabelForEntry,
   shouldDeferFileParamSelection,
   writeCadDirParam,
   writeCadParam,
-  writeCadRefQueryParams
+  writeCadRefQueryParams,
+  writeViewerProjectionParam
 } from "./sidebar.js";
 import {
   buildAvailableThemePresets,
@@ -2385,6 +2387,38 @@ test("writeCadRefQueryParams skips unchanged URL replacements", () => {
     writeCadRefQueryParams(["#e1"]);
     assert.equal(calls.length, 1);
     assert.equal(calls[0][2], "/?file=parts%2Fsample_plate.step&refs=e1");
+  } finally {
+    if (originalWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+  }
+});
+
+test("viewer projection query param reads orthographic and omits perspective defaults", () => {
+  const originalWindow = globalThis.window;
+  const calls = [];
+  globalThis.window = {
+    location: {
+      href: "http://viewer.test/?file=parts%2Fsample_plate.step&projection=orthographic&refs=f2",
+      pathname: "/",
+      search: "?file=parts%2Fsample_plate.step&projection=orthographic&refs=f2",
+      hash: ""
+    },
+    history: {
+      replaceState: (...args) => calls.push(args)
+    }
+  };
+
+  try {
+    assert.equal(readViewerProjectionParam(), "orthographic");
+    assert.equal(writeViewerProjectionParam("orthographic"), false);
+    assert.equal(calls.length, 0);
+
+    assert.equal(writeViewerProjectionParam("perspective"), true);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][2], "/?file=parts%2Fsample_plate.step&refs=f2");
   } finally {
     if (originalWindow === undefined) {
       delete globalThis.window;

--- a/viewer/vite.config.mjs
+++ b/viewer/vite.config.mjs
@@ -100,12 +100,19 @@ function findRootPackageSrc(packageDirName) {
 }
 
 function resolveCadJsPackageRoot() {
+  const bundledPackageSrc = path.join(viewerAppRoot, "packages", "cadjs", "src");
+  if (fs.existsSync(bundledPackageSrc)) {
+    return bundledPackageSrc;
+  }
+  const rootPackageSrc = findRootPackageSrc("cadjs");
+  if (rootPackageSrc) {
+    return rootPackageSrc;
+  }
   const installedPackageSrc = path.join(viewerAppRoot, "node_modules", "cadjs", "src");
   if (fs.existsSync(installedPackageSrc)) {
     return installedPackageSrc;
   }
-  const rootPackageSrc = findRootPackageSrc("cadjs");
-  return rootPackageSrc || path.resolve(viewerAppRoot, "../packages/cadjs/src");
+  return path.resolve(viewerAppRoot, "../packages/cadjs/src");
 }
 
 function resolveDirectoryRoot() {


### PR DESCRIPTION
## Summary

Adds an orthographic projection mode to CAD Viewer and exposes it in the Display menu alongside the existing perspective view.

## Changes

- Adds `projection: "perspective" | "orthographic"` support to perspective snapshots.
- Adds a Display > Projection segmented control for Perspective and Orthographic modes.
- Persists orthographic mode through the `?projection=orthographic` URL parameter while omitting the default perspective mode.
- Keeps projection state in file/session camera snapshots and restored tab state.
- Maintains synchronized perspective and orthographic cameras for resize, framing, clip planes, camera transitions, and snapshot restore.
- Updates bundled viewer/runtime resolution support used by the packaged CAD Viewer flow.

## Validation

- `node packages/cadjs/src/lib/perspective.test.js`
- `node viewer/src/client/workbench/sidebar.test.js`
- `node viewer/scripts/run-tests.mjs` (`372` tests: `368` pass, `4` skipped, `0` fail)

## Manual check

- Open CAD Viewer.
- Use Display > Projection to switch between Perspective and Orthographic.
- Confirm `?projection=orthographic` is written only for orthographic mode.
- Reload the viewer and confirm orthographic mode is restored.