### PR TITLE
feat(viewer): feedback loop from CAD Viewer to agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,9 @@ coverage
 *.stp.glb.lock
 tmp/
 
+# CAD Viewer feedback sidecars (local review artifacts)
+*.feedback.json
+*.feedback/
+
 # Local printer credentials
 /bambu-printers.json

--- a/skills/cad-viewer/SKILL.md
+++ b/skills/cad-viewer/SKILL.md
@@ -90,6 +90,47 @@ initializing. For a `"start"` result, probe `GET /__cad/server` on the base
 URL (e.g. `http://127.0.0.1:<port>/__cad/server`) until it returns HTTP 200
 before passing the `url` value to the Claude Preview tool.
 
+## Review Feedback
+
+Users can attach feedback to a model from inside CAD Viewer: select a face,
+edge, or part, open the feedback panel (message icon in the floating toolbar),
+type what is wrong, and submit. Each submission is persisted as a sidecar next to
+the reviewed model, in the same `--dir` model root:
+
+- `<model>.feedback.json` — JSON array, one object appended per submission.
+- `<model>.feedback/<id>.png` — screenshot for that submission (the `screenshot`
+  field is a path relative to the `--dir` model root, not inlined).
+
+Read `<model>.feedback.json` on demand (when the user says they left feedback, or
+when re-reviewing a model) and act on each item. Item shape:
+
+```json
+{
+  "id": "fb-0001",
+  "createdAt": "<ISO8601>",
+  "comment": "this fillet is too sharp",
+  "references": [
+    { "id": "f42", "label": "Face 42", "copyText": "f42",
+      "partId": "...", "entityType": "ADVANCED_FACE", "selectorType": "face" }
+  ],
+  "camera": { "position": {...}, "target": {...}, "up": {...}, "zoom": 1 },
+  "drawingStrokes": [ { "id": "...", "tool": "arrow", "points": [{"x":..,"y":..}] } ],
+  "screenshot": "<model>.feedback/fb-0001.png"
+}
+```
+
+Use `comment` for the user's intent and `references[].copyText` as the exact CAD
+selector token to locate the entity to change. Open the `screenshot` PNG for
+visual context, and use `camera` to reconstruct the exact view if needed. Empty
+`references` means the comment applies to the whole model.
+
+After you have acted on a feedback item, remove it from `<model>.feedback.json`
+(and delete its `screenshot` PNG) so it is not processed again on the next read.
+When every item is handled, delete the empty `<model>.feedback.json` and the
+`<model>.feedback/` directory. Submitting new feedback recreates them. There is
+no automatic notification or cleanup — feedback is only read when asked, and only
+cleared by you once resolved.
+
 ## References
 
 - Read `references/development.md` when the user asks to modify, debug, or

--- a/skills/cad-viewer/SKILL.md
+++ b/skills/cad-viewer/SKILL.md
@@ -100,6 +100,10 @@ the reviewed model, in the same `--dir` model root:
 - `<model>.feedback.json` — JSON array, one object appended per submission.
 - `<model>.feedback/<id>.png` — screenshot for that submission (the `screenshot`
   field is a path relative to the `--dir` model root, not inlined).
+- `<model>.feedback/<id>.strokes.json` — full annotation strokes for that
+  submission, written only when the user drew annotations. `feedback.json`
+  keeps just a `{ count, tools, path }` summary; the raw point arrays live
+  here so they do not bloat context on every read.
 
 Read `<model>.feedback.json` on demand (when the user says they left feedback, or
 when re-reviewing a model) and act on each item. Item shape:
@@ -114,18 +118,24 @@ when re-reviewing a model) and act on each item. Item shape:
       "partId": "...", "entityType": "ADVANCED_FACE", "selectorType": "face" }
   ],
   "camera": { "position": {...}, "target": {...}, "up": {...}, "zoom": 1 },
-  "drawingStrokes": [ { "id": "...", "tool": "arrow", "points": [{"x":..,"y":..}] } ],
+  "drawingStrokes": { "count": 1, "tools": ["arrow"],
+    "path": "<model>.feedback/fb-0001.strokes.json" },
   "screenshot": "<model>.feedback/fb-0001.png"
 }
 ```
 
 Use `comment` for the user's intent and `references[].copyText` as the exact CAD
 selector token to locate the entity to change. Open the `screenshot` PNG for
-visual context, and use `camera` to reconstruct the exact view if needed. Empty
-`references` means the comment applies to the whole model.
+visual context — the annotation strokes are already drawn into it — and use
+`camera` to reconstruct the exact view if needed. Empty `references` means the
+comment applies to the whole model. `drawingStrokes` is a summary; only read the
+full strokes at `drawingStrokes.path` (normalized screen-space points) if you
+need the raw annotation geometry beyond what the screenshot shows. `count` is 0
+and `path` is absent when no annotations were drawn.
 
 After you have acted on a feedback item, remove it from `<model>.feedback.json`
-(and delete its `screenshot` PNG) so it is not processed again on the next read.
+(and delete its `screenshot` PNG and any `drawingStrokes.path` strokes file) so
+it is not processed again on the next read.
 When every item is handled, delete the empty `<model>.feedback.json` and the
 `<model>.feedback/` directory. Submitting new feedback recreates them. There is
 no automatic notification or cleanup — feedback is only read when asked, and only

--- a/viewer/src/client/components/CadViewer.js
+++ b/viewer/src/client/components/CadViewer.js
@@ -2353,6 +2353,16 @@ const CadViewer = forwardRef(function CadViewer({
       const blob = await blobPromise;
       return triggerBlobDownload(blob, { filename });
     },
+    async captureScreenshotBlob() {
+      const runtime = runtimeRef.current;
+      if (!runtime?.renderer || !runtime?.scene || !runtime?.camera) {
+        throw new Error("CAD Viewer not ready");
+      }
+      renderDrawingOverlay();
+      return buildCompositeScreenshotBlob(runtime, drawingCanvasRef.current, {
+        crop: getViewportFrameCrop(runtime, viewportFrameInsetsRef.current)
+      });
+    },
     getPerspective() {
       return readScopedPerspectiveSnapshot(runtimeRef.current, {
         modelKey,

--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -19,6 +19,7 @@ import UrdfFileSheet from "./workbench/UrdfFileSheet";
 import ViewerAlertDialog from "./workbench/ViewerAlertDialog";
 import ViewerLoadingOverlay from "./workbench/ViewerLoadingOverlay";
 import FloatingToolBar from "./workbench/FloatingToolBar";
+import FeedbackPanel from "./workbench/FeedbackPanel";
 import CadWorkspaceTopBar from "./workbench/CadWorkspaceTopBar";
 import CadWorkspaceHome from "./workbench/CadWorkspaceHome";
 import { useCadAssets } from "./workbench/hooks/useCadAssets";
@@ -1246,6 +1247,7 @@ export default function CadWorkspace({
   const [viewerPerspective, setViewerPerspective] = useState(null);
   const [tabToolMode, setTabToolMode] = useState(TAB_TOOL_MODE.REFERENCES);
   const [drawingStrokes, setDrawingStrokes] = useState([]);
+  const [feedbackPanelOpen, setFeedbackPanelOpen] = useState(false);
   const [drawingUndoStack, setDrawingUndoStack] = useState([]);
   const [drawingRedoStack, setDrawingRedoStack] = useState([]);
   const [jointValuesByFileRef, setJointValuesByFileRef] = useState({});
@@ -5175,6 +5177,8 @@ export default function CadWorkspace({
   const {
     currentReferences,
     activeReferenceMap,
+    selectedReferences,
+    selectedParts,
     hoveredReferenceId,
     hoveredPartId,
     visibleReferences
@@ -8663,6 +8667,7 @@ export default function CadWorkspace({
                 drawingStrokes={drawingStrokes}
                 handleEnterPreviewMode={handleEnterPreviewMode}
                 handleScreenshotCopy={handleScreenshotCopy}
+                handleOpenFeedback={() => setFeedbackPanelOpen(true)}
               />
 
               {!previewMode && (directorySelectionActive || (!selectedEntry && !missingFileRef && !fileParamSelectionPending)) ? (
@@ -8976,6 +8981,24 @@ export default function CadWorkspace({
           viewerAlert={viewerAlert}
           previewMode={previewMode}
           setViewerAlertOpen={setViewerAlertOpen}
+        />
+
+        <FeedbackPanel
+          open={feedbackPanelOpen}
+          onOpenChange={setFeedbackPanelOpen}
+          selectedReferences={[
+            ...selectedReferences,
+            ...(selectedParts || []).map((part) => ({
+              id: part.id,
+              label: part.name || part.displayName || part.label || part.id,
+              partId: part.partId || part.id,
+              copyText: part.copyText || part.displaySelector || "",
+              selectorType: "part",
+            })),
+          ]}
+          drawingStrokes={drawingStrokes}
+          getPerspective={() => viewerRef.current?.getPerspective?.()}
+          captureScreenshotBlob={() => viewerRef.current?.captureScreenshotBlob?.()}
         />
       </SidebarInset>
     </SidebarProvider>

--- a/viewer/src/client/components/workbench/FeedbackPanel.jsx
+++ b/viewer/src/client/components/workbench/FeedbackPanel.jsx
@@ -1,0 +1,231 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { fetchFeedback, submitFeedback } from "../../workbench/cadManifestStore";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { ScrollArea } from "../ui/scroll-area";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "../ui/sheet";
+import { Switch } from "../ui/switch";
+import { Textarea } from "../ui/textarea";
+
+const FEEDBACK_REFERENCE_FIELDS = [
+  "id",
+  "label",
+  "summary",
+  "copyText",
+  "partId",
+  "entityType",
+  "selectorType",
+  "displaySelector",
+];
+
+function pickReferenceFields(reference) {
+  const picked = {};
+  for (const field of FEEDBACK_REFERENCE_FIELDS) {
+    const value = String(reference?.[field] || "").trim();
+    if (value) {
+      picked[field] = value;
+    }
+  }
+  return picked;
+}
+
+function blobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = String(reader.result || "");
+      const comma = result.indexOf(",");
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error || new Error("Failed to read screenshot"));
+    reader.readAsDataURL(blob);
+  });
+}
+
+export default function FeedbackPanel({
+  open,
+  onOpenChange,
+  selectedReferences = [],
+  drawingStrokes = [],
+  getPerspective,
+  captureScreenshotBlob,
+}) {
+  const [comment, setComment] = useState("");
+  const [includeScreenshot, setIncludeScreenshot] = useState(true);
+  const [includeAnnotations, setIncludeAnnotations] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [items, setItems] = useState([]);
+
+  const refreshItems = useCallback(async () => {
+    try {
+      setItems(await fetchFeedback());
+    } catch {
+      // Listing is best-effort; submission errors surface separately.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      setError("");
+      refreshItems();
+    }
+  }, [open, refreshItems]);
+
+  const trimmedComment = comment.trim();
+  const hasStrokes = Array.isArray(drawingStrokes) && drawingStrokes.length > 0;
+
+  const handleSubmit = useCallback(async () => {
+    if (!trimmedComment || submitting) {
+      return;
+    }
+    setSubmitting(true);
+    setError("");
+    setNotice("");
+    try {
+      let screenshotBase64 = "";
+      let screenshotMissing = false;
+      if (includeScreenshot && typeof captureScreenshotBlob === "function") {
+        try {
+          const blob = await captureScreenshotBlob();
+          if (blob) {
+            screenshotBase64 = await blobToBase64(blob);
+          } else {
+            screenshotMissing = true;
+          }
+        } catch {
+          // Screenshot is optional context; keep the comment + references.
+          screenshotMissing = true;
+        }
+      }
+      let camera = null;
+      if (typeof getPerspective === "function") {
+        try {
+          camera = getPerspective() || null;
+        } catch {
+          camera = null;
+        }
+      }
+      await submitFeedback({
+        comment: trimmedComment,
+        references: selectedReferences.map(pickReferenceFields),
+        camera,
+        drawingStrokes: includeAnnotations && hasStrokes ? drawingStrokes : [],
+        screenshotBase64,
+      });
+      setComment("");
+      setNotice(screenshotMissing ? "Submitted — no screenshot could be captured for this view." : "");
+      await refreshItems();
+    } catch (submitError) {
+      setError(submitError?.message || "Failed to submit feedback");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    captureScreenshotBlob,
+    drawingStrokes,
+    getPerspective,
+    hasStrokes,
+    includeAnnotations,
+    includeScreenshot,
+    refreshItems,
+    selectedReferences,
+    submitting,
+    trimmedComment,
+  ]);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>Feedback</SheetTitle>
+          <SheetDescription>
+            Describe what is wrong with the current selection. Saved next to the model for the agent to read.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-4 px-4">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground">
+              {selectedReferences.length
+                ? `Selected (${selectedReferences.length})`
+                : "No selection — comment applies to the whole model"}
+            </span>
+            {selectedReferences.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {selectedReferences.map((reference) => (
+                  <Badge key={reference.id} variant="secondary">
+                    {reference.label || reference.copyText || reference.id}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <Textarea
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            placeholder="e.g. this fillet is too sharp, the hole should be 6mm…"
+            rows={4}
+            autoFocus
+          />
+
+          <label className="flex items-center justify-between gap-3 text-sm">
+            <span>Attach screenshot</span>
+            <Switch checked={includeScreenshot} onCheckedChange={setIncludeScreenshot} />
+          </label>
+          <label className="flex items-center justify-between gap-3 text-sm">
+            <span>
+              Include annotations{hasStrokes ? ` (${drawingStrokes.length})` : ""}
+            </span>
+            <Switch
+              checked={includeAnnotations && hasStrokes}
+              onCheckedChange={setIncludeAnnotations}
+              disabled={!hasStrokes}
+            />
+          </label>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {notice && <p className="text-sm text-muted-foreground">{notice}</p>}
+
+          {items.length > 0 && (
+            <div className="flex min-h-0 flex-1 flex-col gap-1.5">
+              <span className="text-xs font-medium text-muted-foreground">
+                Previous feedback ({items.length})
+              </span>
+              <ScrollArea className="min-h-0 flex-1 rounded-md border">
+                <ul className="flex flex-col divide-y">
+                  {items.map((item) => (
+                    <li key={item.id} className="flex flex-col gap-1 p-2 text-sm">
+                      <span className="font-medium">{item.comment}</span>
+                      {Array.isArray(item.references) && item.references.length > 0 && (
+                        <span className="text-xs text-muted-foreground">
+                          {item.references.map((reference) => reference.label || reference.copyText || reference.id).join(", ")}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </ScrollArea>
+            </div>
+          )}
+        </div>
+
+        <SheetFooter>
+          <Button onClick={handleSubmit} disabled={!trimmedComment || submitting}>
+            {submitting ? "Submitting…" : "Submit feedback"}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/viewer/src/client/components/workbench/FloatingToolBar.js
+++ b/viewer/src/client/components/workbench/FloatingToolBar.js
@@ -1,6 +1,7 @@
 import {
   Crosshair,
   Focus,
+  MessageSquarePlus,
   MousePointer2,
   Orbit,
   Pause,
@@ -50,7 +51,8 @@ function DesktopFloatingToolBar({
   canRedoDrawing,
   drawingStrokes,
   handleEnterPreviewMode,
-  handleScreenshotCopy
+  handleScreenshotCopy,
+  handleOpenFeedback
 }) {
   const dxfMode = renderFormat === RENDER_FORMAT.DXF;
   const implicitMode = renderFormat === RENDER_FORMAT.IMPLICIT;
@@ -148,6 +150,15 @@ function DesktopFloatingToolBar({
           >
             <Focus className="size-3.5" strokeWidth={2} aria-hidden="true" />
           </ToolbarButton>
+
+          {handleOpenFeedback ? (
+            <ToolbarButton
+              label="Give feedback"
+              onClick={() => handleOpenFeedback()}
+            >
+              <MessageSquarePlus className="size-3.5" strokeWidth={2} aria-hidden="true" />
+            </ToolbarButton>
+          ) : null}
         </div>
       </TooltipProvider>
 

--- a/viewer/src/client/workbench/cadManifestStore.js
+++ b/viewer/src/client/workbench/cadManifestStore.js
@@ -351,6 +351,65 @@ export async function requestStepArtifactGeneration(fileRef, { signal } = {}) {
   return payload;
 }
 
+export async function fetchFeedback({ signal } = {}) {
+  if (typeof window === "undefined") {
+    return [];
+  }
+  const response = await fetch(cadApiUrl("/__cad/feedback", { includeFile: true }), {
+    method: "GET",
+    cache: "no-store",
+    signal,
+  });
+  if (response.status === 501) {
+    return [];
+  }
+  if (!response.ok) {
+    throw new Error(await readJsonError(
+      response,
+      `Failed to load feedback: ${response.status} ${response.statusText}`
+    ));
+  }
+  const payload = await response.json();
+  return Array.isArray(payload?.feedback) ? payload.feedback : [];
+}
+
+export async function submitFeedback({
+  comment,
+  references = [],
+  camera = null,
+  drawingStrokes = [],
+  screenshotBase64 = "",
+  signal,
+} = {}) {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  const trimmedComment = String(comment || "").trim();
+  if (!trimmedComment) {
+    throw new Error("Feedback requires a comment");
+  }
+  const response = await fetch(cadApiUrl("/__cad/feedback", { includeFile: true }), {
+    method: "POST",
+    cache: "no-store",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      comment: trimmedComment,
+      references,
+      camera,
+      drawingStrokes,
+      screenshot: screenshotBase64,
+    }),
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(await readJsonError(
+      response,
+      `Failed to submit feedback: ${response.status} ${response.statusText}`
+    ));
+  }
+  return response.json();
+}
+
 export async function requestStepSourceStatus(fileRef, { signal } = {}) {
   if (typeof window === "undefined") {
     return null;

--- a/viewer/src/server/catalog/cadDirectoryScanner.mjs
+++ b/viewer/src/server/catalog/cadDirectoryScanner.mjs
@@ -1268,7 +1268,7 @@ function createSingleAssetEntry({ repoRoot, rootPath, sourcePath, extension }) {
 }
 
 function shouldSkipDirectory(name) {
-  return VIEWER_SKIPPED_DIRECTORIES.has(name) || isHiddenDirectoryName(name) || isPerStepViewerDirectoryName(name) || isPerUrdfViewerDirectoryName(name);
+  return VIEWER_SKIPPED_DIRECTORIES.has(name) || isHiddenDirectoryName(name) || isPerStepViewerDirectoryName(name) || isPerUrdfViewerDirectoryName(name) || String(name || "").endsWith(".feedback");
 }
 
 function scanPathIncluded(includePath, rootPath, entryPath, isDirectory) {

--- a/viewer/src/server/httpHandlers.mjs
+++ b/viewer/src/server/httpHandlers.mjs
@@ -573,6 +573,50 @@ export function createCadViewerApiMiddleware({
       }
       return;
     }
+    if (requestUrl.pathname === "/__cad/feedback") {
+      const method = String(req.method || "GET").toUpperCase();
+      if (typeof backend.appendFeedback !== "function" || typeof backend.readFeedback !== "function") {
+        sendJson(res, 501, {
+          error: "Feedback is only available for the local filesystem CAD Viewer backend",
+        });
+        return;
+      }
+      if (method === "GET") {
+        try {
+          sendJson(res, 200, {
+            ok: true,
+            feedback: backend.readFeedback({ rootDir: activeRootDir, fileRef: activeFileRef }),
+          });
+        } catch (error) {
+          sendJson(res, error?.statusCode || 400, { ok: false, error: errorMessage(error) });
+        }
+        return;
+      }
+      if (method !== "POST") {
+        res.setHeader("allow", "GET, POST");
+        sendJson(res, 405, { error: "Use GET or POST for CAD Viewer feedback" });
+        return;
+      }
+      try {
+        // Screenshots are base64 PNGs; the default 256KB body cap is too small.
+        const body = await readJsonBody(req, { limitBytes: 8 * 1024 * 1024 });
+        const result = backend.appendFeedback({
+          rootDir: activeRootDir,
+          fileRef: activeFileRef,
+          item: {
+            comment: body.comment,
+            references: body.references,
+            camera: body.camera,
+            drawingStrokes: body.drawingStrokes,
+          },
+          screenshotBase64: body.screenshot || "",
+        });
+        sendJson(res, 200, result);
+      } catch (error) {
+        sendJson(res, error?.statusCode || 400, { ok: false, error: errorMessage(error) });
+      }
+      return;
+    }
     next();
   };
 }

--- a/viewer/src/server/httpHandlers.test.mjs
+++ b/viewer/src/server/httpHandlers.test.mjs
@@ -673,3 +673,83 @@ test("CAD Viewer API middleware rejects non-filesystem STEP artifact backends", 
     error: "STEP artifact generation requires a local filesystem CAD Viewer backend",
   });
 });
+
+test("CAD Viewer API middleware appends feedback via POST", async () => {
+  const calls = [];
+  const middleware = createCadViewerApiMiddleware({
+    backend: {
+      readFeedback: () => [],
+      appendFeedback: (request) => {
+        calls.push(request);
+        return { ok: true, id: "fb-0001", item: { id: "fb-0001" } };
+      },
+    },
+  });
+  const req = createJsonRequest({
+    method: "POST",
+    url: "/__cad/feedback?dir=/models&file=box.step",
+    body: { comment: "too sharp", references: [{ id: "f1" }], screenshot: "iVBORw0KGgo=" },
+  });
+  const res = createResponse();
+
+  await middleware(req, res, () => {
+    throw new Error("next should not be called");
+  });
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(JSON.parse(res.body), { ok: true, id: "fb-0001", item: { id: "fb-0001" } });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].fileRef, "box.step");
+  assert.equal(calls[0].item.comment, "too sharp");
+  assert.equal(calls[0].screenshotBase64, "iVBORw0KGgo=");
+});
+
+test("CAD Viewer API middleware reads feedback via GET", async () => {
+  const middleware = createCadViewerApiMiddleware({
+    backend: {
+      readFeedback: () => [{ id: "fb-0001", comment: "too sharp" }],
+      appendFeedback: () => ({ ok: true }),
+    },
+  });
+  const req = { method: "GET", url: "/__cad/feedback?dir=/models&file=box.step" };
+  const res = createResponse();
+
+  await middleware(req, res, () => {
+    throw new Error("next should not be called");
+  });
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(JSON.parse(res.body), {
+    ok: true,
+    feedback: [{ id: "fb-0001", comment: "too sharp" }],
+  });
+});
+
+test("CAD Viewer API middleware rejects non-GET/POST feedback methods", async () => {
+  const middleware = createCadViewerApiMiddleware({
+    backend: { readFeedback: () => [], appendFeedback: () => ({ ok: true }) },
+  });
+  const req = { method: "DELETE", url: "/__cad/feedback" };
+  const res = createResponse();
+
+  await middleware(req, res, () => {
+    throw new Error("next should not be called");
+  });
+
+  assert.equal(res.statusCode, 405);
+  assert.equal(res.getHeader("allow"), "GET, POST");
+});
+
+test("CAD Viewer API middleware reports 501 when feedback is unsupported", async () => {
+  const middleware = createCadViewerApiMiddleware({
+    backend: { readCatalog: async () => ({ schemaVersion: 4, entries: [] }) },
+  });
+  const req = { method: "GET", url: "/__cad/feedback" };
+  const res = createResponse();
+
+  await middleware(req, res, () => {
+    throw new Error("next should not be called");
+  });
+
+  assert.equal(res.statusCode, 501);
+});

--- a/viewer/src/server/localAssetBackend.mjs
+++ b/viewer/src/server/localAssetBackend.mjs
@@ -980,6 +980,116 @@ export function createLocalAssetBackend({
     };
   }
 
+  // Feedback sidecars live next to the model as `<model>.feedback.json` plus a
+  // `<model>.feedback/` directory of screenshots. They are not served CAD assets,
+  // so they cannot go through `writeAsset` (its `isServedCadAsset` gate rejects
+  // `.json`/`.png`). These helpers do their own inside-root validation instead.
+  function resolveFeedbackPaths(fileRef, resolvedRoot) {
+    const filePath = filePathFromRef(fileRef, resolvedRoot);
+    if (!filePath) {
+      throw new Error("Missing model path for feedback");
+    }
+    const jsonPath = `${filePath}.feedback.json`;
+    const dirPath = `${filePath}.feedback`;
+    if (!pathIsInside(jsonPath, resolvedRoot.rootPath) || !pathIsInside(dirPath, resolvedRoot.rootPath)) {
+      const error = new Error("Feedback writes must stay inside the active CAD Viewer root");
+      error.statusCode = 403;
+      throw error;
+    }
+    const relativeBase = relativeFileRef(resolvedRoot.rootPath, filePath);
+    return { filePath, jsonPath, dirPath, relativeBase };
+  }
+
+  function parseFeedbackFile(jsonPath, { strict = false } = {}) {
+    let raw;
+    try {
+      raw = fs.readFileSync(jsonPath, "utf8");
+    } catch {
+      return [];
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      if (strict) {
+        // Refuse to silently overwrite an unreadable sidecar — that would
+        // destroy any prior feedback the agent has not yet handled.
+        const corruptError = new Error("Existing feedback file is not valid JSON");
+        corruptError.statusCode = 409;
+        throw corruptError;
+      }
+      return [];
+    }
+  }
+
+  function readFeedback({ rootDir = defaultRootDir, fileRef = "", resolvedRoot = resolveRequestRoot({ rootDir }) } = {}) {
+    const { jsonPath } = resolveFeedbackPaths(fileRef, resolvedRoot);
+    return parseFeedbackFile(jsonPath);
+  }
+
+  function nextFeedbackId(existing) {
+    let max = 0;
+    for (const entry of existing) {
+      const match = /^fb-(\d+)$/.exec(String(entry?.id || ""));
+      if (match) {
+        max = Math.max(max, Number(match[1]));
+      }
+    }
+    return `fb-${String(max + 1).padStart(4, "0")}`;
+  }
+
+  function decodeScreenshot(screenshotBase64) {
+    const raw = String(screenshotBase64 || "").replace(/^data:[^;,]*;base64,/, "").trim();
+    if (!raw) {
+      return null;
+    }
+    const buffer = Buffer.from(raw, "base64");
+    if (buffer.length === 0) {
+      throw new Error("Screenshot payload is not valid base64");
+    }
+    return buffer;
+  }
+
+  function appendFeedback({
+    rootDir = defaultRootDir,
+    fileRef = "",
+    item = {},
+    screenshotBase64 = "",
+    resolvedRoot = resolveRequestRoot({ rootDir }),
+  } = {}) {
+    const { jsonPath, dirPath, relativeBase } = resolveFeedbackPaths(fileRef, resolvedRoot);
+    const comment = String(item?.comment || "").trim();
+    if (!comment) {
+      const error = new Error("Feedback requires a comment");
+      error.statusCode = 400;
+      throw error;
+    }
+    const existing = parseFeedbackFile(jsonPath, { strict: true });
+    const id = nextFeedbackId(existing);
+    const screenshotBuffer = decodeScreenshot(screenshotBase64);
+    const nextItem = {
+      id,
+      createdAt: new Date().toISOString(),
+      comment,
+      references: Array.isArray(item?.references) ? item.references : [],
+      camera: item?.camera ?? null,
+      drawingStrokes: Array.isArray(item?.drawingStrokes) ? item.drawingStrokes : [],
+      screenshot: null,
+    };
+    if (screenshotBuffer) {
+      fs.mkdirSync(dirPath, { recursive: true });
+      fs.writeFileSync(path.join(dirPath, `${id}.png`), screenshotBuffer);
+      nextItem.screenshot = `${relativeBase}.feedback/${id}.png`;
+    }
+    const nextFeedback = [...existing, nextItem];
+    fs.mkdirSync(path.dirname(jsonPath), { recursive: true });
+    // Write-then-rename so a crash mid-write cannot corrupt the sidecar.
+    const tmpPath = `${jsonPath}.tmp`;
+    fs.writeFileSync(tmpPath, `${JSON.stringify(nextFeedback, null, 2)}\n`);
+    fs.renameSync(tmpPath, jsonPath);
+    return { ok: true, id, item: nextItem };
+  }
+
   return {
     kind: "local-fs",
     canGenerateStepArtifacts: true,
@@ -1007,6 +1117,8 @@ export function createLocalAssetBackend({
     entryForSourcePath,
     assetPathForFileRef,
     writeAsset,
+    readFeedback,
+    appendFeedback,
     contentTypeForPath,
   };
 }

--- a/viewer/src/server/localAssetBackend.mjs
+++ b/viewer/src/server/localAssetBackend.mjs
@@ -1050,6 +1050,17 @@ export function createLocalAssetBackend({
     return buffer;
   }
 
+  function summarizeStrokes(strokes) {
+    const tools = [];
+    for (const stroke of strokes) {
+      const tool = stroke?.tool;
+      if (typeof tool === "string" && tool && !tools.includes(tool)) {
+        tools.push(tool);
+      }
+    }
+    return { count: strokes.length, tools };
+  }
+
   function appendFeedback({
     rootDir = defaultRootDir,
     fileRef = "",
@@ -1067,19 +1078,33 @@ export function createLocalAssetBackend({
     const existing = parseFeedbackFile(jsonPath, { strict: true });
     const id = nextFeedbackId(existing);
     const screenshotBuffer = decodeScreenshot(screenshotBase64);
+    const strokes = Array.isArray(item?.drawingStrokes) ? item.drawingStrokes : [];
     const nextItem = {
       id,
       createdAt: new Date().toISOString(),
       comment,
       references: Array.isArray(item?.references) ? item.references : [],
       camera: item?.camera ?? null,
-      drawingStrokes: Array.isArray(item?.drawingStrokes) ? item.drawingStrokes : [],
+      // Keep only a lightweight summary inline: the annotation is already
+      // visible in the screenshot, and the raw point arrays would bloat the
+      // agent's context on every feedback read. Full strokes go to a sibling
+      // sidecar, loaded on demand only when projecting annotations.
+      drawingStrokes: summarizeStrokes(strokes),
       screenshot: null,
     };
-    if (screenshotBuffer) {
+    if (screenshotBuffer || strokes.length > 0) {
       fs.mkdirSync(dirPath, { recursive: true });
+    }
+    if (screenshotBuffer) {
       fs.writeFileSync(path.join(dirPath, `${id}.png`), screenshotBuffer);
       nextItem.screenshot = `${relativeBase}.feedback/${id}.png`;
+    }
+    if (strokes.length > 0) {
+      fs.writeFileSync(
+        path.join(dirPath, `${id}.strokes.json`),
+        `${JSON.stringify(strokes, null, 2)}\n`
+      );
+      nextItem.drawingStrokes.path = `${relativeBase}.feedback/${id}.strokes.json`;
     }
     const nextFeedback = [...existing, nextItem];
     fs.mkdirSync(path.dirname(jsonPath), { recursive: true });

--- a/viewer/src/server/localAssetBackend.test.mjs
+++ b/viewer/src/server/localAssetBackend.test.mjs
@@ -641,3 +641,84 @@ test("local backend writes only served CAD assets inside the active root", async
     );
   });
 });
+
+test("local backend appends feedback sidecars next to the model", async () => {
+  await withTempDirectoryRoot((directoryRoot) => {
+    const modelRoot = path.join(directoryRoot, "models");
+    fs.mkdirSync(modelRoot, { recursive: true });
+    fs.writeFileSync(path.join(modelRoot, "box.step"), "ISO-10303-21;\n");
+    const backend = createLocalAssetBackend({ directoryRoot, rootDir: "models" });
+
+    assert.deepEqual(backend.readFeedback({ fileRef: "box.step" }), []);
+
+    const first = backend.appendFeedback({
+      fileRef: "box.step",
+      item: {
+        comment: "this fillet is too sharp",
+        references: [{ id: "f42", label: "Face 42", copyText: "f42" }],
+        camera: { position: { x: 1, y: 2, z: 3 } },
+        drawingStrokes: [{ id: "s1", tool: "arrow", points: [{ x: 1, y: 2 }] }],
+      },
+      screenshotBase64: "data:image/png;base64,iVBORw0KGgo=",
+    });
+
+    assert.equal(first.ok, true);
+    assert.equal(first.id, "fb-0001");
+    assert.equal(first.item.screenshot, "box.step.feedback/fb-0001.png");
+    assert.equal(
+      fs.existsSync(path.join(modelRoot, "box.step.feedback", "fb-0001.png")),
+      true
+    );
+
+    const second = backend.appendFeedback({
+      fileRef: "box.step",
+      item: { comment: "hole should be 6mm" },
+    });
+    assert.equal(second.id, "fb-0002");
+    assert.equal(second.item.screenshot, null);
+
+    const feedback = backend.readFeedback({ fileRef: "box.step" });
+    assert.equal(feedback.length, 2);
+    assert.equal(feedback[0].comment, "this fillet is too sharp");
+    assert.equal(feedback[0].references[0].copyText, "f42");
+    assert.equal(feedback[1].comment, "hole should be 6mm");
+    assert.match(feedback[0].createdAt, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+test("local backend rejects feedback that escapes the active root and empty comments", async () => {
+  await withTempDirectoryRoot((directoryRoot) => {
+    fs.mkdirSync(path.join(directoryRoot, "models"), { recursive: true });
+    const backend = createLocalAssetBackend({ directoryRoot, rootDir: "models" });
+
+    assert.throws(
+      () => backend.appendFeedback({ fileRef: "../escape.step", item: { comment: "nope" } }),
+      /inside the active CAD Viewer root/
+    );
+    assert.throws(
+      () => backend.appendFeedback({ fileRef: "box.step", item: { comment: "   " } }),
+      /requires a comment/
+    );
+  });
+});
+
+test("local backend refuses to overwrite a corrupt feedback sidecar and ids from max", async () => {
+  await withTempDirectoryRoot((directoryRoot) => {
+    const modelRoot = path.join(directoryRoot, "models");
+    fs.mkdirSync(modelRoot, { recursive: true });
+    const backend = createLocalAssetBackend({ directoryRoot, rootDir: "models" });
+
+    fs.writeFileSync(path.join(modelRoot, "box.step.feedback.json"), "{ not json");
+    assert.throws(
+      () => backend.appendFeedback({ fileRef: "box.step", item: { comment: "x" } }),
+      /not valid JSON/
+    );
+
+    fs.writeFileSync(
+      path.join(modelRoot, "box.step.feedback.json"),
+      JSON.stringify([{ id: "fb-0007", comment: "old" }])
+    );
+    const appended = backend.appendFeedback({ fileRef: "box.step", item: { comment: "new" } });
+    assert.equal(appended.id, "fb-0008");
+  });
+});

--- a/viewer/src/server/localAssetBackend.test.mjs
+++ b/viewer/src/server/localAssetBackend.test.mjs
@@ -669,6 +669,21 @@ test("local backend appends feedback sidecars next to the model", async () => {
       fs.existsSync(path.join(modelRoot, "box.step.feedback", "fb-0001.png")),
       true
     );
+    // Full strokes go to a sibling sidecar; feedback.json keeps a summary only.
+    assert.deepEqual(first.item.drawingStrokes, {
+      count: 1,
+      tools: ["arrow"],
+      path: "box.step.feedback/fb-0001.strokes.json",
+    });
+    assert.deepEqual(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(modelRoot, "box.step.feedback", "fb-0001.strokes.json"),
+          "utf8"
+        )
+      ),
+      [{ id: "s1", tool: "arrow", points: [{ x: 1, y: 2 }] }]
+    );
 
     const second = backend.appendFeedback({
       fileRef: "box.step",
@@ -676,6 +691,11 @@ test("local backend appends feedback sidecars next to the model", async () => {
     });
     assert.equal(second.id, "fb-0002");
     assert.equal(second.item.screenshot, null);
+    assert.deepEqual(second.item.drawingStrokes, { count: 0, tools: [] });
+    assert.equal(
+      fs.existsSync(path.join(modelRoot, "box.step.feedback", "fb-0002.strokes.json")),
+      false
+    );
 
     const feedback = backend.readFeedback({ fileRef: "box.step" });
     assert.equal(feedback.length, 2);


### PR DESCRIPTION
This was super useful to me so decided to make it a PR
## What

Adds a feedback loop from CAD Viewer back to the agent. In the Viewer, select a
face / edge / part, type what's wrong, and submit. Feedback persists as a sidecar
next to the model that the agent reads on demand and acts on — closing the
review loop without re-describing the part in chat.

## How it works

Submission writes, in the same `--dir` model root:

- `<model>.feedback.json` — array, one object appended per submission
- `<model>.feedback/<id>.png` — screenshot for that submission (path relative to the model root)

Item shape: `comment`, `references[]` (selected faces/edges/parts with
`copyText` selector tokens + `partId`), `camera`, `drawingStrokes`, `screenshot`.
The agent reads the JSON, opens the screenshot, acts on the comment + selectors,
then removes handled items (documented convention — no auto-cleanup).

## Changes

- **server** — `readFeedback` / `appendFeedback` on the local-fs backend:
  inside-root guard, atomic write, id-from-max, strict read that refuses to
  clobber a corrupt file; `GET`/`POST /__cad/feedback` (8 MB body cap for
  screenshots); skip `<model>.feedback/` dirs in the catalog scanner.
- **client** — `FeedbackPanel` (selection chips, comment, screenshot/annotation
  toggles, previous-feedback list) wired into `CadWorkspace` + a floating-toolbar
  button; captures selected references **and** parts, camera, and a screenshot.
  `captureScreenshotBlob()` added to the `CadViewer` imperative handle;
  `submitFeedback` / `fetchFeedback` store helpers.
- **docs** — `cad-viewer` SKILL "Review Feedback" section incl. the clear-on-done convention.
- gitignore the local feedback sidecars; backend + endpoint tests.


## Test plan

- `node --test viewer/src/server/{localAssetBackend,httpHandlers}.test.mjs` — 51 pass
- `npm --prefix viewer run build` — clean
- `scripts/bundle/bundle.sh --check` — up to date · symlink layout valid
- Manual: select parts → comment → submit → sidecar written with refs + highlighted screenshot; agent read + acted (blue / oval / fillet) end-to-end.
