### PR TITLE
[codex] Fix viewer orbit preview speed

### DIFF
--- a/viewer/src/client/components/CadViewer.js
+++ b/viewer/src/client/components/CadViewer.js
@@ -3147,6 +3147,7 @@ const CadViewer = forwardRef(function CadViewer({
     }
     clearKeyboardOrbitState(runtime.keyboardOrbitState);
     runtime.previewOrbitEnabled = !!previewMode;
+    runtime.orbitControlsLastTimestamp = 0;
     runtime.controls.autoRotate = !!previewMode;
     runtime.controls.autoRotateSpeed = PREVIEW_AUTO_ROTATE_SPEED;
     runtime.controls.enabled = true;

--- a/viewer/src/client/components/ImplicitCadViewer.js
+++ b/viewer/src/client/components/ImplicitCadViewer.js
@@ -21,6 +21,7 @@ import {
   normalizeImplicitGraphicsSettings
 } from "@/workbench/implicitGraphicsSettings";
 import ViewPlaneControl from "./viewer/ViewPlaneControl";
+import { updateOrbitControls } from "./viewer/orbitControls.js";
 
 const INTERACTION_IDLE_DELAY_MS = 140;
 const DEFAULT_DAMPING_FACTOR = 0.14;
@@ -809,6 +810,7 @@ const ImplicitCadViewer = forwardRef(function ImplicitCadViewer({
     if (!runtime?.controls) {
       return;
     }
+    runtime.orbitControlsLastTimestamp = 0;
     runtime.controls.autoRotate = !!previewMode;
     runtime.controls.autoRotateSpeed = 1.0;
     runtime.requestRender?.();
@@ -972,6 +974,7 @@ const ImplicitCadViewer = forwardRef(function ImplicitCadViewer({
       controls,
       cameraTransition: null,
       renderQueued: false,
+      orbitControlsLastTimestamp: 0,
       keyboardOrbitState,
       graphicsSettings: graphicsSettingsRef.current,
       dynamicRenderActive: dynamicRenderActiveRef.current,
@@ -1051,7 +1054,7 @@ const ImplicitCadViewer = forwardRef(function ImplicitCadViewer({
       runtime.renderQueued = false;
       const transitionActive = stepCameraTransition(runtime, timestamp);
       const keyboardOrbitMoved = stepKeyboardOrbit(runtime, timestamp);
-      const controlsActive = controls?.update?.();
+      const controlsActive = updateOrbitControls(controls, timestamp, runtime);
       if (keyboardOrbitMoved) {
         emitPerspectiveChange();
       }
@@ -1208,6 +1211,7 @@ const ImplicitCadViewer = forwardRef(function ImplicitCadViewer({
     }
     refineImplicitFitRef.current?.(model);
     if (controls) {
+      runtime.orbitControlsLastTimestamp = 0;
       controls.autoRotate = !!previewMode;
       controls.autoRotateSpeed = 1.0;
     }

--- a/viewer/src/client/components/viewer/hooks/useViewerRuntime.js
+++ b/viewer/src/client/components/viewer/hooks/useViewerRuntime.js
@@ -10,6 +10,7 @@ import {
 import {
   resolveInteractionPixelRatioCap
 } from "cadjs/lib/viewer/renderQuality";
+import { updateOrbitControls } from "../orbitControls.js";
 
 function createWebGlRenderer(THREE) {
   return createCadWebGlRenderer(THREE, {
@@ -359,7 +360,7 @@ export function useViewerRuntime({
         }
         const cameraTransitionActive = stepCameraTransition(runtimeRef.current, timestamp);
         const keyboardOrbitMoved = stepKeyboardOrbit(runtimeRef.current, timestamp);
-        const needsMoreFrames = controls.update();
+        const needsMoreFrames = updateOrbitControls(controls, timestamp, runtimeRef.current);
         if (cameraTransitionActive || keyboardOrbitMoved) {
           emitPerspectiveChange(runtimeRef.current);
         }
@@ -602,6 +603,7 @@ export function useViewerRuntime({
         vertexPickThreshold: 0.9,
         cameraTransition: null,
         previewOrbitEnabled: false,
+        orbitControlsLastTimestamp: 0,
         preserveInteractionPixelRatio: preserveInteractionPixelRatio === true,
         interactionState,
         keyboardOrbitState,

--- a/viewer/src/client/components/viewer/orbitControls.js
+++ b/viewer/src/client/components/viewer/orbitControls.js
@@ -1,0 +1,35 @@
+const MAX_ORBIT_DELTA_SECONDS = 0.05;
+
+function finiteTimestamp(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+export function orbitControlsDeltaSeconds(timestamp, previousTimestamp) {
+  const current = finiteTimestamp(timestamp);
+  const previous = finiteTimestamp(previousTimestamp);
+  if (current === null || previous === null || previous <= 0 || current <= previous) {
+    return null;
+  }
+  return Math.min((current - previous) / 1000, MAX_ORBIT_DELTA_SECONDS);
+}
+
+export function updateOrbitControls(controls, timestamp, state) {
+  if (!controls || typeof controls.update !== "function") {
+    return false;
+  }
+
+  if (!controls.autoRotate) {
+    if (state) {
+      state.orbitControlsLastTimestamp = 0;
+    }
+    return controls.update();
+  }
+
+  const current = finiteTimestamp(timestamp);
+  const deltaSeconds = orbitControlsDeltaSeconds(current, state?.orbitControlsLastTimestamp);
+  if (state) {
+    state.orbitControlsLastTimestamp = current ?? 0;
+  }
+  return deltaSeconds === null ? controls.update() : controls.update(deltaSeconds);
+}

--- a/viewer/src/client/components/viewer/orbitControls.test.js
+++ b/viewer/src/client/components/viewer/orbitControls.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  orbitControlsDeltaSeconds,
+  updateOrbitControls
+} from "./orbitControls.js";
+
+test("orbitControlsDeltaSeconds converts animation timestamps from ms to seconds", () => {
+  assert.equal(orbitControlsDeltaSeconds(1016, 1000), 0.016);
+});
+
+test("orbitControlsDeltaSeconds clamps long frame gaps", () => {
+  assert.equal(orbitControlsDeltaSeconds(2000, 1000), 0.05);
+});
+
+test("updateOrbitControls passes seconds while auto-rotate is active", () => {
+  const updateArgs = [];
+  const controls = {
+    autoRotate: true,
+    update(...args) {
+      updateArgs.push(args);
+      return true;
+    }
+  };
+  const state = { orbitControlsLastTimestamp: 1000 };
+
+  assert.equal(updateOrbitControls(controls, 1016, state), true);
+  assert.deepEqual(updateArgs, [[0.016]]);
+  assert.equal(state.orbitControlsLastTimestamp, 1016);
+});
+
+test("updateOrbitControls resets timing when auto-rotate is inactive", () => {
+  const updateArgs = [];
+  const controls = {
+    autoRotate: false,
+    update(...args) {
+      updateArgs.push(args);
+      return false;
+    }
+  };
+  const state = { orbitControlsLastTimestamp: 1016 };
+
+  assert.equal(updateOrbitControls(controls, 1032, state), false);
+  assert.deepEqual(updateArgs, [[]]);
+  assert.equal(state.orbitControlsLastTimestamp, 0);
+});


### PR DESCRIPTION
## Summary

Fixes the CAD Viewer orbit preview spinning too quickly by making the auto-rotate path use elapsed animation-frame seconds instead of the OrbitControls fixed-frame fallback.

## Details

- Added a small shared orbit-controls helper that converts requestAnimationFrame timestamps from milliseconds to seconds and clamps long frame gaps.
- Wired CAD and implicit viewers through that helper so preview orbit speed is stable across high-refresh displays and after toggling preview mode.
- Added focused unit coverage for timestamp conversion, clamping, and auto-rotate timing reset behavior.

## Root Cause

Three.js OrbitControls treats `update()` without a delta as a fixed 60fps step. On displays or render loops that tick faster than 60Hz, preview auto-rotate advances too much per real second.

## Validation

- `npm --prefix viewer test`
- `npm --prefix viewer run build`
- `scripts/dev/setup-symlinks.sh --check`
- `scripts/bundle/bundle.sh --check`