### PR TITLE
[codex] Fix SRDF group state control loops

### DIFF
--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -172,9 +172,10 @@ import {
   buildUrdfJointAnglesCopyText,
   cloneJointValueMap,
   emptyUrdfPosePickerState,
+  findBestMatchingJointValueState,
   interpolateTrajectoryJointValues,
-  jointValueSubsetClose,
   normalizePoint3,
+  srdfHomeGroupStateJointValuesToDisplay,
   srdfGroupStateJointValuesToDisplay
 } from "@/workbench/robotMotionControls";
 import {
@@ -238,6 +239,7 @@ import {
   interpolateUrdfJointValues,
   jointValueMapsClose,
   URDF_JOINT_ANIMATION_DURATION_MS,
+  URDF_JOINT_ANIMATION_EPSILON,
   URDF_JOINT_ANIMATION_FOLLOW_MS
 } from "cadjs/lib/urdf/jointAnimation";
 import { checkMoveIt2ServerLive, moveit2ServerEnabled, requestMoveIt2Server } from "cadjs/lib/urdf/moveit2ServerClient";
@@ -1629,7 +1631,10 @@ export default function CadWorkspace({
     ? fileKey(selectedEntry)
     : "";
   const defaultSelectedUrdfJointValues = useMemo(
-    () => buildDefaultUrdfJointValues(selectedUrdfData),
+    () => ({
+      ...buildDefaultUrdfJointValues(selectedUrdfData),
+      ...srdfHomeGroupStateJointValuesToDisplay(selectedUrdfData)
+    }),
     [selectedUrdfData]
   );
   const storedSelectedUrdfJointValues = useMemo(() => {
@@ -1685,9 +1690,13 @@ export default function CadWorkspace({
   );
   const matchedSelectedUrdfGroupStateId = useMemo(
     () => (
-      selectedUrdfGroupStates.find((state) => jointValueSubsetClose(selectedUrdfJointValues, state.jointValuesByName))?.id || ""
+      findBestMatchingJointValueState(
+        selectedUrdfGroupStates,
+        selectedUrdfJointValues,
+        defaultSelectedUrdfJointValues
+      )?.id || ""
     ),
-    [selectedUrdfJointValues, selectedUrdfGroupStates]
+    [defaultSelectedUrdfJointValues, selectedUrdfJointValues, selectedUrdfGroupStates]
   );
   const trackedSelectedUrdfGroupStateId = selectedUrdfFileRef
     ? String(selectedUrdfGroupStateIdByFileRef?.[selectedUrdfFileRef] || "").trim()
@@ -6020,6 +6029,10 @@ export default function CadWorkspace({
       return;
     }
     const clampedValueDeg = clampJointValueDeg(joint, nextValueDeg);
+    const currentValueDeg = toFiniteNumber(selectedUrdfJointValues?.[jointName], joint?.defaultValueDeg ?? 0);
+    if (Math.abs(clampedValueDeg - currentValueDeg) <= URDF_JOINT_ANIMATION_EPSILON) {
+      return;
+    }
     const nextJointValues = {
       ...selectedUrdfJointValues,
       [jointName]: clampedValueDeg

--- a/viewer/src/client/components/workbench/UrdfFileSheet.js
+++ b/viewer/src/client/components/workbench/UrdfFileSheet.js
@@ -34,6 +34,10 @@ const compactButtonClasses = FILE_SHEET_COMPACT_BUTTON_CLASSES;
 const JOINT_CONTROL_SYNC_EPSILON = 0.001;
 const JOINT_CONTROL_LOCAL_OVERRIDE_MS = 3500;
 
+function jointControlValuesClose(left, right) {
+  return Math.abs(Number(left) - Number(right)) <= JOINT_CONTROL_SYNC_EPSILON;
+}
+
 function isAngularJoint(joint) {
   const jointType = String(joint?.type || "").trim().toLowerCase();
   return jointType === "continuous" || jointType === "revolute";
@@ -127,7 +131,7 @@ const UrdfJointRow = memo(function UrdfJointRow({
   useEffect(() => {
     latestSafeValueRef.current = safeValueDeg;
     if (localOverrideRef.current) {
-      if (Math.abs(safeValueDeg - pendingValueRef.current) <= JOINT_CONTROL_SYNC_EPSILON) {
+      if (jointControlValuesClose(safeValueDeg, pendingValueRef.current)) {
         releaseLocalOverride(safeValueDeg);
       }
       return;
@@ -193,6 +197,9 @@ const UrdfJointRow = memo(function UrdfJointRow({
           value={[liveValueDeg]}
           onValueChange={(nextValue) => {
             const nextValueDeg = clampJointInputValue(nextValue?.[0], minValueDeg, maxValueDeg, liveValueDeg);
+            if (jointControlValuesClose(nextValueDeg, pendingValueRef.current)) {
+              return;
+            }
             setLiveValueDeg(nextValueDeg);
             holdLocalValueUntilParentSettles(nextValueDeg);
             scheduleValueChange(nextValueDeg, { scrub: true });
@@ -755,7 +762,7 @@ export default function UrdfFileSheet({
                   {groupStatePresets.length ? (
                     <FileSheetControlRow label="Group state">
                       <Select
-                        value={activeGroupStateValue === "__custom__" ? undefined : activeGroupStateValue}
+                        value={activeGroupStateValue}
                         onValueChange={(value) => {
                           if (value === "__custom__") {
                             return;

--- a/viewer/src/client/workbench/robotMotionControls.js
+++ b/viewer/src/client/workbench/robotMotionControls.js
@@ -30,6 +30,27 @@ export function srdfGroupStateJointValuesToDisplay(urdfData, jointValuesByName) 
   );
 }
 
+export function srdfHomeGroupStateJointValuesToDisplay(urdfData) {
+  const groupStates = Array.isArray(urdfData?.srdf?.groupStates)
+    ? urdfData.srdf.groupStates
+    : Array.isArray(urdfData?.motion?.groupStates)
+      ? urdfData.motion.groupStates
+      : [];
+  return groupStates.reduce((homeValues, state) => {
+    if (String(state?.name || "").trim().toLowerCase() !== "home") {
+      return homeValues;
+    }
+    const jointValuesByName = srdfGroupStateJointValuesToDisplay(
+      urdfData,
+      state?.jointValuesByName || state?.jointValuesByNameRad
+    );
+    return {
+      ...homeValues,
+      ...jointValuesByName
+    };
+  }, {});
+}
+
 export function jointValueSubsetClose(values, subset) {
   const targetValues = cloneJointValueMap(subset);
   const targetNames = Object.keys(targetValues);
@@ -38,6 +59,38 @@ export function jointValueSubsetClose(values, subset) {
   }
   const currentValues = Object.fromEntries(targetNames.map((name) => [name, values?.[name]]));
   return jointValueMapsClose(currentValues, targetValues);
+}
+
+export function findBestMatchingJointValueState(states, currentValues, defaultValues = {}) {
+  const normalizedStates = Array.isArray(states) ? states : [];
+  const normalizedCurrentValues = cloneJointValueMap(currentValues);
+  const normalizedDefaultValues = cloneJointValueMap(defaultValues);
+  const defaultJointNames = new Set([
+    ...Object.keys(normalizedCurrentValues),
+    ...Object.keys(normalizedDefaultValues)
+  ]);
+  let bestState = null;
+  let bestJointCount = 0;
+
+  for (const state of normalizedStates) {
+    const stateValues = cloneJointValueMap(state?.jointValuesByName);
+    const stateJointNames = Object.keys(stateValues);
+    if (!stateJointNames.length || !jointValueSubsetClose(normalizedCurrentValues, stateValues)) {
+      continue;
+    }
+    const outsideJointNames = [...defaultJointNames].filter((name) => !Object.hasOwn(stateValues, name));
+    const outsideCurrentValues = Object.fromEntries(outsideJointNames.map((name) => [name, normalizedCurrentValues[name] ?? 0]));
+    const outsideDefaultValues = Object.fromEntries(outsideJointNames.map((name) => [name, normalizedDefaultValues[name] ?? 0]));
+    if (!jointValueMapsClose(outsideCurrentValues, outsideDefaultValues)) {
+      continue;
+    }
+    if (stateJointNames.length > bestJointCount) {
+      bestState = state;
+      bestJointCount = stateJointNames.length;
+    }
+  }
+
+  return bestState;
 }
 
 export function interpolateTrajectoryJointValues(trajectory, elapsedSec, fallbackValues = {}) {

--- a/viewer/src/client/workbench/robotMotionControls.test.js
+++ b/viewer/src/client/workbench/robotMotionControls.test.js
@@ -5,10 +5,12 @@ import {
   buildUrdfJointAnglesCopyText,
   cloneJointValueMap,
   emptyUrdfPosePickerState,
+  findBestMatchingJointValueState,
   interpolateTrajectoryJointValues,
   jointValueSubsetClose,
   normalizePoint3,
   roundedUrdfJointValue,
+  srdfHomeGroupStateJointValuesToDisplay,
   srdfGroupStateJointValuesToDisplay
 } from "./robotMotionControls.js";
 
@@ -33,9 +35,37 @@ test("robot joint value helpers normalize maps and SRDF native values", () => {
     slide: 0.12
   });
 
+  assert.deepEqual(srdfHomeGroupStateJointValuesToDisplay({
+    ...urdfData,
+    srdf: {
+      groupStates: [
+        { name: "open", jointValuesByName: { slide: 0.1 } },
+        { name: "home", jointValuesByName: { shoulder: Math.PI / 4 } },
+        { name: "home", jointValuesByName: { slide: 0.2 } }
+      ]
+    }
+  }), {
+    shoulder: 45,
+    slide: 0.2
+  });
+
   assert.equal(jointValueSubsetClose({ shoulder: 90.0004, slide: 0.12, extra: 10 }, { shoulder: 90, slide: 0.12 }), true);
   assert.equal(jointValueSubsetClose({ shoulder: 91 }, { shoulder: 90 }), false);
   assert.equal(jointValueSubsetClose({ shoulder: 90 }, {}), false);
+});
+
+test("best group-state match ignores partial presets when other joints changed", () => {
+  const states = [
+    { id: "gripper/open", jointValuesByName: { gripper: 0 } },
+    { id: "arm/home", jointValuesByName: { shoulder: 45, elbow: -30 } },
+    { id: "gripper/closed", jointValuesByName: { gripper: 20 } }
+  ];
+  const defaults = { shoulder: 45, elbow: -30, gripper: 0 };
+
+  assert.equal(findBestMatchingJointValueState(states, defaults, defaults)?.id, "arm/home");
+  assert.equal(findBestMatchingJointValueState(states, { ...defaults, gripper: 12 }, defaults), null);
+  assert.equal(findBestMatchingJointValueState(states, { ...defaults, gripper: 20 }, defaults)?.id, "gripper/closed");
+  assert.equal(findBestMatchingJointValueState(states, { shoulder: 20, elbow: -30, gripper: 0 }, defaults), null);
 });
 
 test("trajectory interpolation keeps fallback values and interpolates only target joints", () => {


### PR DESCRIPTION
## Summary

Fix SRDF robot group-state handling in the Viewer so Tom and related SRDF files default to `home`, avoid React controlled/uncontrolled Select churn, and report `custom` when manual joint edits no longer match a complete preset.

## Root Cause

The group-state Select used `undefined` when the active state became `custom`, which flipped the Radix Select between controlled and uncontrolled mode during gripper slider release. At the same time, group-state matching accepted partial presets, so a gripper-only `open` state could be treated as active even when other joints should be anchored to the SRDF `home` defaults.

## Changes

- Keep the group-state Select controlled by treating `custom` as a stable internal value.
- Drop duplicate joint updates when slider values are already within the robot animation epsilon.
- Seed SRDF default joint values from `home` group states when present.
- Match group-state presets only when their joints match and all other joints remain at defaults, preferring the most specific matching state.
- Add focused tests for SRDF `home` default extraction and partial preset matching.

## Validation

- `scripts/dev/setup-symlinks.sh --check`
- `node --test viewer/src/client/workbench/robotMotionControls.test.js`
- `npm --prefix viewer run test`
- `npm --prefix viewer run build`
- Verified in the live Viewer that `robots/tom/v2/tom_with_gripper.srdf` opens on `home` with `elbow_pitch = -90°`, and dragging the gripper changes the group-state display to `custom` without console errors.