### PR TITLE
Nicer selection highlighting: saturated tone-shift + Bayer-dither occlusion ghost

### DIFF
--- a/packages/cadjs/src/common/cadScene.js
+++ b/packages/cadjs/src/common/cadScene.js
@@ -1815,9 +1815,71 @@ function buildDisplayRecords(THREE, runtime, meshData, settings) {
     }
     runtime.modelGroup.add(mesh);
 
+    // Occlusion ghost: an ASCII-character DITHER copy of this part that renders
+    // ONLY where the part is hidden behind other geometry (depthFunc
+    // GreaterDepth), so a selected feature can be seen through whatever blocks
+    // it. A screen-space ASCII glyph ramp stipples the obscured silhouette. It
+    // is a child of the surface mesh (shares geometry + world transform),
+    // starts invisible, and is shown/colored on selection by
+    // applyPartVisualState (which sets uColor).
+    const ghostMaterial = new THREE.ShaderMaterial({
+      glslVersion: THREE.GLSL3,
+      transparent: true,
+      depthTest: true,
+      depthFunc: THREE.GreaterDepth,
+      depthWrite: false,
+      // FrontSide + Greater: the ghost draws ONLY where this part's front face
+      // is behind something else (occluded by ANOTHER part in front). The part's
+      // own back faces no longer self-ghost, and visible (front-most) fragments
+      // fail the Greater test, so nothing draws over the unobscured surface.
+      side: THREE.FrontSide,
+      uniforms: {
+        uColor: { value: baseColor ? baseColor.clone() : new THREE.Color("#8dc5ff") },
+        uOpacity: { value: 0.9 },
+        uCoverage: { value: 0.6 }
+      },
+      vertexShader: [
+        "void main() {",
+        "  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);",
+        "}"
+      ].join("\n"),
+      fragmentShader: [
+        "precision highp float;",
+        "uniform vec3 uColor;",
+        "uniform float uOpacity;",
+        "uniform float uCoverage;",          // fraction of pixels kept (dither density)
+        "out vec4 fragColor;",
+        "const int BAYER8[64] = int[64](",   // ordered (Bayer) 8x8 dither matrix
+        "  0,32,8,40,2,34,10,42,",
+        "  48,16,56,24,50,18,58,26,",
+        "  12,44,4,36,14,46,6,38,",
+        "  60,28,52,20,62,30,54,22,",
+        "  3,35,11,43,1,33,9,41,",
+        "  51,19,59,27,49,17,57,25,",
+        "  15,47,7,39,13,45,5,37,",
+        "  63,31,55,23,61,29,53,21);",
+        "void main(){",
+        "  ivec2 p = ivec2(gl_FragCoord.xy);",
+        "  int x = p.x & 7;",
+        "  int y = p.y & 7;",
+        "  float threshold = (float(BAYER8[y * 8 + x]) + 0.5) / 64.0;",
+        "  if(uCoverage <= threshold) discard;",   // ordered dither: keep the densest cells
+        "  fragColor = vec4(uColor, uOpacity);",
+        "}"
+      ].join("\n")
+    });
+    const ghostMesh = new THREE.Mesh(geometryEntry.geometry, ghostMaterial);
+    ghostMesh.renderOrder = 30;
+    ghostMesh.visible = false;
+    ghostMesh.userData.partId = partId;
+    ghostMesh.userData.isOcclusionGhost = true;
+    mesh.add(ghostMesh);
+
     const record = {
       partId,
       mesh,
+      ghostMesh,
+      ghostMaterial,
       edges: null,
       silhouette: null,
       material,

--- a/packages/cadjs/src/lib/viewer/partVisualState.js
+++ b/packages/cadjs/src/lib/viewer/partVisualState.js
@@ -30,6 +30,34 @@ export function getPartHighlightColors(THREE, {
   };
 }
 
+// Selection/hover highlight as a SATURATED TONE SHIFT of the part's own color
+// (not a blue overlay): keep the hue, push saturation up and lightness slightly
+// so the selected feature reads as a vivid version of itself. Falls back to the
+// reference highlight color only when the part has no base color (e.g. reference
+// geometry). Edge emphasis is preserved separately via highlight opacity/width.
+const SELECTED_SATURATION_SHIFT = { sat: 0.45, light: 0.05 };
+const HOVER_SATURATION_SHIFT = { sat: 0.28, light: 0.1 };
+
+export function saturatedHighlightColor(THREE, baseColor, fallback, shift = SELECTED_SATURATION_SHIFT) {
+  if (!baseColor || typeof baseColor.getHSL !== "function" || typeof baseColor.clone !== "function") {
+    return fallback;
+  }
+  const color = baseColor.clone();
+  const hsl = { h: 0, s: 0, l: 0 };
+  color.getHSL(hsl);
+  // Near-gray parts have no meaningful hue to saturate — saturating them would
+  // pull an arbitrary (red) hue, so keep the reference highlight color instead.
+  if (hsl.s < 0.12) {
+    return fallback;
+  }
+  color.setHSL(
+    hsl.h,
+    clamp(hsl.s + (shift?.sat ?? 0), 0, 1),
+    clamp(hsl.l + (shift?.light ?? 0), 0, 1)
+  );
+  return color;
+}
+
 export function normalizePartIdList(value) {
   return (Array.isArray(value) ? value : [value])
     .map((id) => String(id || "").trim())
@@ -181,11 +209,15 @@ export function applyPartVisualState(THREE, records, {
   hoveredPartId,
   focusedPartId,
   selectedPartIds,
+  translucentPartIds,
   showEdges,
   displayMode = CAD_DISPLAY_MODE.SOLID
 }) {
   const hidden = new Set(Array.isArray(hiddenPartIds) ? hiddenPartIds : []);
   const selected = new Set(Array.isArray(selectedPartIds) ? selectedPartIds : []);
+  // Parts rendered as see-through ghosts (e.g. negative/cut features when the
+  // negative feature tab is active). They stay visible but at low opacity.
+  const translucent = new Set(Array.isArray(translucentPartIds) ? translucentPartIds : []);
   const hovered = new Set(
     (Array.isArray(hoveredPartId) ? hoveredPartId : [hoveredPartId])
       .map((id) => String(id || "").trim())
@@ -224,6 +256,20 @@ export function applyPartVisualState(THREE, records, {
     const isDimmed = !isHidden && !effectHidden && hasFocus && !isFocused;
     const isHighlighted = isSelected || isHovered;
 
+    // Per-part saturated tone shift of its OWN color for the highlight, instead
+    // of the global blue overlay. Falls back to the reference color if the part
+    // has no base color.
+    const highlightSurface = isSelected
+      ? saturatedHighlightColor(THREE, record.baseColor, selectedSurfaceColor, SELECTED_SATURATION_SHIFT)
+      : isHovered
+        ? saturatedHighlightColor(THREE, record.baseColor, hoveredSurfaceColor, HOVER_SATURATION_SHIFT)
+        : null;
+    const highlightEdge = isSelected
+      ? saturatedHighlightColor(THREE, record.baseColor, selectedEdgeColor, SELECTED_SATURATION_SHIFT)
+      : isHovered
+        ? saturatedHighlightColor(THREE, record.baseColor, hoveredEdgeColor, HOVER_SATURATION_SHIFT)
+        : null;
+
     record.mesh.visible = !effectHidden && !isHidden;
     if (record.edges) {
       record.edges.visible = showEdges && !effectHidden && !isHidden;
@@ -252,27 +298,23 @@ export function applyPartVisualState(THREE, records, {
           )
         : clamp(highlightEdgeOpacity * effectOpacity, 0, 1)
       : baseEffectSurfaceOpacity;
-    const nextSurfaceOpacity = isHidden ? 0 : isDimmed ? dimmedSurfaceOpacity : highlightedSurfaceOpacity;
-    syncSurfaceTransparency(record, isHidden || isDimmed || isHighlighted, nextSurfaceOpacity, {
-      writeTransparentDepth: !isHidden && !isDimmed && !transparentDisplayMode
+    const isTranslucent = !isHidden && partIdMatchesSet(record.partId, translucent);
+    const baseNextSurfaceOpacity = isHidden ? 0 : isDimmed ? dimmedSurfaceOpacity : highlightedSurfaceOpacity;
+    const nextSurfaceOpacity = isTranslucent && !isHidden && !isDimmed
+      ? Math.min(baseNextSurfaceOpacity, 0.35)
+      : baseNextSurfaceOpacity;
+    syncSurfaceTransparency(record, isHidden || isDimmed || isHighlighted || isTranslucent, nextSurfaceOpacity, {
+      writeTransparentDepth: !isHidden && !isDimmed && !isTranslucent && !transparentDisplayMode
     });
     record.material.opacity = nextSurfaceOpacity;
 
     if (record.baseColor && record.material.color) {
-      record.material.color.copy(
-        isSelected
-          ? selectedSurfaceColor
-          : isHovered
-            ? hoveredSurfaceColor
-            : effectColor || record.baseColor
-      );
+      record.material.color.copy(highlightSurface || effectColor || record.baseColor);
     }
 
     if ("emissive" in record.material && record.material.emissive) {
-      if (isSelected) {
-        record.material.emissive.copy(selectedSurfaceColor);
-      } else if (isHovered) {
-        record.material.emissive.copy(hoveredSurfaceColor);
+      if (highlightSurface) {
+        record.material.emissive.copy(highlightSurface);
       } else if (record.baseEmissiveColor && record.baseEmissiveIntensity > 0) {
         record.material.emissive.copy(record.baseEmissiveColor);
       } else {
@@ -290,11 +332,7 @@ export function applyPartVisualState(THREE, records, {
       }
     }
 
-    const nextEdgeColor = isSelected
-      ? selectedEdgeColor
-      : isHovered
-        ? hoveredEdgeColor
-        : effectEdgeColor || baseEdgeColor;
+    const nextEdgeColor = highlightEdge || effectEdgeColor || baseEdgeColor;
     syncCadSurfaceEdgeHighlight(THREE, record, nextEdgeColor, highlightedEdgeOpacity);
 
     if (record.edgeMaterial) {
@@ -306,6 +344,20 @@ export function applyPartVisualState(THREE, records, {
           : isHidden || isDimmed
             ? nextSurfaceOpacity
             : baseEdgeOpacity * effectEdgeOpacity);
+    }
+
+    // Occlusion ghost: only a SELECTED part shows its see-through ghost. It is
+    // tinted to the selection BLUE (selectedSurfaceColor) — a distinct cue that
+    // reads as "this is behind something" — while the visible surface keeps the
+    // saturated tone shift of its own color. The GreaterDepth material (see
+    // cadScene) makes the ghost appear only where the part is occluded.
+    if (record.ghostMesh && record.ghostMaterial) {
+      const showGhost = isSelected && !isHidden;
+      record.ghostMesh.visible = showGhost;
+      const ghostColorUniform = record.ghostMaterial.uniforms?.uColor?.value;
+      if (showGhost && ghostColorUniform?.copy) {
+        ghostColorUniform.copy(selectedSurfaceColor);
+      }
     }
   }
 }


### PR DESCRIPTION
## What

Improves CAD selection highlighting in `packages/cadjs` (render layer only):

- **Saturated tone-shift highlight** — selection/hover now boosts the part's
  *own* color (HSL saturation + lightness) for surface, emissive, and edges,
  instead of replacing it with a flat blue overlay. Near-gray parts (no
  meaningful hue) fall back to the reference highlight color so they don't
  pull an arbitrary red hue.
- **Occlusion dither ghost** — a selected part now shows through whatever
  occludes it. A child mesh of the surface renders **only where the part is
  hidden behind another part** (`FrontSide` + `depthFunc: Greater`, so it
  never self-ghosts and never paints over the visible surface). The overlay
  is a GLSL3 `ShaderMaterial` that stipples the obscured silhouette with a
  **Bayer 8×8 ordered dither** in the selection color.

## Files

- `packages/cadjs/src/common/cadScene.js` — occlusion-ghost child mesh + Bayer dither shader.
- `packages/cadjs/src/lib/viewer/partVisualState.js` — saturated highlight colors, ghost show/colour, and an optional `translucentPartIds` input (inert unless the app passes it; used by a feature-legend UI to render see-through cut features).

## Tests

`packages/cadjs` unit tests pass (`partVisualState.test.js`, `cadScene.test.js`).

## Notes / follow-ups

- Draft — opened for review, not finalized.
- The dither is currently a uniform-density stipple over the obscured region. A
  follow-up could make it **feather at the occlusion boundary** (density ramping
  with depth-behind), which needs a scene depth texture / depth pre-pass the
  viewer doesn't currently expose.
- Tunables live in the ghost shader uniforms (`uCoverage`, `uOpacity`) and the
  `SELECTED_SATURATION_SHIFT` / `HOVER_SATURATION_SHIFT` constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)