### PR TITLE
[codex] Remove viewer refs query param

### DIFF
--- a/viewer/docs/storage.md
+++ b/viewer/docs/storage.md
@@ -16,7 +16,6 @@ Use query params only for shareable state that should survive copying a URL:
   the directory where the Viewer server was started. When omitted, the Viewer
   uses the active directory remembered for the tab, or the directory where the
   server was started when that is the only active directory.
-- `refs`: copied CAD references and selection targets.
 - `moveit2Ws`: explicit MoveIt2 websocket override for local or hosted sessions.
 
 Do not put dense viewer state, panel state, drawing state, or per-file controls

--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -83,13 +83,10 @@ import {
   buildSelectionCopyButtonLabel,
   buildSelectionCopyPayload,
   buildWholeStepEntryCopyReference,
-  cadRefQueryHasKnownEntry,
   canonicalCadRefCopyText,
-  collectCadRefSelectionRequest,
   computeNextSelectionIds,
   orderedStringListEqual,
   parseAssemblyPartReferenceSelectionId,
-  resolveCadRefSelection,
   uniqueStringList
 } from "@/workbench/referenceSelection";
 import {
@@ -194,15 +191,12 @@ import {
   missingFileRefForCatalog,
   readCadDirParam,
   readCadParam,
-  readCadRefQueryParams,
-  readNavigationCadRefQueryParams,
   selectedEntryKeyFromUrl,
   sidebarDirectoryIdForEntry,
   sidebarLabelForEntry,
   shouldDeferFileParamSelection,
   writeCadDirParam,
   writeCadParam,
-  writeCadRefQueryParams,
 } from "@/workbench/sidebar";
 import { buildCadRefToken } from "cadjs/lib/cadRefs.js";
 import {
@@ -1315,7 +1309,6 @@ export default function CadWorkspace({
   const [implicitParameterInteractionActive, setImplicitParameterInteractionActive] = useState(false);
   const implicitParameterInteractionTimerRef = useRef(0);
   const [urdfPosePickerState, setUrdfPosePickerState] = useState(emptyUrdfPosePickerState);
-  const [pendingCadRefQueryParams, setPendingCadRefQueryParams] = useState(() => readCadRefQueryParams());
   const lastPersistenceFailureKeyRef = useRef("");
   const urdfTrajectoryPlaybackRef = useRef({
     frameId: 0,
@@ -3301,8 +3294,6 @@ export default function CadWorkspace({
   const tabToolsResizeStateRef = useRef(null);
   const selectedFileSheetKeyRef = useRef("");
   const cadDirectorySessionBootstrappedRef = useRef(false);
-  const cadRefQueryRescueUsedRef = useRef(false);
-  const cadRefQueryResolvedOnceRef = useRef(false);
 
   useEffect(() => {
     openTabsRef.current = openTabs;
@@ -4361,8 +4352,6 @@ export default function CadWorkspace({
     defaultSidebarWidth: DEFAULT_SIDEBAR_WIDTH,
     sidebarMinWidth: DESKTOP_SIDEBAR_MIN_WIDTH,
     readCadParam,
-    readCadRefQueryParams,
-    setPendingCadRefQueryParams,
     activateEntryTab,
     resetActiveDirectory,
     writeCadParam,
@@ -5112,7 +5101,7 @@ export default function CadWorkspace({
     !hasStepGlbByteCost(selectedEntry) &&
     !selectedMeshMatches
   );
-  const referenceLoadingExplicitlyRequested = pendingCadRefQueryParams.length > 0 || selectedStepPartRootActive;
+  const referenceLoadingExplicitlyRequested = selectedStepPartRootActive;
   const selectedTopologyDeferredByCost = Boolean(
     plainStepReferencePickingEnabled &&
     selectedTopologyLargeByCost &&
@@ -5120,11 +5109,9 @@ export default function CadWorkspace({
     !referenceLoadingExplicitlyRequested
   );
   const topLevelReferenceSelectionActive =
-    pendingCadRefQueryParams.length > 0 ||
     selectedStepPartRootActive ||
     plainStepReferencePickingEnabled;
   const referenceLoadingEnabled =
-    pendingCadRefQueryParams.length > 0 ||
     selectedStepPartRootActive ||
     assemblyStepTreeTopologyLoadingEnabled ||
     (
@@ -6681,165 +6668,6 @@ export default function CadWorkspace({
     () => buildSelectionCopyButtonLabel(canonicalCopySelectionLines, { count: copySelectionPayload.copiedCount }),
     [canonicalCopySelectionLines, copySelectionPayload.copiedCount]
   );
-  const cadRefQueryParamsForUrlSignature = useMemo(() => (
-    selectedEntry
-      ? uniqueStringList([
-          ...(selectedWholeEntryCadRefToken ? [selectedWholeEntryCadRefToken] : []),
-          ...canonicalCopySelectionLines
-        ]).join("\n")
-      : ""
-  ), [canonicalCopySelectionLines, selectedEntry, selectedWholeEntryCadRefToken]);
-
-  useEffect(() => {
-    if (!pendingCadRefQueryParams.length) {
-      return;
-    }
-
-    if (!selectedEntry) {
-      if (explicitFileParam || !catalogHydrated || catalogRefreshing) {
-        return;
-      }
-      if (!cadRefQueryHasKnownEntry(pendingCadRefQueryParams, catalogEntries)) {
-        setPendingCadRefQueryParams((current) => Array.isArray(current) && current.length ? [] : current);
-      }
-      return;
-    }
-
-    const selectionRequest = collectCadRefSelectionRequest(pendingCadRefQueryParams, selectedEntry);
-    if (!selectionRequest.hasMatchingToken) {
-      if (!cadRefQueryHasKnownEntry(pendingCadRefQueryParams, catalogEntries)) {
-        setPendingCadRefQueryParams((current) => Array.isArray(current) && current.length ? [] : current);
-      }
-      return;
-    }
-
-    if (selectionRequest.needsParts && !assemblyPartsLoaded) {
-      return;
-    }
-    if (selectionRequest.needsMates && !selectedAssemblyStructureReady) {
-      return;
-    }
-    if (selectionRequest.needsReferences && selectedEntryHasReferences && !selectedReferencesMatch) {
-      return;
-    }
-
-    const resolvedSelection = resolveCadRefSelection({
-      cadRefs: pendingCadRefQueryParams,
-      entry: selectedEntry,
-      references: visibleReferences,
-      assemblyParts: assemblyNodes,
-      assemblyMates: selectedAssemblyMates,
-      isAssemblyView
-    });
-
-    if (!orderedStringListEqual(selectedReferenceIdsRef.current, resolvedSelection.selectedReferenceIds)) {
-      selectedReferenceIdsRef.current = resolvedSelection.selectedReferenceIds;
-      setSelectedReferenceIds(resolvedSelection.selectedReferenceIds);
-    }
-    if (!orderedStringListEqual(selectedPartIdsRef.current, resolvedSelection.selectedPartIds)) {
-      selectedPartIdsRef.current = resolvedSelection.selectedPartIds;
-      setSelectedPartIds(resolvedSelection.selectedPartIds);
-    }
-    if (!orderedStringListEqual(selectedMateIdsRef.current, resolvedSelection.selectedMateIds)) {
-      selectedMateIdsRef.current = resolvedSelection.selectedMateIds;
-      setSelectedMateIds(resolvedSelection.selectedMateIds);
-    }
-    setSelectedRenderPartIdByAssemblyPartId((current) => Object.keys(current || {}).length ? {} : current);
-    const nextWholeEntryCadRefToken = resolvedSelection.hasWholeEntryToken
-      ? buildCadRefToken({ cadPath: cadPathForEntry(selectedEntry) })
-      : "";
-    setSelectedWholeEntryCadRefToken((current) => (
-      current === nextWholeEntryCadRefToken ? current : nextWholeEntryCadRefToken
-    ));
-    const resolvedTreeNodeIds = uniqueStringList([
-      ...resolvedSelection.selectedPartIds.flatMap((id) => collectStepTreeAncestorIds(stepTreeRoot, id)),
-      ...resolvedSelection.expandedAssemblyPartIds.flatMap((id) => collectStepTreeAncestorIds(stepTreeRoot, id)),
-      ...resolvedSelection.expandedAssemblyPartIds
-    ]);
-    if (resolvedTreeNodeIds.length) {
-      setExpandedStepTreeNodeIds((current) => uniqueStringList([...current, ...resolvedTreeNodeIds]));
-    }
-    if (resolvedTreeNodeIds.length || resolvedSelection.selectedMateIds.length) {
-      openFileSheetSection(FILE_SHEET_SECTION_IDS.STEP_TREE);
-    }
-    setHoveredListReferenceId((current) => current ? "" : current);
-    setHoveredModelReferenceId((current) => current ? "" : current);
-    setHoveredListPartId((current) => current ? "" : current);
-    setHoveredModelPartId((current) => current ? "" : current);
-    setHoveredMateId((current) => current ? "" : current);
-    setCopyStatus((current) => current ? "" : current);
-    setTabToolMode((current) => current === TAB_TOOL_MODE.REFERENCES ? current : TAB_TOOL_MODE.REFERENCES);
-    setPendingCadRefQueryParams((current) => Array.isArray(current) && current.length ? [] : current);
-  }, [
-    assemblyPartsLoaded,
-    assemblyNodes,
-    assemblyRootNodeId,
-    catalogEntries,
-    catalogHydrated,
-    catalogRefreshing,
-    explicitFileParam,
-    isAssemblyView,
-    openFileSheetSection,
-    pendingCadRefQueryParams,
-    selectedEntry,
-    selectedEntryHasReferences,
-    selectedAssemblyMates,
-    selectedAssemblyStructureReady,
-    selectedReferencesMatch,
-    selectedMateIdsRef,
-    selectedReferenceIdsRef,
-    selectedPartIdsRef,
-    stepTreeRoot,
-    visibleReferences
-  ]);
-
-  useEffect(() => {
-    if (!cadDirectorySessionBootstrappedRef.current || pendingCadRefQueryParams.length) {
-      return;
-    }
-    if (cadRefQueryParamsForUrlSignature) {
-      cadRefQueryResolvedOnceRef.current = true;
-      writeCadRefQueryParams(cadRefQueryParamsForUrlSignature.split("\n"));
-      return;
-    }
-    if (!cadRefQueryRescueUsedRef.current && !cadRefQueryParamsForUrlSignature) {
-      const liveCadRefQueryParams = readCadRefQueryParams();
-      const rescuedCadRefQueryParams = liveCadRefQueryParams.length
-        ? liveCadRefQueryParams
-        : readNavigationCadRefQueryParams();
-      if (rescuedCadRefQueryParams.length) {
-        if (selectedEntry) {
-          cadRefQueryRescueUsedRef.current = true;
-          setPendingCadRefQueryParams(rescuedCadRefQueryParams);
-        }
-        return;
-      }
-    }
-    if (!cadRefQueryResolvedOnceRef.current) {
-      const liveCadRefQueryParams = readCadRefQueryParams();
-      const rescuedCadRefQueryParams = liveCadRefQueryParams.length
-        ? liveCadRefQueryParams
-        : readNavigationCadRefQueryParams();
-      if (rescuedCadRefQueryParams.length) {
-        if (selectedEntry) {
-          setPendingCadRefQueryParams((current) => (
-            orderedStringListEqual(current, rescuedCadRefQueryParams) ? current : rescuedCadRefQueryParams
-          ));
-        }
-        return;
-      }
-    }
-    writeCadRefQueryParams([]);
-  }, [
-    cadRefQueryParamsForUrlSignature,
-    selectedEntry,
-    pendingCadRefQueryParams,
-    readCadRefQueryParams,
-    readNavigationCadRefQueryParams,
-    setPendingCadRefQueryParams,
-    cadDirectorySessionBootstrappedRef
-  ]);
-
   const expandStepTreeAroundNode = useCallback((nodeId, {
     expandSelf = false,
     includeVisualOnlyAncestors = true

--- a/viewer/src/client/components/workbench/hooks/useCadDirectorySession.js
+++ b/viewer/src/client/components/workbench/hooks/useCadDirectorySession.js
@@ -42,8 +42,6 @@ export function useCadDirectorySession({
   catalogEntries,
   manifestRevision = 0,
   readCadParam = () => null,
-  readCadRefQueryParams = () => [],
-  setPendingCadRefQueryParams = () => {},
   activateEntryTab,
   resetActiveDirectory,
   writeCadParam,
@@ -59,12 +57,8 @@ export function useCadDirectorySession({
     }
     cadDirectorySessionBootstrappedRef.current = true;
 
-    const initialCadRefQueryParams = readCadRefQueryParams();
-    if (initialCadRefQueryParams.length) {
-      setPendingCadRefQueryParams(initialCadRefQueryParams);
-    }
     const urlSelectedKey = selectedEntryKeyFromUrl(manifestEntries);
-    initialUnresolvedUrlSelectionRef.current = Boolean(readCadParam() || initialCadRefQueryParams.length) && !urlSelectedKey;
+    initialUnresolvedUrlSelectionRef.current = Boolean(readCadParam()) && !urlSelectedKey;
 
     if (urlSelectedKey) {
       const fileSessionState = readEntrySessionState(urlSelectedKey);
@@ -83,12 +77,10 @@ export function useCadDirectorySession({
     applyTabRecord,
     createTabRecord,
     manifestEntries,
-    readCadRefQueryParams,
     readCadParam,
     readEntrySessionState,
     selectedEntryKeyFromUrl,
     setOpenTabs,
-    setPendingCadRefQueryParams,
     upsertTabRecord,
     initialSelectedTabSnapshot,
     cadDirectorySessionBootstrappedRef
@@ -100,7 +92,7 @@ export function useCadDirectorySession({
   }, [defaultDocumentTitle, selectedEntry]);
 
   useLayoutEffect(() => {
-    const urlSelectionRequested = Boolean(readCadParam() || readCadRefQueryParams().length);
+    const urlSelectionRequested = Boolean(readCadParam());
     const nextSelectedKey = selectedEntryKeyFromUrl(catalogEntries);
     const selectedKeyExists = Boolean(selectedKey && entryMap.has(selectedKey));
 
@@ -140,7 +132,6 @@ export function useCadDirectorySession({
     entryMap,
     manifestRevision,
     readCadParam,
-    readCadRefQueryParams,
     resetActiveDirectory,
     selectedEntryKeyFromUrl,
     selectedKey,
@@ -150,9 +141,6 @@ export function useCadDirectorySession({
 
   useEffect(() => {
     const syncSelectionFromHistory = () => {
-      const nextCadRefQueryParams = readCadRefQueryParams();
-      setPendingCadRefQueryParams(nextCadRefQueryParams);
-
       const nextSelectedKey = selectedEntryKeyFromUrl(catalogEntries);
       if (nextSelectedKey) {
         activateEntryTab(nextSelectedKey);
@@ -168,25 +156,17 @@ export function useCadDirectorySession({
   }, [
     activateEntryTab,
     catalogEntries,
-    readCadRefQueryParams,
     resetActiveDirectory,
-    selectedEntryKeyFromUrl,
-    setPendingCadRefQueryParams
+    selectedEntryKeyFromUrl
   ]);
 
   useEffect(() => {
     if (selectedEntry) {
-      const currentCadRefQueryParams = readCadRefQueryParams();
-      if (currentCadRefQueryParams.length) {
-        setPendingCadRefQueryParams((current) => (
-          Array.isArray(current) && current.length ? current : currentCadRefQueryParams
-        ));
-      }
       writeCadParam(cadFileParamForEntry(selectedEntry));
       return;
     }
     if (!selectedKey) {
-      const unresolvedUrlSelection = Boolean(readCadParam() || readCadRefQueryParams().length);
+      const unresolvedUrlSelection = Boolean(readCadParam());
       if (unresolvedUrlSelection) {
         const urlSelectedKey = selectedEntryKeyFromUrl(catalogEntries);
         if (
@@ -207,11 +187,9 @@ export function useCadDirectorySession({
     cadFileParamForEntry,
     manifestRevision,
     readCadParam,
-    readCadRefQueryParams,
     selectedEntry,
     selectedEntryKeyFromUrl,
     selectedKey,
-    setPendingCadRefQueryParams,
     writeCadParam
   ]);
 

--- a/viewer/src/client/workbench/referenceSelection.js
+++ b/viewer/src/client/workbench/referenceSelection.js
@@ -1,10 +1,7 @@
-import { buildCadRefToken, parseCadRefSelector, parseCadRefToken, sortCadRefSelectors } from "cadjs/lib/cadRefs.js";
+import { buildCadRefToken, parseCadRefToken, sortCadRefSelectors } from "cadjs/lib/cadRefs.js";
 import { entryReferenceAssetSignature } from "cadjs/lib/entryAssets.js";
 import { buildSelectorRuntime } from "cadjs/lib/selectors/runtime.js";
-import { STEP_MODEL_ROOT_ID } from "cadjs/lib/step/stepTree.js";
 import { cadPathForEntry, fileKey } from "./sidebar.js";
-
-const ASSEMBLY_MATE_SELECTOR_RE = /^m\d+$/;
 
 export function buildReferenceCacheKey(entry) {
   const fileRef = fileKey(entry);
@@ -252,11 +249,6 @@ export function buildAssemblyMateSelector(mate) {
   return String(mate?.id || "").trim();
 }
 
-export function parseAssemblyMateSelector(selector) {
-  const normalizedSelector = String(selector || "").trim();
-  return ASSEMBLY_MATE_SELECTOR_RE.test(normalizedSelector) ? normalizedSelector : "";
-}
-
 export function buildAssemblyMateCopyText(mate, entry) {
   void entry;
   const selector = buildAssemblyMateSelector(mate);
@@ -264,21 +256,6 @@ export function buildAssemblyMateCopyText(mate, entry) {
     return "";
   }
   return buildCadRefToken({ selector });
-}
-
-export function buildAssemblyMateSelectorMap(mates) {
-  const map = new Map();
-  for (const mate of Array.isArray(mates) ? mates : []) {
-    const mateId = String(mate?.id || "").trim();
-    if (!mateId) {
-      continue;
-    }
-    const selector = buildAssemblyMateSelector(mate);
-    if (selector) {
-      map.set(selector, mateId);
-    }
-  }
-  return map;
 }
 
 export function buildSelectionCopyPayload({ references = [], parts = [], mates = [], entry = null } = {}) {
@@ -392,194 +369,6 @@ export function resolveTopologyRelativeFile(entry, sourcePath) {
   const stepDirectory = stepParts.join("/");
   const topologyDirectory = stepDirectory ? `${stepDirectory}/.${stepFilename}` : `.${stepFilename}`;
   return normalizePosixPath(`${topologyDirectory}/${relativeSourcePath}`);
-}
-
-export function cadRefQueryHasKnownEntry(cadRefs, entries) {
-  void cadRefs;
-  void entries;
-  return false;
-}
-
-export function collectCadRefSelectionRequest(cadRefs, entry) {
-  const selectors = [];
-  let hasMatchingToken = false;
-  let hasWholeEntryToken = false;
-
-  if (!entry) {
-    return {
-      hasMatchingToken,
-      hasWholeEntryToken,
-      selectors,
-      needsParts: false,
-      needsMates: false,
-      needsReferences: false
-    };
-  }
-
-  for (const cadRef of Array.isArray(cadRefs) ? cadRefs : []) {
-    const parsedToken = parseCadRefToken(cadRef);
-    if (!parsedToken) {
-      continue;
-    }
-    hasMatchingToken = true;
-    if (!parsedToken.selectors.length) {
-      hasWholeEntryToken = true;
-      continue;
-    }
-    selectors.push(...parsedToken.selectors);
-  }
-
-  const normalizedSelectors = sortCadRefSelectors(selectors);
-  let needsParts = false;
-  let needsMates = false;
-  let needsReferences = false;
-  for (const selector of normalizedSelectors) {
-    const parsedSelector = parseCadRefSelector(selector);
-    if (parseAssemblyMateSelector(selector)) {
-      needsMates = true;
-    } else if (entry?.kind === "assembly" && parsedSelector?.selectorType === "occurrence") {
-      needsParts = true;
-    } else {
-      needsReferences = true;
-    }
-  }
-
-  return {
-    hasMatchingToken,
-    hasWholeEntryToken,
-    selectors: normalizedSelectors,
-    needsParts,
-    needsMates,
-    needsReferences
-  };
-}
-
-function addTokenSelectorsToMap(map, copyText, value) {
-  const parsedToken = parseCadRefToken(copyText);
-  if (!parsedToken) {
-    return;
-  }
-  for (const selector of parsedToken.selectors) {
-    if (selector && !map.has(selector)) {
-      map.set(selector, value);
-    }
-  }
-}
-
-function addReferenceIdSelectorToMap(map, reference, value) {
-  const displaySelector = String(reference?.displaySelector || reference?.normalizedSelector || "").trim();
-  if (!displaySelector) {
-    return;
-  }
-  const parsedSelector = parseCadRefSelector(displaySelector);
-  if (parsedSelector?.canonical && !map.has(parsedSelector.canonical)) {
-    map.set(parsedSelector.canonical, value);
-  }
-  if (reference?.normalizedSelector && !map.has(reference.normalizedSelector)) {
-    map.set(reference.normalizedSelector, value);
-  }
-}
-
-export function buildReferenceSelectorMap(references, cadPath) {
-  void cadPath;
-  const map = new Map();
-  for (const reference of Array.isArray(references) ? references : []) {
-    const referenceId = String(reference?.id || "").trim();
-    if (!referenceId) {
-      continue;
-    }
-    const value = {
-      id: referenceId,
-      partId: String(reference?.partId || "").trim()
-    };
-    addTokenSelectorsToMap(map, reference?.copyText, value);
-    addReferenceIdSelectorToMap(map, reference, value);
-  }
-  return map;
-}
-
-export function buildAssemblyPartSelectorMap(parts, cadPath) {
-  void cadPath;
-  const map = new Map();
-  for (const part of Array.isArray(parts) ? parts : []) {
-    const partId = String(part?.id || "").trim();
-    const selector = String(part?.occurrenceId || partId).trim();
-    const selectionId = partId || selector;
-    if (!selectionId || !selector) {
-      continue;
-    }
-    const copyText = buildCadRefToken({
-      cadPath,
-      selector
-    });
-    addTokenSelectorsToMap(map, copyText, selectionId);
-    addTokenSelectorsToMap(map, selector, selectionId);
-  }
-  return map;
-}
-
-export function resolveCadRefSelection({
-  cadRefs = [],
-  entry = null,
-  references = [],
-  assemblyParts = [],
-  assemblyMates = [],
-  isAssemblyView = false
-} = {}) {
-  const request = collectCadRefSelectionRequest(cadRefs, entry);
-  const cadPath = cadPathForEntry(entry);
-  const referenceSelectorMap = buildReferenceSelectorMap(references, cadPath);
-  const assemblyPartSelectorMap = buildAssemblyPartSelectorMap(assemblyParts, cadPath);
-  const assemblyMateSelectorMap = buildAssemblyMateSelectorMap(assemblyMates);
-  const selectedReferenceIds = [];
-  const selectedPartIds = [];
-  const selectedMateIds = [];
-  const expandedAssemblyPartIds = [];
-
-  if (request.hasWholeEntryToken && !isAssemblyView) {
-    selectedPartIds.push(STEP_MODEL_ROOT_ID);
-  }
-
-  for (const selector of request.selectors) {
-    const parsedSelector = parseCadRefSelector(selector);
-    const canonicalSelector = String(parsedSelector?.canonical || selector || "").trim();
-    if (!canonicalSelector) {
-      continue;
-    }
-
-    const mateId = assemblyMateSelectorMap.get(canonicalSelector);
-    if (mateId) {
-      selectedMateIds.push(mateId);
-      continue;
-    }
-
-    if (isAssemblyView && parsedSelector?.selectorType === "occurrence") {
-      const partId = assemblyPartSelectorMap.get(canonicalSelector);
-      if (partId) {
-        selectedPartIds.push(partId);
-        expandedAssemblyPartIds.push(partId);
-      }
-      continue;
-    }
-
-    const reference = referenceSelectorMap.get(canonicalSelector);
-    if (!reference) {
-      continue;
-    }
-    selectedReferenceIds.push(reference.id);
-    if (isAssemblyView && reference.partId) {
-      expandedAssemblyPartIds.push(reference.partId);
-    }
-  }
-
-  return {
-    ...request,
-    selectedReferenceIds: uniqueStringList(selectedReferenceIds),
-    selectedPartIds: uniqueStringList(selectedPartIds),
-    selectedMateIds: uniqueStringList(selectedMateIds),
-    inspectedAssemblyNodeId: "",
-    expandedAssemblyPartIds: uniqueStringList(expandedAssemblyPartIds)
-  };
 }
 
 export function computeNextSelectionIds(currentIds, selectionId, { multiSelect = false } = {}) {

--- a/viewer/src/client/workbench/referenceSelection.test.js
+++ b/viewer/src/client/workbench/referenceSelection.test.js
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { STEP_MODEL_ROOT_ID } from "cadjs/lib/step/stepTree.js";
 import {
   buildAssemblyPartCopyText,
   buildAssemblyMateCopyText,
@@ -10,15 +9,12 @@ import {
   buildSelectionCopyButtonLabel,
   buildSelectionCopyPayload,
   buildWholeStepEntryCopyReference,
-  cadRefQueryHasKnownEntry,
   canonicalCadRefCopyText,
-  collectCadRefSelectionRequest,
   computeNextSelectionIds,
   copySelectedReferenceText,
   normalizeReferenceList,
   orderedStringListEqual,
   parseAssemblyPartReferenceSelectionId,
-  resolveCadRefSelection,
   resolveTopologyRelativeFile,
   uniqueStringList
 } from "./referenceSelection.js";
@@ -154,62 +150,7 @@ test("copy helpers merge selector refs and keep plain fallback lines", () => {
   assert.equal(buildSelectionCopyButtonLabel([]), "Copy refs");
 });
 
-test("whole-entry refs select the single STEP root row", () => {
-  const resolved = resolveCadRefSelection({
-    cadRefs: ["#"],
-    entry: STEP_ENTRY,
-    isAssemblyView: false
-  });
-  assert.equal(resolved.hasWholeEntryToken, true);
-  assert.deepEqual(resolved.selectedPartIds, [STEP_MODEL_ROOT_ID]);
-  assert.deepEqual(resolved.selectedReferenceIds, []);
-  assert.deepEqual(resolved.selectedMateIds, []);
-});
-
-test("selector ref query helpers classify and resolve selected references and parts", () => {
-  const assemblyEntry = {
-    ...STEP_ENTRY,
-    kind: "assembly"
-  };
-  const cadRefs = [
-    "#o1.2,f1"
-  ];
-  assert.equal(cadRefQueryHasKnownEntry(cadRefs, [assemblyEntry]), false);
-  assert.deepEqual(collectCadRefSelectionRequest(cadRefs, assemblyEntry), {
-    hasMatchingToken: true,
-    hasWholeEntryToken: false,
-    selectors: ["o1.2", "o1.2.f1"],
-    needsParts: true,
-    needsMates: false,
-    needsReferences: true
-  });
-
-  const resolved = resolveCadRefSelection({
-    cadRefs,
-    entry: assemblyEntry,
-    isAssemblyView: true,
-    references: [
-      {
-        id: "ref-face-1",
-        partId: "part-a",
-        copyText: "#o1.2.f1",
-        displaySelector: "o1.2.f1",
-        normalizedSelector: "o1.2.f1"
-      }
-    ],
-    assemblyParts: [
-      { id: "root", children: [{ id: "part-b", occurrenceId: "o1.2" }] },
-      { id: "part-b", occurrenceId: "o1.2" }
-    ]
-  });
-  assert.equal(resolved.hasMatchingToken, true);
-  assert.deepEqual(resolved.selectedReferenceIds, ["ref-face-1"]);
-  assert.deepEqual(resolved.selectedPartIds, ["part-b"]);
-  assert.equal(resolved.inspectedAssemblyNodeId, "");
-  assert.deepEqual(resolved.expandedAssemblyPartIds, ["part-b", "part-a"]);
-});
-
-test("selector ref query helpers copy and resolve assembly mate refs", () => {
+test("assembly mate refs copy as selector lines", () => {
   const assemblyEntry = {
     ...STEP_ENTRY,
     kind: "assembly"
@@ -236,45 +177,6 @@ test("selector ref query helpers copy and resolve assembly mate refs", () => {
     "#m1"
   ]);
   assert.equal(payload.copiedCount, 1);
-  assert.deepEqual(collectCadRefSelectionRequest(payload.lines, assemblyEntry), {
-    hasMatchingToken: true,
-    hasWholeEntryToken: false,
-    selectors: ["m1"],
-    needsParts: false,
-    needsMates: true,
-    needsReferences: false
-  });
-
-  const resolved = resolveCadRefSelection({
-    cadRefs: payload.lines,
-    entry: assemblyEntry,
-    isAssemblyView: true,
-    assemblyMates: [mate]
-  });
-  assert.deepEqual(resolved.selectedMateIds, [mate.id]);
-  assert.deepEqual(resolved.selectedPartIds, []);
-  assert.deepEqual(resolved.selectedReferenceIds, []);
-});
-
-test("selector ref query resolves nested occurrence selection without entering focus", () => {
-  const assemblyEntry = {
-    ...STEP_ENTRY,
-    kind: "assembly"
-  };
-  const resolved = resolveCadRefSelection({
-    cadRefs: ["#o1.2.3"],
-    entry: assemblyEntry,
-    isAssemblyView: true,
-    assemblyParts: [
-      { id: "root", children: [{ id: "module", occurrenceId: "o1.2" }] },
-      { id: "module", occurrenceId: "o1.2", children: [{ id: "part-c", occurrenceId: "o1.2.3" }] },
-      { id: "part-c", occurrenceId: "o1.2.3" }
-    ]
-  });
-
-  assert.deepEqual(resolved.selectedPartIds, ["part-c"]);
-  assert.equal(resolved.inspectedAssemblyNodeId, "");
-  assert.deepEqual(resolved.expandedAssemblyPartIds, ["part-c"]);
 });
 
 test("selection utility helpers preserve list and topology path behavior", () => {

--- a/viewer/src/client/workbench/sidebar.js
+++ b/viewer/src/client/workbench/sidebar.js
@@ -1,4 +1,3 @@
-import { buildCadRefToken, parseCadRefToken } from "cadjs/lib/cadRefs.js";
 import {
   readStoredActiveCadDir,
   rememberActiveCadDir
@@ -7,7 +6,6 @@ import { normalizeViewerDefaultFile } from "../../shared/viewerConfig.mjs";
 
 const CAD_DIR_QUERY_PARAM = "dir";
 const CAD_QUERY_PARAM = "file";
-const CAD_REF_QUERY_PARAM = "refs";
 
 export function fileKey(entry) {
   return String(entry?.file || "").trim();
@@ -87,43 +85,6 @@ export function readDefaultCadParam() {
   return normalizeViewerDefaultFile(import.meta.env?.VIEWER_DEFAULT_FILE) || null;
 }
 
-export function normalizeCadRefQueryParams(values) {
-  const sourceValues = Array.isArray(values) ? values : [values];
-  const seenTokens = new Set();
-  const tokens = [];
-
-  for (const sourceValue of sourceValues) {
-    const lines = String(sourceValue || "").split(/\r?\n/);
-    for (const line of lines) {
-      const normalizedLine = String(line || "").trim();
-      const parsedToken = parseCadRefToken(normalizedLine) ||
-        (normalizedLine && !normalizedLine.startsWith("#")
-          ? parseCadRefToken(`#${normalizedLine}`)
-          : null);
-      const token = String(
-        parsedToken
-          ? buildCadRefToken({ selectors: parsedToken.selectors })
-          : ""
-      ).trim();
-      if (!token || seenTokens.has(token)) {
-        continue;
-      }
-      seenTokens.add(token);
-      tokens.push(token);
-    }
-  }
-
-  return tokens;
-}
-
-function cadRefQueryValueFromToken(token) {
-  const parsedToken = parseCadRefToken(token);
-  if (!parsedToken) {
-    return "";
-  }
-  return parsedToken.selectors.length ? parsedToken.selectors.join(",") : parsedToken.token;
-}
-
 export function readCadParam() {
   if (typeof window === "undefined") {
     return null;
@@ -146,38 +107,6 @@ export function readCadDirParam() {
     ? String(value).trim()
     : "";
   return normalizedValue || null;
-}
-
-export function readCadRefQueryParams() {
-  if (typeof window === "undefined") {
-    return [];
-  }
-  const params = new URLSearchParams(window.location.search);
-  return normalizeCadRefQueryParams(params.getAll(CAD_REF_QUERY_PARAM));
-}
-
-export function cadRefQueryParamsFromUrl(urlValue, baseUrl = "") {
-  const normalizedUrl = String(urlValue || "").trim();
-  if (!normalizedUrl) {
-    return [];
-  }
-  try {
-    const url = new URL(normalizedUrl, baseUrl || "http://localhost/");
-    return normalizeCadRefQueryParams(url.searchParams.getAll(CAD_REF_QUERY_PARAM));
-  } catch {
-    return [];
-  }
-}
-
-export function readNavigationCadRefQueryParams() {
-  if (typeof window === "undefined") {
-    return [];
-  }
-  const entries = typeof window.performance?.getEntriesByType === "function"
-    ? window.performance.getEntriesByType("navigation")
-    : [];
-  const navigationUrl = String(entries?.[0]?.name || "").trim();
-  return cadRefQueryParamsFromUrl(navigationUrl, window.location.href);
 }
 
 export function findEntryByUrlPath(entries, urlPath) {
@@ -225,20 +154,14 @@ export function missingFileRefForCatalog({
   return normalizedFileParam;
 }
 
-export function findEntryByCadRefParams(entries, cadRefs = readCadRefQueryParams()) {
-  void entries;
-  void cadRefs;
-  return null;
-}
-
-export function selectedEntryKeyFromUrl(entries, { cadRefs = readCadRefQueryParams(), defaultFile = readDefaultCadParam() } = {}) {
+export function selectedEntryKeyFromUrl(entries, { defaultFile = readDefaultCadParam() } = {}) {
   const explicitFilePath = readCadParam();
   if (explicitFilePath) {
     const match = findEntryByUrlPath(entries, explicitFilePath);
     return match ? fileKey(match) : "";
   }
 
-  const match = findEntryByCadRefParams(entries, cadRefs) || findEntryByUrlPath(entries, normalizeCadFileQueryParam(defaultFile));
+  const match = findEntryByUrlPath(entries, normalizeCadFileQueryParam(defaultFile));
   return match ? fileKey(match) : "";
 }
 
@@ -248,6 +171,7 @@ export function writeCadParam(urlPath, { history = "replace" } = {}) {
   }
   const normalizedUrlPath = normalizeCadFileQueryParam(urlPath);
   const url = new URL(window.location.href);
+  url.searchParams.delete("refs");
   if (normalizedUrlPath) {
     url.searchParams.set(CAD_QUERY_PARAM, normalizedUrlPath);
     if (url.searchParams.has(CAD_DIR_QUERY_PARAM)) {
@@ -270,6 +194,7 @@ export function writeCadDirParam(dirPath, { history = "replace", preserveFile = 
   }
   const normalizedDirPath = String(dirPath || "").trim();
   const url = new URL(window.location.href);
+  url.searchParams.delete("refs");
   if (!preserveFile) {
     url.searchParams.delete(CAD_QUERY_PARAM);
   }
@@ -280,21 +205,6 @@ export function writeCadDirParam(dirPath, { history = "replace", preserveFile = 
     url.searchParams.delete(CAD_DIR_QUERY_PARAM);
   }
   return writeUrl(url, { history });
-}
-
-export function writeCadRefQueryParams(cadRefs) {
-  if (typeof window === "undefined") {
-    return;
-  }
-  const url = new URL(window.location.href);
-  url.searchParams.delete(CAD_REF_QUERY_PARAM);
-  for (const token of Array.isArray(cadRefs) ? cadRefs : [cadRefs]) {
-    const queryValue = cadRefQueryValueFromToken(token);
-    if (queryValue) {
-      url.searchParams.append(CAD_REF_QUERY_PARAM, queryValue);
-    }
-  }
-  writeUrl(url);
 }
 
 function compareSidebarLabels(a, b) {

--- a/viewer/src/client/workbench/sidebar.test.js
+++ b/viewer/src/client/workbench/sidebar.test.js
@@ -7,21 +7,17 @@ import {
   findSidebarDirectoryById,
   findEntryByUrlPath,
   missingFileRefForCatalog,
-  cadRefQueryParamsFromUrl,
   selectedEntryKeyFromUrl,
   listSidebarItems,
   filenameLabelForEntry,
   normalizeCadFileQueryParam,
-  normalizeCadRefQueryParams,
   readCadDirParam,
-  readNavigationCadRefQueryParams,
   sidebarDirectoryPath,
   sidebarDirectoryIdForEntry,
   sidebarLabelForEntry,
   shouldDeferFileParamSelection,
   writeCadDirParam,
-  writeCadParam,
-  writeCadRefQueryParams
+  writeCadParam
 } from "./sidebar.js";
 import {
   buildAvailableThemePresets,
@@ -1722,51 +1718,6 @@ test("theme persistence ignores legacy full preset payloads", () => {
   }
 });
 
-test("normalizeCadRefQueryParams accepts selector refs", () => {
-  assert.deepEqual(
-    normalizeCadRefQueryParams(["#f2", "o1.2,f1", "m2"]),
-    ["#f2", "#o1.2,o1.2.f1", "#m2"]
-  );
-});
-
-test("cadRefQueryParamsFromUrl reads encoded mate refs", () => {
-  assert.deepEqual(
-    cadRefQueryParamsFromUrl("http://viewer.test/?file=assembly.step&refs=%23m2"),
-    ["#m2"]
-  );
-  assert.deepEqual(
-    cadRefQueryParamsFromUrl("http://viewer.test/?file=assembly.step&refs=m2"),
-    ["#m2"]
-  );
-});
-
-test("readNavigationCadRefQueryParams recovers original URL refs", () => {
-  const originalWindow = globalThis.window;
-  globalThis.window = {
-    location: {
-      href: "http://viewer.test/?file=assembly.step",
-      search: "?file=assembly.step"
-    },
-    performance: {
-      getEntriesByType: (type) => (
-        type === "navigation"
-          ? [{ name: "http://viewer.test/?file=assembly.step&refs=%23m2" }]
-          : []
-      )
-    }
-  };
-
-  try {
-    assert.deepEqual(readNavigationCadRefQueryParams(), ["#m2"]);
-  } finally {
-    if (originalWindow === undefined) {
-      delete globalThis.window;
-    } else {
-      globalThis.window = originalWindow;
-    }
-  }
-});
-
 test("selectedEntryKeyFromUrl restores the selected file query param", () => {
   const originalWindow = globalThis.window;
   globalThis.window = {
@@ -1866,7 +1817,7 @@ test("selectedEntryKeyFromUrl does not fall back to VIEWER_DEFAULT_FILE for miss
   }
 });
 
-test("selectedEntryKeyFromUrl does not use refs to mask a missing explicit file param", () => {
+test("selectedEntryKeyFromUrl ignores retired refs when explicit file param is missing", () => {
   const originalWindow = globalThis.window;
   globalThis.window = {
     location: {
@@ -1894,7 +1845,7 @@ test("selectedEntryKeyFromUrl does not use refs to mask a missing explicit file 
   }
 });
 
-test("selectedEntryKeyFromUrl does not use selector refs as file identity", () => {
+test("selectedEntryKeyFromUrl ignores retired refs as file identity", () => {
   const originalWindow = globalThis.window;
   globalThis.window = {
     location: {
@@ -2137,7 +2088,7 @@ test("normalizeCadFileQueryParam normalizes file params as relative paths", () =
   assert.equal(normalizeCadFileQueryParam("/workspace/imports/widget.step/"), "workspace/imports/widget.step");
 });
 
-test("selectedEntryKeyFromUrl ignores selector refs without a file context", () => {
+test("selectedEntryKeyFromUrl ignores retired refs without a file context", () => {
   const originalWindow = globalThis.window;
   globalThis.window = {
     location: {
@@ -2175,9 +2126,9 @@ test("writeCadParam skips unchanged URL replacements", () => {
   const calls = [];
   globalThis.window = {
     location: {
-      href: "http://viewer.test/?file=parts%2Fsample_plate.step&refs=f2",
+      href: "http://viewer.test/?file=parts%2Fsample_plate.step",
       pathname: "/",
-      search: "?file=parts%2Fsample_plate.step&refs=f2",
+      search: "?file=parts%2Fsample_plate.step",
       hash: ""
     },
     history: {
@@ -2191,7 +2142,35 @@ test("writeCadParam skips unchanged URL replacements", () => {
 
     writeCadParam("parts/sample_base.step");
     assert.equal(calls.length, 1);
-    assert.equal(calls[0][2], "/?file=parts%2Fsample_base.step&refs=f2");
+    assert.equal(calls[0][2], "/?file=parts%2Fsample_base.step");
+  } finally {
+    if (originalWindow === undefined) {
+      delete globalThis.window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+  }
+});
+
+test("writeCadParam drops retired refs query params", () => {
+  const originalWindow = globalThis.window;
+  const calls = [];
+  globalThis.window = {
+    location: {
+      href: "http://viewer.test/?file=parts%2Fsample_plate.step&refs=f2",
+      pathname: "/",
+      search: "?file=parts%2Fsample_plate.step&refs=f2",
+      hash: ""
+    },
+    history: {
+      replaceState: (...args) => calls.push(args)
+    }
+  };
+
+  try {
+    writeCadParam("parts/sample_plate.step");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][2], "/?file=parts%2Fsample_plate.step");
   } finally {
     if (originalWindow === undefined) {
       delete globalThis.window;
@@ -2252,7 +2231,7 @@ test("writeCadParam stores active dir and omits dir for directory file selection
     const nextUrl = new URL(`http://viewer.test${calls[0][2]}`);
     assert.equal(nextUrl.searchParams.has("dir"), false);
     assert.equal(nextUrl.searchParams.get("file"), "hero/planetary_gear_assembly.step.glb");
-    assert.equal(nextUrl.searchParams.get("refs"), "#f2");
+    assert.equal(nextUrl.searchParams.has("refs"), false);
     assert.equal(readStoredActiveCadDir(), "docs/public");
   } finally {
     if (originalWindow === undefined) {
@@ -2348,39 +2327,8 @@ test("writeCadDirParam selects a workspace and clears file selection", () => {
     const nextUrl = new URL(`http://viewer.test${calls[0][3]}`);
     assert.equal(nextUrl.searchParams.get("dir"), "/workspace/models");
     assert.equal(nextUrl.searchParams.has("file"), false);
-    assert.equal(nextUrl.searchParams.get("refs"), "f2");
+    assert.equal(nextUrl.searchParams.has("refs"), false);
     assert.equal(readStoredActiveCadDir(), "/workspace/models");
-  } finally {
-    if (originalWindow === undefined) {
-      delete globalThis.window;
-    } else {
-      globalThis.window = originalWindow;
-    }
-  }
-});
-
-test("writeCadRefQueryParams skips unchanged URL replacements", () => {
-  const originalWindow = globalThis.window;
-  const calls = [];
-  globalThis.window = {
-    location: {
-      href: "http://viewer.test/?file=parts%2Fsample_plate.step&refs=f2",
-      pathname: "/",
-      search: "?file=parts%2Fsample_plate.step&refs=f2",
-      hash: ""
-    },
-    history: {
-      replaceState: (...args) => calls.push(args)
-    }
-  };
-
-  try {
-    writeCadRefQueryParams(["#f2"]);
-    assert.equal(calls.length, 0);
-
-    writeCadRefQueryParams(["#e1"]);
-    assert.equal(calls.length, 1);
-    assert.equal(calls[0][2], "/?file=parts%2Fsample_plate.step&refs=e1");
   } finally {
     if (originalWindow === undefined) {
       delete globalThis.window;


### PR DESCRIPTION
## Summary

Remove the CAD Viewer `refs` query parameter surface with no backwards compatibility.

- Delete the URL parsing, navigation recovery, and URL-writing paths for selected CAD refs.
- Treat existing `?refs=` values as retired URL state: they no longer select entries or restore selections, and file/dir URL updates drop them.
- Remove the now-unused query-ref resolver helpers and update the storage docs/tests to reflect the supported URL params.

## Impact

Viewer URLs now use `file`, `dir`, and other still-supported query params only. CAD reference selection remains available in the UI and copy helpers, but it is no longer represented in shareable URLs.

## Validation

- `npm --prefix viewer test -- src/client/workbench/sidebar.test.js src/client/workbench/referenceSelection.test.js`
- `npm --prefix viewer test`
- `npm --prefix viewer run build`
- pre-commit bundle freshness checks and Viewer sourcemap build
- `git diff --check`