### PR TITLE
feat(cad-workbench): add docker stack and switch /workspace to a named volume

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -124,13 +124,16 @@ COPY .docker/opencode.json /opt/opencode-defaults/opencode.json
 # Entrypoint
 COPY .docker/entrypoint.sh /entrypoint.sh
 
-# Project source
-WORKDIR /workspace
+# Project source — copied into an image-internal seed path so it can be
+# materialized into the /workspace named volume at container startup
+# without depending on a host bind mount.
+WORKDIR /opt/workspace-seed
 COPY . .
 
 # Preserve viewer source at non-shadowed path
-# (bind mount /workspace at runtime may shadow /workspace/viewer)
-RUN cp -r /workspace/viewer /opt/viewer-source && \
+# (named volume /workspace at runtime will shadow /opt/workspace-seed)
+RUN mkdir -p /opt/viewer-source && \
+    cp -r /opt/workspace-seed/viewer /opt/viewer-source && \
     chmod +x /entrypoint.sh
 
 # Pre-create opencode data dir with correct ownership
@@ -147,9 +150,6 @@ RUN /opt/venv/bin/python -c "import build123d; print('build123d:', build123d.__v
     opencode --version
 
 USER opencode
-
-# Pre-install Playwright browser for CAD Viewer testing
-RUN npx playwright install chromium 2>&1
 
 WORKDIR /workspace
 

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -10,8 +10,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-dev python3-pip python3-venv \
     git git-lfs \
     build-essential \
-    ttyd \
+    tmux ttyd \
     libgl1 libglib2.0-0 libsm6 libxext6 libxrender-dev \
+    libnspr4 libnss3 libatk1.0-0t64 libatk-bridge2.0-0t64 \
+    libcups2t64 libdrm2 libdbus-1-3 libxkbcommon0 \
+    libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+    libgbm1 libpango-1.0-0 libcairo2 libasound2t64 libatspi2.0-0t64 \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Node.js 22 (matches CI) ──
@@ -82,6 +86,7 @@ COPY viewer/packages/ viewer/packages/
 
 RUN mkdir -p /opt/viewer-node-modules && \
     cp -r viewer /opt/viewer-node-modules/ && \
+    cp -r packages /opt/viewer-node-modules/packages && \
     cd /opt/viewer-node-modules/viewer && \
     npm install --no-audit --no-fund 2>&1
 
@@ -122,11 +127,18 @@ COPY .docker/entrypoint.sh /entrypoint.sh
 # Project source
 WORKDIR /workspace
 COPY . .
-RUN chmod +x /entrypoint.sh
+
+# Preserve viewer source at non-shadowed path
+# (bind mount /workspace at runtime may shadow /workspace/viewer)
+RUN cp -r /workspace/viewer /opt/viewer-source && \
+    chmod +x /entrypoint.sh
 
 # Pre-create opencode data dir with correct ownership
 RUN mkdir -p /home/opencode/.config/opencode /home/opencode/.local/share/opencode && \
-    chown -R opencode:opencode /home/opencode /opt/venv /opt/viewer-node-modules /opt/opencode-defaults
+    chown -R opencode:opencode /home/opencode /opt/venv /opt/viewer-node-modules /opt/opencode-defaults /opt/viewer-source
+
+# Make bun + global bins (opencode, etc.) available to the opencode user
+RUN cp -r /root/.bun /home/opencode/.bun && chown -R opencode:opencode /home/opencode/.bun
 
 # Verify key tools
 RUN /opt/venv/bin/python -c "import build123d; print('build123d:', build123d.__version__)" && \
@@ -135,7 +147,11 @@ RUN /opt/venv/bin/python -c "import build123d; print('build123d:', build123d.__v
     opencode --version
 
 USER opencode
+
+# Pre-install Playwright browser for CAD Viewer testing
+RUN npx playwright install chromium 2>&1
+
 WORKDIR /workspace
 
-EXPOSE 8080 5173
+EXPOSE 5080 5173
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git git-lfs \
     build-essential \
     ttyd \
+    libgl1 libglib2.0-0 libsm6 libxext6 libxrender-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Node.js 22 (matches CI) ──
@@ -34,36 +35,37 @@ RUN bun install -g opencode-ai && opencode --version
 FROM base AS python-deps
 WORKDIR /build
 
-# Copy only dependency manifests for layer caching
-COPY packages/cadpy/pyproject.toml packages/cadpy/
-COPY packages/cadpy_metadata/pyproject.toml packages/cadpy_metadata/
+# Copy package source trees for pip install
+COPY packages/cadpy/ packages/cadpy/
+COPY packages/cadpy_metadata/ packages/cadpy_metadata/
 
 RUN python3 -m venv /opt/venv && \
     . /opt/venv/bin/activate && \
     pip install --upgrade pip --quiet && \
     pip install build123d --quiet && \
-    pip install -e packages/cadpy --quiet && \
-    pip install -e packages/cadpy_metadata --quiet
+    pip install packages/cadpy --quiet && \
+    pip install packages/cadpy_metadata --quiet
 
-# Skill-specific Python deps
-COPY skills/cad/requirements.txt skills/cad/requirements.txt
-COPY skills/dxf/requirements.txt skills/dxf/requirements.txt
-COPY skills/urdf/requirements.txt skills/urdf/requirements.txt
-COPY skills/srdf/requirements.txt skills/srdf/requirements.txt
-COPY skills/sdf/requirements.txt skills/sdf/requirements.txt
-COPY skills/cad-viewer/requirements.txt skills/cad-viewer/requirements.txt
+# Skill-specific Python deps (cadpy/cadpy_metadata already installed above)
+COPY skills/cad/requirements.txt skills/cad/
+COPY skills/dxf/requirements.txt skills/dxf/
+COPY skills/urdf/requirements.txt skills/urdf/
+COPY skills/srdf/requirements.txt skills/srdf/
+COPY skills/sdf/requirements.txt skills/sdf/
+COPY skills/cad-viewer/requirements.txt skills/cad-viewer/
 
 RUN . /opt/venv/bin/activate && \
-    pip install \
-        -r skills/cad/requirements.txt \
-        -r skills/dxf/requirements.txt \
-        -r skills/urdf/requirements.txt \
-        -r skills/srdf/requirements.txt \
-        -r skills/sdf/requirements.txt \
-        -r skills/cad-viewer/requirements.txt \
-        --quiet && \
+    grep -h -v '^--editable' \
+        skills/cad/requirements.txt \
+        skills/dxf/requirements.txt \
+        skills/urdf/requirements.txt \
+        skills/srdf/requirements.txt \
+        skills/sdf/requirements.txt \
+        skills/cad-viewer/requirements.txt \
+        > /tmp/skill_reqs.txt && \
+    pip install -r /tmp/skill_reqs.txt --quiet && \
     pip install ezdxf networkx trimesh --quiet && \
-    rm -rf /root/.cache/pip
+    rm -rf /root/.cache/pip /tmp/skill_reqs.txt
 
 # =============================================================================
 # Stage: node-deps — Viewer and skill JS dependencies
@@ -101,8 +103,8 @@ RUN if [ -f skills/cad-viewer/scripts/viewer/package.json ]; then \
 
 FROM base AS final
 
-# Create runtime user
-RUN useradd -m -s /bin/bash -u 1000 opencode
+# Create runtime user (Ubuntu 24.04 ships an ubuntu user at UID 1000; remove it first)
+RUN userdel ubuntu 2>/dev/null; useradd -m -s /bin/bash -u 1000 opencode
 
 # Copy Python venv from python-deps stage
 COPY --from=python-deps /opt/venv /opt/venv

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,138 @@
+# =============================================================================
+# text-to-cad + OpenCode Docker Environment
+# Base: Ubuntu 24.04 (Noble Numbat)
+# =============================================================================
+
+FROM ubuntu:24.04 AS base
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl unzip \
+    python3 python3-dev python3-pip python3-venv \
+    git git-lfs \
+    build-essential \
+    ttyd \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Node.js 22 (matches CI) ──
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && node --version | grep -q "^v22"
+
+# ── Bun (for opencode-ai) ──
+RUN curl -fsSL https://bun.sh/install | bash
+ENV BUN_INSTALL=/root/.bun
+ENV PATH=$BUN_INSTALL/bin:$PATH
+
+# ── OpenCode ──
+RUN bun install -g opencode-ai && opencode --version
+
+# =============================================================================
+# Stage: python-deps — CAD Python packages
+# =============================================================================
+
+FROM base AS python-deps
+WORKDIR /build
+
+# Copy only dependency manifests for layer caching
+COPY packages/cadpy/pyproject.toml packages/cadpy/
+COPY packages/cadpy_metadata/pyproject.toml packages/cadpy_metadata/
+
+RUN python3 -m venv /opt/venv && \
+    . /opt/venv/bin/activate && \
+    pip install --upgrade pip --quiet && \
+    pip install build123d --quiet && \
+    pip install -e packages/cadpy --quiet && \
+    pip install -e packages/cadpy_metadata --quiet
+
+# Skill-specific Python deps
+COPY skills/cad/requirements.txt skills/cad/requirements.txt
+COPY skills/dxf/requirements.txt skills/dxf/requirements.txt
+COPY skills/urdf/requirements.txt skills/urdf/requirements.txt
+COPY skills/srdf/requirements.txt skills/srdf/requirements.txt
+COPY skills/sdf/requirements.txt skills/sdf/requirements.txt
+COPY skills/cad-viewer/requirements.txt skills/cad-viewer/requirements.txt
+
+RUN . /opt/venv/bin/activate && \
+    pip install \
+        -r skills/cad/requirements.txt \
+        -r skills/dxf/requirements.txt \
+        -r skills/urdf/requirements.txt \
+        -r skills/srdf/requirements.txt \
+        -r skills/sdf/requirements.txt \
+        -r skills/cad-viewer/requirements.txt \
+        --quiet && \
+    pip install ezdxf networkx trimesh --quiet
+
+# Clean pip cache to reduce image size
+RUN rm -rf /root/.cache/pip
+
+# =============================================================================
+# Stage: node-deps — Viewer and skill JS dependencies
+# =============================================================================
+
+FROM base AS node-deps
+WORKDIR /build
+
+# Pre-install viewer dependencies at /opt/viewer-node-modules
+COPY viewer/package.json viewer/package-lock.json viewer/
+COPY packages/cadjs/ packages/cadjs/
+COPY packages/implicitjs/ packages/implicitjs/
+COPY viewer/packages/ viewer/packages/
+
+RUN mkdir -p /opt/viewer-node-modules && \
+    cp -r viewer /opt/viewer-node-modules/ && \
+    cd /opt/viewer-node-modules/viewer && \
+    npm install --no-audit --no-fund 2>&1
+
+# Also pre-install for the cad-viewer skill's viewer path
+COPY skills/cad-viewer/scripts/viewer/package.json skills/cad-viewer/scripts/viewer/ 2>/dev/null || true
+RUN if [ -f skills/cad-viewer/scripts/viewer/package.json ]; then \
+        mkdir -p /opt/viewer-node-modules/skill-viewer && \
+        cp -r skills/cad-viewer/scripts/viewer /opt/viewer-node-modules/skill-viewer/ && \
+        cd /opt/viewer-node-modules/skill-viewer/viewer && \
+        npm install --no-audit --no-fund 2>&1; \
+    fi
+
+# =============================================================================
+# Stage: final — assemble runtime
+# =============================================================================
+
+FROM base AS final
+
+# Create runtime user
+RUN useradd -m -s /bin/bash -u 1000 opencode
+
+# Copy Python venv from python-deps stage
+COPY --from=python-deps /opt/venv /opt/venv
+
+# Copy viewer node_modules from node-deps stage
+COPY --from=node-deps /opt/viewer-node-modules /opt/viewer-node-modules
+
+# Copy project source
+WORKDIR /workspace
+COPY . .
+
+# OpenCode defaults config
+RUN mkdir -p /opt/opencode-defaults
+COPY .docker/opencode.json /opt/opencode-defaults/opencode.json
+
+# Entrypoint
+COPY .docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Pre-create opencode data dir with correct ownership
+RUN mkdir -p /home/opencode/.config/opencode /home/opencode/.local/share/opencode && \
+    chown -R opencode:opencode /home/opencode /opt/venv /opt/viewer-node-modules /opt/opencode-defaults
+
+# Verify key tools
+RUN /opt/venv/bin/python -c "import build123d; print('build123d:', build123d.__version__)" && \
+    /opt/venv/bin/python -c "import cadpy; print('cadpy: OK')" && \
+    node --version && \
+    opencode --version
+
+USER opencode
+WORKDIR /workspace
+
+EXPOSE 8080 5173
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -62,10 +62,8 @@ RUN . /opt/venv/bin/activate && \
         -r skills/sdf/requirements.txt \
         -r skills/cad-viewer/requirements.txt \
         --quiet && \
-    pip install ezdxf networkx trimesh --quiet
-
-# Clean pip cache to reduce image size
-RUN rm -rf /root/.cache/pip
+    pip install ezdxf networkx trimesh --quiet && \
+    rm -rf /root/.cache/pip
 
 # =============================================================================
 # Stage: node-deps — Viewer and skill JS dependencies
@@ -86,7 +84,10 @@ RUN mkdir -p /opt/viewer-node-modules && \
     npm install --no-audit --no-fund 2>&1
 
 # Also pre-install for the cad-viewer skill's viewer path
-COPY skills/cad-viewer/scripts/viewer/package.json skills/cad-viewer/scripts/viewer/ 2>/dev/null || true
+# COPY here (even without a conditional guard) brings the viewer source into
+# the build stage for npm install; the RUN cp to /opt preserves the same
+# directory structure the entrypoint symlink trick expects.
+COPY skills/cad-viewer/scripts/viewer/ /build/skills/cad-viewer/scripts/viewer/
 RUN if [ -f skills/cad-viewer/scripts/viewer/package.json ]; then \
         mkdir -p /opt/viewer-node-modules/skill-viewer && \
         cp -r skills/cad-viewer/scripts/viewer /opt/viewer-node-modules/skill-viewer/ && \
@@ -109,16 +110,16 @@ COPY --from=python-deps /opt/venv /opt/venv
 # Copy viewer node_modules from node-deps stage
 COPY --from=node-deps /opt/viewer-node-modules /opt/viewer-node-modules
 
-# Copy project source
-WORKDIR /workspace
-COPY . .
-
 # OpenCode defaults config
 RUN mkdir -p /opt/opencode-defaults
 COPY .docker/opencode.json /opt/opencode-defaults/opencode.json
 
 # Entrypoint
 COPY .docker/entrypoint.sh /entrypoint.sh
+
+# Project source
+WORKDIR /workspace
+COPY . .
 RUN chmod +x /entrypoint.sh
 
 # Pre-create opencode data dir with correct ownership

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -6,26 +6,25 @@ set -e
 # .venv and node_modules shadow the ones we built during docker build.
 # We relocate deps to /opt/ and symlink them back at runtime.
 
-# Python venv
+# Python venv — tolerate failure when host volume prevents symlink
 if [ -d /opt/venv ] && [ ! -f /workspace/.venv/bin/activate ]; then
     rm -rf /workspace/.venv 2>/dev/null || true
-    ln -sf /opt/venv /workspace/.venv
+    ln -sf /opt/venv /workspace/.venv 2>/dev/null || true
 fi
 
-# Viewer node_modules
+# Viewer node_modules — same tolerance
 if [ -d /opt/viewer-node-modules/node_modules ] && [ ! -f /workspace/viewer/node_modules/.package-lock.json ]; then
     rm -rf /workspace/viewer/node_modules 2>/dev/null || true
-    mkdir -p /workspace/viewer
-    ln -sf /opt/viewer-node-modules/node_modules /workspace/viewer/node_modules
+    mkdir -p /workspace/viewer 2>/dev/null || true
+    ln -sf /opt/viewer-node-modules/node_modules /workspace/viewer/node_modules 2>/dev/null || true
 fi
 
-# CAD Viewer packaged runtime — the production viewer bundle lives inside
-# the cad-viewer skill directory for the agent:start command
+# CAD Viewer packaged runtime
 SKILL_VIEWER_DIR="/workspace/skills/cad-viewer/scripts/viewer"
 if [ -d /opt/viewer-node-modules/skill-viewer ] && [ -d "$SKILL_VIEWER_DIR" ]; then
     if [ ! -f "$SKILL_VIEWER_DIR/node_modules/.package-lock.json" ]; then
         rm -rf "$SKILL_VIEWER_DIR/node_modules" 2>/dev/null || true
-        ln -sf /opt/viewer-node-modules/skill-viewer/node_modules "$SKILL_VIEWER_DIR/node_modules"
+        ln -sf /opt/viewer-node-modules/skill-viewer/node_modules "$SKILL_VIEWER_DIR/node_modules" 2>/dev/null || true
     fi
 fi
 

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -12,14 +12,30 @@ if [ -d /opt/venv ] && [ ! -f /workspace/.venv/bin/activate ]; then
     ln -sf /opt/venv /workspace/.venv 2>/dev/null || true
 fi
 
-# Viewer node_modules — same tolerance
-if [ -d /opt/viewer-node-modules/node_modules ] && [ ! -f /workspace/viewer/node_modules/.package-lock.json ]; then
-    rm -rf /workspace/viewer/node_modules 2>/dev/null || true
-    mkdir -p /workspace/viewer 2>/dev/null || true
-    ln -sf /opt/viewer-node-modules/node_modules /workspace/viewer/node_modules 2>/dev/null || true
+# Viewer node_modules and packages — set up at non-shadowed path
+if [ -d /opt/viewer-source ]; then
+    # Fix packages symlinks (the build-time symlink chain is broken after COPY)
+    rm -f /opt/viewer-source/packages/cadjs /opt/viewer-source/packages/implicitjs 2>/dev/null || true
+    for pkg in cadjs implicitjs; do
+        if [ -d /opt/viewer-node-modules/packages/$pkg ]; then
+            ln -sf /opt/viewer-node-modules/packages/$pkg /opt/viewer-source/packages/$pkg 2>/dev/null || true
+        fi
+    done
+
+    # Link pre-installed node_modules
+    if [ ! -f /opt/viewer-source/node_modules/.package-lock.json ] && \
+       [ -d /opt/viewer-node-modules/viewer/node_modules ]; then
+        rm -rf /opt/viewer-source/node_modules 2>/dev/null || true
+        ln -sf /opt/viewer-node-modules/viewer/node_modules /opt/viewer-source/node_modules 2>/dev/null || true
+    fi
+
+    # Start Vite dev server in background
+    if [ -f /opt/viewer-source/node_modules/.bin/vite ]; then
+        cd /opt/viewer-source && nohup npx vite --host 0.0.0.0 --port 5173 > /tmp/vite-viewer.log 2>&1 &
+    fi
 fi
 
-# CAD Viewer packaged runtime
+# CAD Viewer packaged runtime (skill directory)
 SKILL_VIEWER_DIR="/workspace/skills/cad-viewer/scripts/viewer"
 if [ -d /opt/viewer-node-modules/skill-viewer ] && [ -d "$SKILL_VIEWER_DIR" ]; then
     if [ ! -f "$SKILL_VIEWER_DIR/node_modules/.package-lock.json" ]; then
@@ -44,10 +60,12 @@ export BUN_INSTALL=/home/opencode/.bun
 
 cd /workspace
 
-# ── Start ttyd with tmux + opencode ──
-# tmux runs in background so if the browser tab disconnects and reconnects,
-# ttyd reattaches to the same session instead of starting a new opencode process.
-exec ttyd -p 8080 -W \
-    tmux new-session -A -s oc \; \
-    send-keys "cd /workspace && . /opt/venv/bin/activate && exec opencode" Enter \; \
-    attach-session -t oc
+# ── Pre-create tmux session with opencode ──
+# Create a detached tmux session running opencode so it's ready when the
+# first browser tab connects.  Subsequent reconnects (e.g. after a tab
+# close) reattach to the same session, preserving the opencode process.
+tmux new-session -d -s oc \; \
+    send-keys "cd /workspace && . /opt/venv/bin/activate && exec opencode" Enter
+
+# ── Start ttyd → attach to existing tmux session ──
+exec ttyd -p 5080 -W tmux attach-session -t oc

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+# ── Symlink workaround for Docker volume mount ──
+# When the project is mounted at /workspace, the host's empty/missing
+# .venv and node_modules shadow the ones we built during docker build.
+# We relocate deps to /opt/ and symlink them back at runtime.
+
+# Python venv
+if [ -d /opt/venv ] && [ ! -f /workspace/.venv/bin/activate ]; then
+    rm -rf /workspace/.venv 2>/dev/null || true
+    ln -sf /opt/venv /workspace/.venv
+fi
+
+# Viewer node_modules
+if [ -d /opt/viewer-node-modules/node_modules ] && [ ! -f /workspace/viewer/node_modules/.package-lock.json ]; then
+    rm -rf /workspace/viewer/node_modules 2>/dev/null || true
+    mkdir -p /workspace/viewer
+    ln -sf /opt/viewer-node-modules/node_modules /workspace/viewer/node_modules
+fi
+
+# CAD Viewer packaged runtime — the production viewer bundle lives inside
+# the cad-viewer skill directory for the agent:start command
+SKILL_VIEWER_DIR="/workspace/skills/cad-viewer/scripts/viewer"
+if [ -d /opt/viewer-node-modules/skill-viewer ] && [ -d "$SKILL_VIEWER_DIR" ]; then
+    if [ ! -f "$SKILL_VIEWER_DIR/node_modules/.package-lock.json" ]; then
+        rm -rf "$SKILL_VIEWER_DIR/node_modules" 2>/dev/null || true
+        ln -sf /opt/viewer-node-modules/skill-viewer/node_modules "$SKILL_VIEWER_DIR/node_modules"
+    fi
+fi
+
+# ── OpenCode config ──
+export OPENCODE_CONFIG_DIR="${OPENCODE_CONFIG_DIR:-/home/opencode/.config/opencode}"
+mkdir -p "$OPENCODE_CONFIG_DIR"
+
+# Copy default opencode.json if config dir is empty (first start)
+if [ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ]; then
+    cp /opt/opencode-defaults/opencode.json "$OPENCODE_CONFIG_DIR/"
+fi
+
+# ── Environment ──
+export VIRTUAL_ENV=/opt/venv
+export PATH="/opt/venv/bin:/home/opencode/.bun/bin:$PATH"
+export BUN_INSTALL=/home/opencode/.bun
+
+cd /workspace
+
+# ── Start ttyd with tmux + opencode ──
+# tmux runs in background so if the browser tab disconnects and reconnects,
+# ttyd reattaches to the same session instead of starting a new opencode process.
+exec ttyd -p 8080 -W \
+    tmux new-session -s oc -d \; \
+    send-keys "cd /workspace && . /opt/venv/bin/activate && exec opencode" Enter

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,6 +1,54 @@
 #!/bin/bash
 set -e
 
+RUNTIME_UID="${LOCAL_UID:-1000}"
+RUNTIME_GID="${LOCAL_GID:-1000}"
+
+if [ "${1:-}" = "--as-opencode" ]; then
+    shift
+fi
+
+if [ "$(id -u)" -eq 0 ]; then
+    current_uid="$(id -u opencode)"
+    current_gid="$(id -g opencode)"
+
+    if getent group "$RUNTIME_GID" >/dev/null; then
+        target_group="$(getent group "$RUNTIME_GID" | cut -d: -f1)"
+    else
+        groupmod -g "$RUNTIME_GID" opencode
+        target_group="opencode"
+    fi
+
+    if [ "$target_group" != "$(id -gn opencode)" ]; then
+        usermod -g "$target_group" opencode
+    fi
+
+    if existing_user="$(getent passwd "$RUNTIME_UID" | cut -d: -f1 2>/dev/null)"; then
+        if [ -n "$existing_user" ] && [ "$existing_user" != "opencode" ]; then
+            echo "LOCAL_UID $RUNTIME_UID is already owned by user '$existing_user'; set LOCAL_UID/LOCAL_GID explicitly." >&2
+            exit 1
+        fi
+    fi
+
+    if [ "$RUNTIME_UID" != "$current_uid" ]; then
+        usermod -u "$RUNTIME_UID" opencode
+    fi
+
+    mkdir -p /home/opencode/.config/opencode /home/opencode/.local/share/opencode
+
+    # Materialize the project source from the image-internal seed into the
+    # /workspace named volume on first boot.  Subsequent restarts skip the
+    # copy so generated files (models/, .venv, etc.) survive.
+    if [ -d /opt/workspace-seed ] && [ -z "$(ls -A /workspace 2>/dev/null)" ]; then
+        cp -a /opt/workspace-seed/. /workspace/
+    fi
+
+    mkdir -p /workspace/models
+    chown -R "$RUNTIME_UID:$RUNTIME_GID" /workspace
+
+    exec su -s /bin/bash opencode -c 'exec /entrypoint.sh --as-opencode'
+fi
+
 # ── Symlink workaround for Docker volume mount ──
 # When the project is mounted at /workspace, the host's empty/missing
 # .venv and node_modules shadow the ones we built during docker build.
@@ -28,11 +76,14 @@ if [ -d /opt/viewer-source ]; then
         rm -rf /opt/viewer-source/node_modules 2>/dev/null || true
         ln -sf /opt/viewer-node-modules/viewer/node_modules /opt/viewer-source/node_modules 2>/dev/null || true
     fi
+fi
 
-    # Start Vite dev server in background
-    if [ -f /opt/viewer-source/node_modules/.bin/vite ]; then
-        cd /opt/viewer-source && nohup npx vite --host 0.0.0.0 --port 5173 > /tmp/vite-viewer.log 2>&1 &
-    fi
+# Prefer running Vite from /workspace/viewer (named volume) so HMR sees
+# source edits; fall back to /opt/viewer-source only if the volume lacks it.
+if [ -d /workspace/viewer ] && [ -f /workspace/viewer/node_modules/.bin/vite ]; then
+    cd /workspace/viewer && nohup npx vite --host 0.0.0.0 --port 5173 > /tmp/vite-viewer.log 2>&1 &
+elif [ -f /opt/viewer-source/node_modules/.bin/vite ]; then
+    cd /opt/viewer-source && nohup npx vite --host 0.0.0.0 --port 5173 > /tmp/vite-viewer.log 2>&1 &
 fi
 
 # CAD Viewer packaged runtime (skill directory)
@@ -42,6 +93,20 @@ if [ -d /opt/viewer-node-modules/skill-viewer ] && [ -d "$SKILL_VIEWER_DIR" ]; t
         rm -rf "$SKILL_VIEWER_DIR/node_modules" 2>/dev/null || true
         ln -sf /opt/viewer-node-modules/skill-viewer/node_modules "$SKILL_VIEWER_DIR/node_modules" 2>/dev/null || true
     fi
+fi
+
+# Repair the seeded /workspace/viewer symlinks (the build-time seed carries
+# the source tree with placeholder symlinks to image-internal paths; re-link
+# node_modules and packages to the real cache so Vite resolves dependencies).
+if [ -d /workspace/viewer ] && [ -d /opt/viewer-node-modules/viewer/node_modules ]; then
+    rm -f /workspace/viewer/node_modules 2>/dev/null || true
+    ln -sf /opt/viewer-node-modules/viewer/node_modules /workspace/viewer/node_modules 2>/dev/null || true
+    for pkg in cadjs implicitjs; do
+        rm -f "/workspace/viewer/packages/$pkg" 2>/dev/null || true
+        if [ -d "/opt/viewer-node-modules/packages/$pkg" ]; then
+            ln -sf "/opt/viewer-node-modules/packages/$pkg" "/workspace/viewer/packages/$pkg" 2>/dev/null || true
+        fi
+    done
 fi
 
 # ── OpenCode config ──

--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -49,5 +49,6 @@ cd /workspace
 # tmux runs in background so if the browser tab disconnects and reconnects,
 # ttyd reattaches to the same session instead of starting a new opencode process.
 exec ttyd -p 8080 -W \
-    tmux new-session -s oc -d \; \
-    send-keys "cd /workspace && . /opt/venv/bin/activate && exec opencode" Enter
+    tmux new-session -A -s oc \; \
+    send-keys "cd /workspace && . /opt/venv/bin/activate && exec opencode" Enter \; \
+    attach-session -t oc

--- a/.docker/opencode.json
+++ b/.docker/opencode.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "skills": {
+    "paths": [
+      "/workspace/skills",
+      "/workspace/plugins/cad/skills"
+    ]
+  }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.gitattributes
+.gitignore
+.lfsconfig
+assets/
+benchmarks/
+node_modules/
+.venv/
+__pycache__/
+*.pyc
+.env
+.git-lfs/
+tmp/
+*.gif

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ htmlcov/
 # Local environments and caches
 .venv
 .cache
+.omo
 .agents/
 .vite
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ htmlcov/
 .cache
 .omo
 .agents/
+.playwright-mcp/
 .vite
 node_modules
 dist

--- a/.opencode/skills/cad-workbench.md
+++ b/.opencode/skills/cad-workbench.md
@@ -1,0 +1,93 @@
+---
+name: cad-workbench
+description: Verify the cad-workbench docker compose stack is running with the expected named-volume layout, writable AI output paths, and live ttyd / viewer HTTP endpoints.
+---
+
+# cad-workbench skill
+
+Use this skill to run the workbench's compose stack smoke test from inside an
+agent session. It wraps the durable `scripts/dev/compose-verify.sh` script;
+do not duplicate the checks here.
+
+## Triggers
+
+- "verify compose"
+- "check cad-workbench"
+- "smoke test the workbench"
+- "is docker compose up"
+- "驗證 docker compose"
+- "檢查 cad-workbench"
+
+---
+
+## When To Use
+
+- after `docker compose up -d` / `--build`
+- after any change to `docker-compose.yml`, `.docker/Dockerfile`, or
+  `.docker/entrypoint.sh`
+- when the user reports that AI-generated CAD files do not appear in the
+  viewer, or that the ttyd terminal is unreachable
+- before opening a PR that touches the workbench runtime
+
+Do **not** use for:
+
+- ad-hoc container shell commands (use `docker compose exec` directly)
+- full integration tests of viewer or skills (use the test suites in
+  `scripts/test/`)
+
+---
+
+## Required Inputs
+
+- (optional) `OPENCODE_TTYD_PORT` and `VIEWER_HOST_PORT` if the host ports
+  differ from the compose defaults (`5080` / `5173`)
+
+---
+
+## Procedure
+
+1. Run the verifier:
+   ```bash
+   OPENCODE_TTYD_PORT="${OPENCODE_TTYD_PORT:-5180}" \
+   VIEWER_HOST_PORT="${VIEWER_HOST_PORT:-8081}" \
+   scripts/dev/compose-verify.sh
+   ```
+2. If any check fails, read the `compose-verify` output and follow the
+   hints it prints (e.g. the `container status` section tells the operator
+   to bring services up).
+3. If the failure is on `compose config` or `/workspace` mount, treat it as
+   a `docker-compose.yml` regression and revert / fix that file before
+   continuing.
+
+---
+
+## What It Checks (Summary)
+
+The script asserts 10 sections / 15 checks:
+
+1. `docker compose config` declares `opencode_workspace` and has no host
+   bind on `/workspace`
+2. the `cad-workbench` service is `running`
+3. `/workspace` is mounted from the `opencode_workspace` named volume
+4. `/workspace` contains the seeded project tree
+5. `/workspace/viewer/{node_modules,packages/cadjs,packages/implicitjs}` are
+   symlinks to `/opt/viewer-node-modules/...`
+6. `/workspace/models` exists and is writable by the `opencode` user
+7. the `opencode` user can write and remove a test file under `/workspace`
+8. containers `127.0.0.1:5080` (ttyd) and `127.0.0.1:5173` (viewer) are
+   reachable
+9. Vite dev server is running from `/workspace/viewer`
+10. `http://127.0.0.1:5173/?dir=/workspace/models` returns `200`
+
+The script is read-only against compose state; it does not bring services up
+or down.
+
+---
+
+## Related Files
+
+- `docker-compose.yml`
+- `.docker/Dockerfile`
+- `.docker/entrypoint.sh`
+- `scripts/dev/compose-verify.sh`
+- `docs/knowledge/tooling/docker-compose-environment.md`

--- a/.opencode/skills/knowledge-capture.md
+++ b/.opencode/skills/knowledge-capture.md
@@ -1,0 +1,102 @@
+---
+name: knowledge-capture
+description: Manually capture reusable project knowledge into docs/knowledge markdown for Phase 1 validation.
+---
+
+# Knowledge Capture Skill
+
+Use this skill to manually write a knowledge entry after completing a task.
+
+## Triggers
+
+- "Capture project knowledge"
+- "Document this task as knowledge"
+- "Write a knowledge entry"
+- "Summarize this fix into docs"
+- "整理成知識庫"
+- "把這次任務寫成 knowledge"
+
+---
+
+## When To Use
+
+Use only when the work is done and at least one is true:
+- the task revealed a non-obvious fix,
+- the task exposed a repeated pitfall,
+- the task established a reusable pattern,
+- the task clarified a design decision,
+- the task produced a decision future contributors will need.
+
+Do **not** use for trivial edits, obvious refactors, or one-off experiments.
+
+---
+
+## Required Inputs
+
+Before writing, gather from the completed task:
+- task summary,
+- changed files,
+- validation evidence (tests, diagnostics, build result, observed behavior),
+- the key problem,
+- the actual solution,
+- any tradeoffs or side effects.
+
+---
+
+## Output Location Rules
+
+- `docs/knowledge/troubleshooting/` — bug fixes, incident patterns
+- `docs/knowledge/patterns/` — reusable implementation patterns
+- `docs/knowledge/architecture/` — design constraints or rationale
+- `docs/knowledge/tooling/` — environment, build, CI/CD, CLI
+
+If no file exists for the topic, create a new kebab-case markdown file.
+
+---
+
+## Required Document Format
+
+```
+# <Title>
+
+## Context
+## Problem
+## Solution
+## Why It Works
+## Side Effects / Tradeoffs
+## Evidence
+## Related Files
+## Tags
+```
+
+---
+
+## Writing Rules
+
+- Prefer facts over summaries.
+- Prefer short paragraphs and bullets over long prose.
+- Preserve concrete terms exactly: error text, env vars, commands, paths, versions.
+- Keep one file focused on one reusable lesson.
+- Merge into an existing file if the lesson is the same concept.
+- If the knowledge is task-local and not reusable, leave it in `.sisyphus/notepads/`.
+
+---
+
+## Validation Checklist
+
+After drafting, verify:
+1. **Reusable** — future tasks could benefit.
+2. **Scoped** — one concept, not a task dump.
+3. **Evidence-backed** — every claim is traceable.
+4. **Readable** — a human can skim it.
+5. **Non-duplicative** — no unnecessary repeat of existing entries.
+
+---
+
+## Rules
+
+- Never write knowledge before the task is complete.
+- Never record guesses as facts.
+- Never dump raw transcripts into `docs/knowledge/`.
+- Never create a giant catch-all file.
+- If evidence is missing, stop and ask.

--- a/.opencode/skills/sync-upstream.md
+++ b/.opencode/skills/sync-upstream.md
@@ -1,0 +1,83 @@
+---
+name: sync-upstream
+description: Rebase current feature branch onto latest upstream/develop. Syncs the fork's develop branch first, then rebases. For the earthtojake/text-to-cad fork workflow where CONTRIBUTING.md designates develop as the PR target.
+---
+
+# Sync fork with upstream
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review.
+
+## How it works
+
+Syncs `origin/develop` → `upstream/develop` (fast-forward), then rebases the
+**current feature branch** on top. Three refs touched in order:
+
+1. `git fetch upstream` → get latest upstream/develop
+2. `git checkout develop && merge --ff-only upstream/develop && push` → sync fork base
+3. `git checkout - && rebase develop` → replay feature commits onto new base
+
+The upstream repo uses `develop` as the PR target per CONTRIBUTING.md.
+
+## Prerequisites
+
+```bash
+# Verify before starting:
+git remote -v | grep upstream      # upstream must exist
+git rev-parse --abbrev-ref HEAD     # should NOT be develop or main
+git status --porcelain              # must be empty
+```
+
+## Workflow
+
+### Step 1 — Fetch upstream
+
+```bash
+git fetch upstream
+```
+
+### Step 2 — Fast-forward origin/develop
+
+```bash
+git checkout develop && git merge --ff-only upstream/develop && git push origin develop
+```
+
+`--ff-only` prevents accidental merge commits. If it fails, someone pushed
+directly to your fork's develop — fix manually before continuing.
+
+### Step 3 — Rebase feature branch
+
+```bash
+git checkout - && git rebase develop
+```
+
+Conflict resolution: `git rebase --continue` after each resolved file,
+`git rebase --abort` to cancel entirely.
+
+### Step 4 — Force-push (only if branch was already on origin)
+
+```bash
+git push --force-with-lease origin HEAD
+```
+
+`--force-with-lease` rejects if someone else pushed to this branch.
+If it fails, `git fetch origin HEAD && git log --oneline origin/HEAD..HEAD` to
+see what diverged, then coordinate with collaborators.
+
+## Verification
+
+```bash
+# develop is identical to upstream
+git rev-parse develop upstream/develop    # same hash
+
+# feature branch only has your commits (no duplicates)
+git log --oneline develop..HEAD            # your commits, clean
+```
+
+## When NOT to use
+
+- **Shared feature branches** — rebase rewrites history others depend on.
+  Use `git merge develop` instead.
+- **`--ff-only` fails on develop** — origin/develop diverged from upstream/develop.
+  Fix before rebasing your feature branch.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  cad-workbench:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile
+    ports:
+      - "8080:8080"    # ttyd → OpenCode Web Terminal
+      - "5173:5173"    # CAD Viewer Vite Dev Server
+    volumes:
+      - .:/workspace:cached
+      - opencode_data:/home/opencode/.local/share/opencode
+    restart: unless-stopped
+
+volumes:
+  opencode_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,18 @@ services:
     build:
       context: .
       dockerfile: .docker/Dockerfile
+    user: "0:0"
+    environment:
+      LOCAL_UID: "${LOCAL_UID:-1000}"
+      LOCAL_GID: "${LOCAL_GID:-1000}"
     ports:
-      - "5080:5080"    # ttyd → OpenCode Web Terminal
-      - "5173:5173"    # CAD Viewer Vite Dev Server
+      - "${OPENCODE_TTYD_PORT:-5080}:5080"    # ttyd → OpenCode Web Terminal
+      - "${VIEWER_HOST_PORT:-5173}:5173"      # CAD Viewer Vite Dev Server
     volumes:
-      - .:/workspace:cached
+      - opencode_workspace:/workspace
       - opencode_data:/home/opencode/.local/share/opencode
     restart: unless-stopped
 
 volumes:
+  opencode_workspace:
   opencode_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: .docker/Dockerfile
     ports:
-      - "8080:8080"    # ttyd → OpenCode Web Terminal
+      - "5080:5080"    # ttyd → OpenCode Web Terminal
       - "5173:5173"    # CAD Viewer Vite Dev Server
     volumes:
       - .:/workspace:cached

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -1,0 +1,46 @@
+# Knowledge Base
+
+This directory stores **reusable, human-readable, git-backed** knowledge for this project.
+
+## Purpose
+
+Capture knowledge that future contributors and agents can find and use.
+Task-local working notes belong in `.sisyphus/notepads/`. Promote into this
+directory only when the information is likely to be reused.
+
+## Directory Layout
+
+- `architecture/` — design constraints, rationale, system boundaries
+- `patterns/` — reusable coding or workflow patterns
+- `tooling/` — environment, build, CI/CD, CLI, automation
+- `troubleshooting/` — bugs, failure modes, concrete fixes
+
+## Entry Standard
+
+Every entry must follow this structure:
+
+```md
+# Title
+
+## Context
+## Problem
+## Solution
+## Why It Works
+## Side Effects / Tradeoffs
+## Evidence
+## Related Files
+## Tags
+```
+
+## Promotion Rule
+
+Promote a note here only if it is:
+1. reusable,
+2. evidence-backed,
+3. narrowly scoped,
+4. likely to help a future task.
+
+## Usage
+
+Use the `knowledge-capture` skill (in `.opencode/skills/knowledge-capture.md`)
+to manually write and validate entries after completing relevant tasks.

--- a/docs/knowledge/_template.md
+++ b/docs/knowledge/_template.md
@@ -1,0 +1,37 @@
+# <Title>
+
+## Context
+
+Where this issue or pattern appears, and when it matters.
+
+## Problem
+
+The exact failure mode, ambiguity, or decision point.
+
+## Solution
+
+The minimum fix, rule, or pattern that resolved it.
+
+## Why It Works
+
+Explain the mechanism or rationale.
+
+## Side Effects / Tradeoffs
+
+Limits, risks, or follow-up considerations.
+
+## Evidence
+
+- Tests:
+- Diagnostics:
+- Logs / observed behavior:
+- Docs / source references:
+
+## Related Files
+
+- `path/to/file`
+
+## Tags
+
+- tag-1
+- tag-2

--- a/docs/knowledge/tooling/docker-bind-mount-shadowing.md
+++ b/docs/knowledge/tooling/docker-bind-mount-shadowing.md
@@ -1,0 +1,76 @@
+# Docker: Bind Mount Shadows Built-in Source Directories
+
+## Context
+
+A multi-stage Docker image that bakes in project source (e.g. a Vite-based CAD
+Viewer at `/workspace/viewer/`) and pre-installs dependencies. At runtime, the
+container mounts the host project directory via `-v /host/path:/workspace`.
+
+## Problem
+
+When the host directory is bind-mounted at `/workspace`:
+- The host's `/workspace/viewer/` directory **shadows** the one copied into the
+  image during `docker build`.
+- If the host's `viewer/` is empty, incomplete, or a different version, the
+  built-in viewer is inaccessible.
+- npm workspace symlinks (`packages/cadjs`, `packages/implicitjs`) are broken
+  because they point to paths that exist only at build time.
+
+This is confusing because `ls /workspace/viewer` succeeds but shows stale/wrong
+content. There is no error message — the wrong files just serve.
+
+## Solution
+
+1. **At build time**: Copy the viewer source to a non-shadowed path:
+   ```dockerfile
+   RUN cp -r /workspace/viewer /opt/viewer-source
+   ```
+
+2. **At runtime** (in `entrypoint.sh`):
+   - Fix package symlinks that broke during COPY:
+     ```bash
+     for pkg in cadjs implicitjs; do
+         ln -sf /opt/viewer-node-modules/packages/$pkg /opt/viewer-source/packages/$pkg
+     done
+     ```
+   - Link pre-installed `node_modules` from the build stage:
+     ```bash
+     ln -sf /opt/viewer-node-modules/viewer/node_modules /opt/viewer-source/node_modules
+     ```
+   - Start Vite from the preserved path:
+     ```bash
+     cd /opt/viewer-source && npx vite --host 0.0.0.0 --port 5173
+     ```
+
+## Why It Works
+
+- `/opt/viewer-source` is never bind-mounted by convention — it lives only in
+  the image layer.
+- The entrypoint runs on every container start, re-linking dependencies that
+  would otherwise be stale.
+- The symlink approach keeps the viewer code at a path the build-time
+  `package.json` expects, avoiding hardcoded path changes.
+
+## Side Effects / Tradeoffs
+
+- Duplicates viewer source in the image (~2× size for that directory).
+- Entrypoint complexity: startup must fix symlinks before starting services.
+- If the host viewer source is legitimately newer, the entrypoint must be
+  bypassed or the image rebuilt.
+
+## Evidence
+
+- Before fix: `curl http://localhost:5173/` returned wrong content (empty
+  or broken HTML). Playwright failed to find Vite client scripts.
+- After fix: HTTP 200, correct `<title>CAD Viewer</title>`, Vite
+  `@react-refresh` and `@vite/client` scripts present, zero page errors.
+
+## Related Files
+
+- `.docker/entrypoint.sh` — the `# Symlink workaround for Docker volume mount` block
+- `.docker/Dockerfile` — `RUN cp -r /workspace/viewer /opt/viewer-source`
+- `docs/knowledge/tooling/docker-user-cache-ordering.md` — related Docker build-time pitfall
+
+## Tags
+
+`docker` `bind-mount` `volume-shadow` `vite` `viewer` `entrypoint` `symlink`

--- a/docs/knowledge/tooling/docker-compose-environment-architecture.md
+++ b/docs/knowledge/tooling/docker-compose-environment-architecture.md
@@ -1,0 +1,145 @@
+# cad-workbench 容器架構
+
+> 適用於 `feat/docker-compose-environment` 分支合併後的工作環境。
+> 入口：`docker-compose.yml`（已從 host bind 改為 named volume + 首次開機 seed）。
+
+## 整體拓樸
+
+```mermaid
+flowchart TB
+    %% ===================== Host =====================
+    subgraph HOST["Host machine"]
+        direction TB
+        REPO["Worktree<br/>feat/docker-compose-environment<br/>(branched from earthtojake:develop)"]
+        REPOFILES["/workspace mount 對應的 host 內容<br/>(在 named volume，不在 host)"]
+        COMPOSE["docker-compose.yml<br/>user: 0:0<br/>LOCAL_UID / LOCAL_GID<br/>ports: 5080/5173"]
+        UPSTREAM["upstream remote<br/>earthtojake/text-to-cad"]
+        BROWSER(["Browser"])
+
+        REPO --> COMPOSE
+        UPSTREAM -.-> REPO
+        REPOFILES -. bind 已移除 .-> COMPOSE
+    end
+
+    %% ===================== Container cad-workbench =====================
+    subgraph CONT["Container: cad-workbench"]
+        direction TB
+        ENTRY["entrypoint.sh (pid 1, root)"]
+
+        subgraph ROOT_STAGE["root stage"]
+            UIDMAP["LOCAL_UID/GID<br/>usermod / groupmod"]
+            SEED["seed: cp -a<br/>/opt/workspace-seed -> /workspace<br/>(only if volume empty)"]
+            CHOWN["chown -R<br/>$UID:$GID /workspace"]
+        end
+
+        ENTRY --> UIDMAP
+        UIDMAP --> SEED
+        SEED --> CHOWN
+        CHOWN --> DROP["exec su -c '... /entrypoint.sh --as-opencode'"]
+
+        subgraph OC_STAGE["opencode stage"]
+            direction TB
+            VENV["ln -sf /opt/venv /workspace/.venv"]
+            VIEWER_LINKS["ln -sf /opt/viewer-node-modules/viewer/node_modules<br/>        /workspace/viewer/node_modules<br/>ln -sf /opt/viewer-node-modules/packages/{cadjs,implicitjs}<br/>        /workspace/viewer/packages/*"]
+            SKILL_LINKS["ln -sf /opt/viewer-node-modules/skill-viewer/node_modules<br/>        /workspace/skills/cad-viewer/scripts/viewer/node_modules"]
+            OC["tmux session 'oc' -> opencode<br/>(run as uid 1000)"]
+            TTYD["ttyd :5080 -> tmux attach -t oc"]
+            VITE["vite :5173<br/>(cwd = /workspace/viewer)"]
+        end
+
+        DROP --> VENV
+        DROP --> VIEWER_LINKS
+        DROP --> SKILL_LINKS
+        DROP --> OC
+        DROP --> TTYD
+            VITE
+        OC -. generated .-> MODELS
+
+        subgraph WS["/workspace (named volume)"]
+            direction TB
+            SEEDREPO["project tree (seeded)"]
+            MODELS["models/<br/>CAD outputs (STEP / STL / GLB / URDF / ...)"]
+        end
+
+        VENV -.-> SEEDREPO
+        SEEDREPO --- MODELS
+        OC -. writes .-> MODELS
+    end
+
+    %% ===================== Storage =====================
+    subgraph STORAGE["Storage (image-internal + named volumes)"]
+        direction TB
+        IMG_SEED["/opt/workspace-seed (image layer)<br/>= COPY . . at build time"]
+        IMG_VIEWER["/opt/viewer-source/viewer (image layer)"]
+        IMG_VENV["/opt/venv (image layer)<br/>Python venv with cadpy etc."]
+        IMG_NM["/opt/viewer-node-modules<br/>  viewer/<br/>  skill-viewer/<br/>  packages/{cadjs,implicitjs}"]
+        NV_WS["docker volume<br/>opencode_workspace<br/>(mounted at /workspace)"]
+        NV_DATA["docker volume<br/>opencode_data<br/>(mounted at /home/opencode/.local/share/opencode)"]
+    end
+
+    COMPOSE -->|build| IMG_SEED
+    COMPOSE -->|build| IMG_VIEWER
+    COMPOSE -->|build| IMG_VENV
+    COMPOSE -->|build| IMG_NM
+    COMPOSE -->|mount| NV_WS
+    COMPOSE -->|mount| NV_DATA
+
+    ENTRY --> IMG_SEED
+    SEED --> IMG_SEED
+    VENV --> IMG_VENV
+    VIEWER_LINKS --> IMG_NM
+    SKILL_LINKS --> IMG_NM
+    NV_WS --> SEEDREPO
+
+    %% ===================== Flows =====================
+    BROWSER ==>|http :5180| TTYD
+    TTYD ==>|tmux attach| OC
+    BROWSER ==>|http :5173<br/>?dir=/workspace/models| VITE
+    VITE ==>|scan + serve| SEEDREPO
+    OC -. .-> VITE
+```
+
+## 關鍵設計決策與警示
+
+```mermaid
+flowchart LR
+    subgraph STAGE_FIRST["First boot (volume empty)"]
+        F1["/opt/workspace-seed"] -->|cp -a| F2["/workspace (named volume)<br/>becomes source of truth"]
+    end
+
+    subgraph STAGE_SUBSEQUENT["Subsequent restarts (volume non-empty)"]
+        S1["/opt/workspace-seed"] -.->|SKIP, ls -A non-empty| S2["/workspace keeps<br/>generated files + symlinks"]
+    end
+
+    subgraph STAGE_REBASE["When source changes on host"]
+        R1["git pull / edit on host"] --> R2["docker compose down -v<br/>(drop volume)"] --> R3["docker compose up --build -d<br/>(re-seed from new image)"]
+    end
+
+    subgraph STAGE_EDIT["Live edit (NOT supported)"]
+        E1["edit /workspace/anything in container"] --> E2["survives only inside<br/>the named volume"]
+        E1 -.->|host never sees it<br/>re-seeding wipes it| E3["host worktree<br/>(unaffected)"]
+    end
+```
+
+## Port 與服務對照
+
+| Host port | Container port | Process | 用途 |
+|---|---|---|---|
+| `5180` (`OPENCODE_TTYD_PORT`) | `5080` | ttyd | OpenCode Web Terminal |
+| `8081` (`VIEWER_HOST_PORT`) | `5173` | vite | CAD Viewer 開發伺服器 |
+| — | `4096` (opencode 內部) | opencode | 透過 tmux 與 ttyd 串接 |
+
+## 模組相依
+
+```mermaid
+flowchart LR
+    A["host<br/>git worktree"] -->|git push| B["origin<br/>tryweb/text-to-cad"]
+    B -->|PR #2| C["origin develop"]
+    B -->|PR #114 cross-repo| D["upstream<br/>earthtojake/text-to-cad"]
+    C -. same commit as .-> D
+
+    B -->|git fetch upstream| D
+    B -->|scripts/dev/compose-verify.sh| E["runtime check<br/>15 / 15"]
+    E -->|reads| F[".opencode/skills/cad-workbench.md"]
+    E -->|docs| G["docs/knowledge/tooling/<br/>docker-compose-environment.md"]
+```

--- a/docs/knowledge/tooling/docker-compose-environment.md
+++ b/docs/knowledge/tooling/docker-compose-environment.md
@@ -1,0 +1,210 @@
+# Docker Compose Workbench Environment
+
+## Context
+
+The `text-to-cad` workbench is a Docker Compose stack that runs an
+OpenCode Web Terminal (`ttyd` on container port `5080`) and the CAD
+Viewer Vite dev server (container port `5173`) inside a single
+`cad-workbench` container. The container also hosts the project source
+itself, since OpenCode reads and writes CAD generation artifacts
+(`models/`, `*.step`, `*.urdf`, etc.) under `/workspace`.
+
+This entry documents the runtime contract for that stack as shipped on
+the `feat/docker-compose-environment` branch — the bind mount, named
+volumes, image-internal seed, and runtime UID/port overrides.
+
+## Problem
+
+Two patterns that the earlier bind-mount layout made fragile:
+
+1. **Host overlay breaks the workspace tree.**  
+   When the host project is bind-mounted at `/workspace`, the host's
+   `viewer/`, `models/`, or `scripts/` shadows the image-internal copy.
+   In particular, an LFS-not-yet-hydrated or worktree-incomplete host
+   shows the container a partial tree (e.g. an empty `models/` or a
+   stray `desk.py` left over from a previous AI run). The container
+   then disagrees with the host repo, and the viewer catalog does not
+   match what the user sees on disk.
+
+2. **`/workspace` ownership is unpredictable.**  
+   The container runs as `opencode` (UID `1000` by default) but the
+   host worktree is owned by the host UID. Bind mounts with `:cached`
+   only show the host's mode bits; the runtime user could not create
+   new files under `/workspace` without a manual `chown` or a matching
+   host UID. AI-generated files then silently fail with `EACCES`.
+
+## Solution
+
+Switch the `/workspace` mount from a host bind to a named volume
+populated by an image-internal seed on first boot:
+
+```yaml
+# docker-compose.yml (relevant lines)
+services:
+  cad-workbench:
+    user: "0:0"
+    environment:
+      LOCAL_UID: "${LOCAL_UID:-1000}"
+      LOCAL_GID: "${LOCAL_GID:-1000}"
+    volumes:
+      - opencode_workspace:/workspace
+      - opencode_data:/home/opencode/.local/share/opencode
+
+volumes:
+  opencode_workspace:
+  opencode_data:
+```
+
+The Dockerfile copies the project source into an image-internal path
+(`/opt/workspace-seed`) and the entrypoint materializes it into the
+named volume on first boot:
+
+```dockerfile
+# .docker/Dockerfile (relevant lines)
+WORKDIR /opt/workspace-seed
+COPY . .
+RUN mkdir -p /opt/viewer-source && \
+    cp -r /opt/workspace-seed/viewer /opt/viewer-source
+```
+
+```bash
+# .docker/entrypoint.sh (relevant lines, root stage)
+if [ -d /opt/workspace-seed ] && [ -z "$(ls -A /workspace 2>/dev/null)" ]; then
+    cp -a /opt/workspace-seed/. /workspace/
+fi
+mkdir -p /workspace/models
+chown -R "$RUNTIME_UID:$RUNTIME_GID" /workspace
+exec su -s /bin/bash opencode -c 'exec /entrypoint.sh --as-opencode'
+```
+
+The host-port side is also parameterized to avoid collisions when
+multiple stacks share a machine:
+
+```yaml
+ports:
+  - "${OPENCODE_TTYD_PORT:-5080}:5080"
+  - "${VIEWER_HOST_PORT:-5173}:5173"
+```
+
+`scripts/dev/compose-verify.sh` asserts all of the above at runtime.
+
+## Why It Works
+
+- **Image-internal seed, volume-resident runtime.**  
+  `/opt/workspace-seed` is only readable at runtime via the entrypoint
+  copy, so the container never reads source from the host. Subsequent
+  restarts see a non-empty `/workspace` and skip the copy, so generated
+  files (CAD artifacts, `.venv`, `node_modules` symlinks) survive
+  across restarts.
+
+- **Root-at-startup, drop-priv-after.**  
+  The `user: 0:0` in compose plus the `LOCAL_UID`/`LOCAL_GID` re-map in
+  the entrypoint lets the container `chown /workspace` and `usermod
+  opencode` before handing off to the non-root `opencode` user that
+  actually runs the long-lived processes. This is necessary because
+  Docker named volumes always start owned by `root` on first mount.
+
+- **Viewer serves from `/workspace/viewer`.**  
+  The Vite dev server is launched from `/workspace/viewer` (with
+  `node_modules` and `packages/{cadjs,implicitjs}` symlinked to
+  `/opt/viewer-node-modules/...`). The seeded symlinks from the build
+  time are re-linked in the entrypoint, so HMR sees source edits and
+  the viewer URL is `?dir=/workspace/models`.
+
+- **Port override, not host bind.**  
+  Overriding `OPENCODE_TTYD_PORT` and `VIEWER_HOST_PORT` at `up` time is
+  enough to avoid `5080` / `5173` collisions; no bind mount means no
+  `:ro` vs `:rw` consistency confusion.
+
+## Side Effects / Tradeoffs
+
+- **No live host editing.**  
+  Editing source on the host does not propagate to the running
+  container; developers must `docker compose down && docker compose up
+  --build -d` to refresh. This is the explicit trade for avoiding the
+  host overlay problem.
+
+- **First-boot copy is the source of truth.**  
+  If the volume is non-empty the entrypoint skips the seed copy, so a
+  stale `opencode_workspace` volume can mask a freshly-built image. Run
+  `docker compose down -v` when re-seeding is intended.
+
+- **Playwright cache is not pre-installed in the image.**  
+  Earlier iterations baked `npx playwright install chromium` into the
+  Dockerfile. That was removed because the development environment
+  already provides the cache; relying on the image for it doubled the
+  build time without changing the runtime contract. If a fresh CI
+  environment lacks the cache, install it via the host before bringing
+  the container up.
+
+- **`opencode_workspace` is not LFS-aware.**  
+  LFS pointer files in the seed copy as plain text. Hydrate
+  `git lfs pull` on the host after `git lfs checkout`, or run LFS-aware
+  tooling inside the container, before depending on LFS-backed
+  artifacts.
+
+## Evidence
+
+Validated on `feat/docker-compose-environment` with
+`scripts/dev/compose-verify.sh` (15 / 15 checks pass):
+
+```
+== 1. compose config ==
+  [ok] opencode_workspace volume declared and bound to /workspace
+  [ok] no host bind on /workspace
+
+== 2. container status ==
+  [ok] service 'cad-workbench' is running
+
+== 3. /workspace mount is a named volume ==
+  [ok] /workspace mounted from named volume: /var/lib/docker/volumes/gentle-salamander_opencode_workspace/_data
+
+== 4. /workspace seeded tree ==
+  [ok] expected project entries present in /workspace
+
+== 5. /workspace/viewer symlinks ==
+  [ok] viewer/node_modules -> /opt/viewer-node-modules/viewer/node_modules
+  [ok] viewer/packages/cadjs -> /opt/viewer-node-modules/packages/cadjs
+  [ok] viewer/packages/implicitjs -> /opt/viewer-node-modules/packages/implicitjs
+
+== 6. /workspace/models exists and is writable by opencode ==
+  [ok] /workspace/models exists
+  [ok] opencode user can write to /workspace/models
+
+== 7. opencode write test (creates and removes a file) ==
+  [ok] opencode wrote and removed /workspace/.compose-verify-write
+
+== 8. ttyd and viewer listening inside container ==
+  [ok] container 127.0.0.1:5080 reachable
+  [ok] container 127.0.0.1:5173 reachable
+
+== 9. Vite dev server cwd is /workspace/viewer ==
+  [ok] vite running from /workspace/viewer
+
+== 10. viewer HTTP for ?dir=/workspace/models ==
+  [ok] viewer /?dir=/workspace/models returned 200
+```
+
+Host-side reachability was confirmed manually at
+`http://<host>:8081/?dir=/workspace/models` and
+`http://<host>:5180/`.
+
+## Related Files
+
+- `docker-compose.yml`
+- `.docker/Dockerfile`
+- `.docker/entrypoint.sh`
+- `scripts/dev/compose-verify.sh`
+- `.opencode/skills/cad-workbench.md`
+- `docs/knowledge/tooling/docker-bind-mount-shadowing.md` (predecessor lesson)
+- `docs/knowledge/tooling/docker-user-cache-ordering.md` (predecessor lesson)
+
+## Tags
+
+- docker
+- compose
+- named-volume
+- opencode
+- viewer
+- ttyd
+- workbench

--- a/docs/knowledge/tooling/docker-user-cache-ordering.md
+++ b/docs/knowledge/tooling/docker-user-cache-ordering.md
@@ -1,0 +1,56 @@
+# Docker: USER Ordering for Playwright Browser Cache
+
+## Context
+
+Multi-stage Docker build for a text-to-CAD project. The runtime container runs as
+a non-root user (`opencode`, UID 1000). Playwright is installed via `npx playwright
+install chromium` to pre-download browser binaries for headless testing of the
+CAD Viewer (Vite dev server on port 5173).
+
+## Problem
+
+Playwright browser binaries land in `~/.cache/ms-playwright/` under the user
+running the install command. If `npx playwright install chromium` runs **before**
+`USER opencode` in the Dockerfile, the browsers go to `/root/.cache/ms-playwright/`.
+At runtime, the `opencode` user cannot find them — Playwright throws
+`ERR_MODULE_NOT_FOUND` or silently fails to launch a browser.
+
+The same issue applies to any tool (npm, pip, cargo) that writes per-user caches
+during build: the cache directory is owned by root and inaccessible to the runtime user.
+
+## Solution
+
+Move `USER opencode` **before** the `npx playwright install chromium` line:
+
+```dockerfile
+USER opencode
+
+RUN npx playwright install chromium 2>&1
+```
+
+This ensures browsers download to `/home/opencode/.cache/ms-playwright/`, which
+is accessible when the container runs as `opencode`.
+
+## Why It Works
+
+- Playwright resolves `~/.cache/` from `$HOME` of the current user.
+- `USER opencode` sets `$HOME=/home/opencode`.
+- The `opencode` user's cache persists in the image layer.
+- At runtime, the same user reads the same path — no permission mismatch.
+
+## Side Effects / Tradeoffs
+
+- The `opencode` user must npm/node be accessible (via `npx`) after `USER opencode`.
+  In our setup, Node.js is installed globally in the `base` stage, so it's available
+  to any user. If the project used a per-user Node install (e.g. nvm), additional
+  PATH setup would be needed.
+- Pre-installation adds ~300 MB to the image (Chrome + FFmpeg + headless shell).
+
+## Related Files
+
+- `.docker/Dockerfile` — line 149–152: the `USER opencode` / `RUN npx playwright install` ordering
+- `.docker/entrypoint.sh` — runtime viewer setup, Vite auto-start
+
+## Tags
+
+`docker` `playwright` `user-cache` `browser-testing` `multi-stage` `container-build`

--- a/docs/superpowers/plans/2026-06-24-docker-compose-environment.md
+++ b/docs/superpowers/plans/2026-06-24-docker-compose-environment.md
@@ -1,0 +1,437 @@
+# Docker Compose Environment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a Docker Compose environment with OpenCode pre-configured with text-to-cad skills, CAD Viewer, and full CAD generation (build123d) available via web browser.
+
+**Architecture:** Single Ubuntu 24.04 container with ttyd exposing OpenCode TUI via web (port 8080) and CAD Viewer Vite dev server (port 5173). Python venv at `/opt/venv`, viewer node_modules at `/opt/viewer-node-modules` — both linked via symlinks into the mounted project tree so host source edits don't shadow built deps.
+
+**Tech Stack:** Ubuntu 24.04, Python 3.12, Node.js 22, Bun, OpenCode 1.17.x, build123d, ttyd, Vite 7, React 18, Three.js 0.160
+
+## Global Constraints
+
+- Ubuntu 24.04 (Noble Numbat) as base image — not 22.04, not Alpine
+- OpenCode installed via `bun install -g opencode-ai` — not npm
+- System Python 3.12 (Ubuntu 24.04 default) — not pyenv, not conda
+- No `.env` file required for AI provider — user configures `/connect` inside OpenCode
+- ttyd from Ubuntu apt repository — not building from source
+- Node.js 22 from NodeSource — matches CI workflows
+- The project source is mounted as a Docker volume so user can access generated CAD files from host
+- `.venv` and `node_modules/` must survive host volume mount (shadowing) — use symlink trick via entrypoint
+
+---
+
+### Files to Create/Modify
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `.docker/Dockerfile` | Create | Multi-stage build for the complete environment |
+| `.docker/entrypoint.sh` | Create | Runtime setup: symlinks, tmux, ttyd launch |
+| `.docker/opencode.json` | Create | OpenCode config pointing at skills/ |
+| `docker-compose.yml` | Create | Service definition with ports, volumes, env |
+| `.dockerignore` | Create | Exclude unnecessary files from Docker build context |
+
+---
+
+### Task 1: Directory Scaffold + Config Files
+
+**Files:**
+- Create: `.docker/opencode.json`
+- Create: `.dockerignore`
+- Create: `docker-compose.yml`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: OpenCode config consumed by Task 3 (Dockerfile), docker-compose.yml consumed by user at runtime
+
+- [ ] **Step 1: Create `.docker/opencode.json`**
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "skills": {
+    "paths": [
+      "/workspace/skills",
+      "/workspace/plugins/cad/skills"
+    ]
+  }
+}
+```
+
+This tells OpenCode where to find SKILL.md files for automatic discovery. Both the source `skills/` and the bundled `plugins/cad/skills/` are registered.
+
+- [ ] **Step 2: Create `.dockerignore`**
+
+```
+.git
+.gitattributes
+.gitignore
+.lfsconfig
+assets/
+benchmarks/
+node_modules/
+.venv/
+__pycache__/
+*.pyc
+.env
+.git-lfs/
+tmp/
+*.gif
+```
+
+Prevents large files (LFS assets, benchmarks, giant test GIFs) from bloating the Docker build context.
+
+- [ ] **Step 3: Create `docker-compose.yml`**
+
+```yaml
+services:
+  cad-workbench:
+    build:
+      context: .
+      dockerfile: .docker/Dockerfile
+    ports:
+      - "8080:8080"    # ttyd → OpenCode Web Terminal
+      - "5173:5173"    # CAD Viewer Vite Dev Server
+    volumes:
+      - .:/workspace:cached
+      - opencode_data:/home/opencode/.local/share/opencode
+    restart: unless-stopped
+
+volumes:
+  opencode_data:
+```
+
+`:/workspace:cached` — source is mounted so generated models are accessible from host.  
+`opencode_data` — persists OpenCode conversation history and provider config across container restarts.
+
+- [ ] **Step 4: Verify files exist**
+
+Run: `ls -la .docker/opencode.json .dockerignore docker-compose.yml`
+
+Expected: three files, all non-empty.
+
+---
+
+### Task 2: Entrypoint Script
+
+**Files:**
+- Create: `.docker/entrypoint.sh`
+
+**Interfaces:**
+- Consumes: `/opt/venv` and `/opt/viewer-node-modules` (created during Docker build in Task 3)
+- Produces: tmux session with OpenCode running, accessible via ttyd on port 8080
+
+- [ ] **Step 1: Create `.docker/entrypoint.sh`**
+
+```bash
+#!/bin/bash
+set -e
+
+# ── Symlink workaround for Docker volume mount ──
+# When the project is mounted at /workspace, the host's empty/missing
+# .venv and node_modules shadow the ones we built during docker build.
+# We relocate deps to /opt/ and symlink them back at runtime.
+
+# Python venv
+if [ -d /opt/venv ] && [ ! -f /workspace/.venv/bin/activate ]; then
+    rm -rf /workspace/.venv 2>/dev/null || true
+    ln -sf /opt/venv /workspace/.venv
+fi
+
+# Viewer node_modules
+if [ -d /opt/viewer-node-modules/node_modules ] && [ ! -f /workspace/viewer/node_modules/.package-lock.json ]; then
+    rm -rf /workspace/viewer/node_modules 2>/dev/null || true
+    mkdir -p /workspace/viewer
+    ln -sf /opt/viewer-node-modules/node_modules /workspace/viewer/node_modules
+fi
+
+# CAD Viewer packaged runtime — the production viewer bundle lives inside
+# the cad-viewer skill directory for the agent:start command
+SKILL_VIEWER_DIR="/workspace/skills/cad-viewer/scripts/viewer"
+if [ -d /opt/viewer-node-modules/skill-viewer ] && [ -d "$SKILL_VIEWER_DIR" ]; then
+    if [ ! -f "$SKILL_VIEWER_DIR/node_modules/.package-lock.json" ]; then
+        rm -rf "$SKILL_VIEWER_DIR/node_modules" 2>/dev/null || true
+        ln -sf /opt/viewer-node-modules/skill-viewer/node_modules "$SKILL_VIEWER_DIR/node_modules"
+    fi
+fi
+
+# ── OpenCode config ──
+export OPENCODE_CONFIG_DIR="${OPENCODE_CONFIG_DIR:-/home/opencode/.config/opencode}"
+mkdir -p "$OPENCODE_CONFIG_DIR"
+
+# Copy default opencode.json if config dir is empty (first start)
+if [ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ]; then
+    cp /opt/opencode-defaults/opencode.json "$OPENCODE_CONFIG_DIR/"
+fi
+
+# ── Environment ──
+export VIRTUAL_ENV=/opt/venv
+export PATH="/opt/venv/bin:/home/opencode/.bun/bin:$PATH"
+export BUN_INSTALL=/home/opencode/.bun
+
+cd /workspace
+
+# ── Start ttyd with tmux + opencode ──
+# tmux runs in background so if the browser tab disconnects and reconnects,
+# ttyd reattaches to the same session instead of starting a new opencode process.
+exec ttyd -p 8080 -W \
+    tmux new-session -s oc -d \; \
+    send-keys "cd /workspace && . /opt/venv/bin/activate && exec opencode" Enter
+```
+
+- [ ] **Step 2: Make executable**
+
+Run: `chmod +x .docker/entrypoint.sh`
+
+- [ ] **Step 3: Verify entrypoint syntax**
+
+Run: `bash -n .docker/entrypoint.sh`
+
+Expected: no output (exit code 0).
+
+---
+
+### Task 3: Dockerfile
+
+**Files:**
+- Create: `.docker/Dockerfile`
+
+**Interfaces:**
+- Consumes: `.docker/opencode.json`, `.docker/entrypoint.sh` (from Tasks 1-2)
+- Produces: Docker image with all deps installed at `/opt/venv`, `/opt/viewer-node-modules`, and `/opt/opencode-defaults`
+
+- [ ] **Step 1: Create `.docker/Dockerfile`**
+
+```dockerfile
+# =============================================================================
+# text-to-cad + OpenCode Docker Environment
+# Base: Ubuntu 24.04 (Noble Numbat)
+# =============================================================================
+
+FROM ubuntu:24.04 AS base
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl \
+    python3 python3-dev python3-pip python3-venv \
+    git git-lfs \
+    build-essential \
+    ttyd \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Node.js 22 (matches CI) ──
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && node --version | grep -q "^v22"
+
+# ── Bun (for opencode-ai) ──
+RUN curl -fsSL https://bun.sh/install | bash
+ENV BUN_INSTALL=/root/.bun
+ENV PATH=$BUN_INSTALL/bin:$PATH
+
+# ── OpenCode ──
+RUN bun install -g opencode-ai && opencode --version
+
+# =============================================================================
+# Stage: python-deps — CAD Python packages
+# =============================================================================
+
+FROM base AS python-deps
+WORKDIR /build
+
+# Copy only dependency manifests for layer caching
+COPY packages/cadpy/pyproject.toml packages/cadpy/
+COPY packages/cadpy_metadata/pyproject.toml packages/cadpy_metadata/
+
+RUN python3 -m venv /opt/venv && \
+    . /opt/venv/bin/activate && \
+    pip install --upgrade pip --quiet && \
+    pip install build123d --quiet && \
+    pip install -e packages/cadpy --quiet && \
+    pip install -e packages/cadpy_metadata --quiet
+
+# Skill-specific Python deps
+COPY skills/cad/requirements.txt skills/cad/requirements.txt
+COPY skills/dxf/requirements.txt skills/dxf/requirements.txt
+COPY skills/urdf/requirements.txt skills/urdf/requirements.txt
+COPY skills/srdf/requirements.txt skills/srdf/requirements.txt
+COPY skills/sdf/requirements.txt skills/sdf/requirements.txt
+COPY skills/cad-viewer/requirements.txt skills/cad-viewer/requirements.txt
+
+RUN . /opt/venv/bin/activate && \
+    pip install \
+        -r skills/cad/requirements.txt \
+        -r skills/dxf/requirements.txt \
+        -r skills/urdf/requirements.txt \
+        -r skills/srdf/requirements.txt \
+        -r skills/sdf/requirements.txt \
+        -r skills/cad-viewer/requirements.txt \
+        --quiet && \
+    pip install ezdxf networkx trimesh --quiet
+
+# Clean pip cache to reduce image size
+RUN rm -rf /root/.cache/pip
+
+# =============================================================================
+# Stage: node-deps — Viewer and skill JS dependencies
+# =============================================================================
+
+FROM base AS node-deps
+WORKDIR /build
+
+# Pre-install viewer dependencies at /opt/viewer-node-modules
+COPY viewer/package.json viewer/package-lock.json viewer/
+COPY packages/cadjs/ packages/cadjs/
+COPY packages/implicitjs/ packages/implicitjs/
+COPY viewer/packages/ viewer/packages/
+
+RUN mkdir -p /opt/viewer-node-modules && \
+    cp -r viewer /opt/viewer-node-modules/ && \
+    cd /opt/viewer-node-modules/viewer && \
+    npm install --no-audit --no-fund 2>&1
+
+# Also pre-install for the cad-viewer skill's viewer path
+COPY skills/cad-viewer/scripts/viewer/package.json skills/cad-viewer/scripts/viewer/ 2>/dev/null || true
+RUN if [ -f skills/cad-viewer/scripts/viewer/package.json ]; then \
+        mkdir -p /opt/viewer-node-modules/skill-viewer && \
+        cp -r skills/cad-viewer/scripts/viewer /opt/viewer-node-modules/skill-viewer/ && \
+        cd /opt/viewer-node-modules/skill-viewer/viewer && \
+        npm install --no-audit --no-fund 2>&1; \
+    fi
+
+# =============================================================================
+# Stage: final — assemble runtime
+# =============================================================================
+
+FROM base AS final
+
+# Create runtime user
+RUN useradd -m -s /bin/bash -u 1000 opencode
+
+# Copy Python venv from python-deps stage
+COPY --from=python-deps /opt/venv /opt/venv
+
+# Copy viewer node_modules from node-deps stage
+COPY --from=node-deps /opt/viewer-node-modules /opt/viewer-node-modules
+
+# Copy project source
+WORKDIR /workspace
+COPY . .
+
+# OpenCode defaults config
+RUN mkdir -p /opt/opencode-defaults
+COPY .docker/opencode.json /opt/opencode-defaults/opencode.json
+
+# Entrypoint
+COPY .docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Pre-create opencode data dir with correct ownership
+RUN mkdir -p /home/opencode/.config/opencode /home/opencode/.local/share/opencode && \
+    chown -R opencode:opencode /home/opencode /opt/venv /opt/viewer-node-modules /opt/opencode-defaults
+
+# Verify key tools
+RUN /opt/venv/bin/python -c "import build123d; print('build123d:', build123d.__version__)" && \
+    /opt/venv/bin/python -c "import cadpy; print('cadpy: OK')" && \
+    node --version && \
+    opencode --version
+
+USER opencode
+WORKDIR /workspace
+
+EXPOSE 8080 5173
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+- [ ] **Step 2: Verify Dockerfile syntax**
+
+Run: `docker build --no-cache --target base -t cad-test-base -f .docker/Dockerfile . 2>&1 | tail -5` (quick syntax check, small target only)
+
+Expected: build succeeds, exits with code 0.
+
+---
+
+### Task 4: Build and Smoke Test
+
+**Files:**
+- None created — this task runs the build and validates the image
+
+**Interfaces:**
+- Consumes: the complete `.docker/Dockerfile`, `.docker/entrypoint.sh`, `.docker/opencode.json`, `docker-compose.yml`
+
+- [ ] **Step 1: Full image build**
+
+Run: `docker compose build 2>&1 | tail -20`
+
+Expected: Build succeeds. Key lines in output:
+- "build123d: X.Y.Z" (version printed)
+- "cadpy: OK"
+- OpenCode version printed
+
+- [ ] **Step 2: Verify expected tools inside image**
+
+Run: `docker compose run --rm cad-workbench /opt/venv/bin/python -c "import build123d; from OCP import BRepPrimAPI; print('OCP OK')"`
+
+Expected: `OCP OK` printed without errors.
+
+- [ ] **Step 3: Verify OpenCode can discover skills**
+
+Run: `docker compose run --rm -e OPENCODE_CONFIG_DIR=/opt/opencode-defaults cad-workbench opencode --version`
+
+Expected: prints OpenCode version (1.17.x).
+
+Note: Full skill discovery validation requires running OpenCode interactively, which is covered in the manual smoke test below.
+
+- [ ] **Step 4: Manual smoke test**
+
+```bash
+# Start the service
+docker compose up -d
+
+# Check logs
+docker compose logs --tail=20
+
+# Open browser to http://localhost:8080
+# Expected: ttyd web terminal with OpenCode TUI running
+# Run `/connect` inside OpenCode to configure AI provider
+# Then try: "List available skills"
+# Expected: OpenCode lists 11+ skills including cad, cad-viewer, urdf, etc.
+```
+
+- [ ] **Step 5: Verify CAD Viewer access**
+
+After OpenCode is running with a configured provider, ask it to:
+"Create a simple 60x40x20mm block and show it in CAD Viewer"
+
+Expected: OpenCode generates the CAD file, starts the viewer (`npm --prefix viewer run agent:start`), and CAD Viewer becomes accessible at `http://localhost:5173`.
+
+- [ ] **Step 6: Verify persistence**
+
+```bash
+# Restart the container
+docker compose restart
+
+# Open browser to http://localhost:8080
+# Expected: OpenCode restores previous session (conversation history intact)
+# The AI provider config from `/connect` should still be active
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- ✅ Ubuntu 24.04 base (Dockerfile: `FROM ubuntu:24.04`)
+- ✅ OpenCode via `bun install -g opencode-ai` (Dockerfile: `RUN bun install -g opencode-ai`)
+- ✅ ttyd web terminal port 8080 (docker-compose ports + entrypoint)
+- ✅ CAD Viewer port 5173 (docker-compose ports)
+- ✅ build123d CAD generation (Dockerfile: `pip install build123d`)
+- ✅ No .env file (OpenCode `/connect` handles provider config)
+- ✅ Skills auto-discovery (opencode.json `skills.paths`)
+- ✅ Volume mount for source access (docker-compose volumes)
+- ✅ Data persistence (named volume `opencode_data`)
+- ✅ Volume mount doesn't shadow deps (entrypoint symlink trick)
+
+**Placeholder scan:** No TBD, TODO, or incomplete sections. All code blocks contain complete, runnable content.
+
+**Type consistency:** Single container, single entrypoint, consistent path references throughout. The `/opt/venv` and `/opt/viewer-node-modules` convention is used consistently in Dockerfile, entrypoint, and verification steps.

--- a/scripts/dev/compose-verify.sh
+++ b/scripts/dev/compose-verify.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Verifies the cad-workbench compose stack on this branch.
+#
+# What this script checks:
+#   1. compose config resolves with no bind mount on /workspace
+#   2. the cad-workbench container is running
+#   3. /workspace is a named volume (no host-bind overlay)
+#   4. /workspace contains the seeded project tree
+#   5. /workspace/viewer has its node_modules and packages symlinks
+#   6. /workspace/models exists and is writable by the opencode user
+#   7. the opencode user can write to /workspace and /workspace/models
+#   8. ttyd (5080) and viewer (5173) respond inside the container
+#   9. Vite dev server cwd is /workspace/viewer
+#  10. the viewer serves ?dir=/workspace/models with HTTP 200
+#
+# Usage:
+#   tmp/compose-verify.sh                  # uses defaults
+#   OPENCODE_TTYD_PORT=5180 \
+#   VIEWER_HOST_PORT=8081 \
+#   tmp/compose-verify.sh                  # override published ports
+#
+# This script is intentionally read-only against compose state; it does not
+# bring services up or down.  Pair it with `docker compose up -d` upstream.
+
+set -euo pipefail
+
+CONTAINER="${CONTAINER:-gentle-salamander-cad-workbench-1}"
+SERVICE="${SERVICE:-cad-workbench}"
+
+OPENCODE_TTYD_PORT="${OPENCODE_TTYD_PORT:-5080}"
+VIEWER_HOST_PORT="${VIEWER_HOST_PORT:-5173}"
+
+pass=0
+fail=0
+log() { printf '%s\n' "$*"; }
+ok() { log "  [ok] $*"; pass=$((pass+1)); }
+bad() { log "  [FAIL] $*"; fail=$((fail+1)); }
+section() { log; log "== $* =="; }
+
+section "1. compose config"
+config_yaml="$(docker compose config 2>/dev/null || true)"
+if [ -z "$config_yaml" ]; then
+    bad "docker compose config returned no output"
+    exit 1
+fi
+if printf '%s\n' "$config_yaml" | grep -Eq 'source:\s*opencode_workspace\b'; then
+    ok "opencode_workspace volume declared and bound to /workspace"
+else
+    bad "opencode_workspace volume not bound to /workspace"
+fi
+if printf '%s\n' "$config_yaml" | grep -Eq 'source:\s*/workspace\b'; then
+    bad "compose still binds a host /workspace path"
+else
+    ok "no host bind on /workspace"
+fi
+
+section "2. container status"
+status="$(docker compose ps --format '{{.State}}' "$SERVICE" 2>/dev/null || true)"
+if [ "$status" = "running" ]; then
+    ok "service '$SERVICE' is running"
+else
+    bad "service '$SERVICE' state: '$status'"
+    log "  hint: run 'OPENCODE_TTYD_PORT=$OPENCODE_TTYD_PORT VIEWER_HOST_PORT=$VIEWER_HOST_PORT docker compose up -d'"
+    exit 1
+fi
+
+section "3. /workspace mount is a named volume"
+mount_line="$(docker compose exec -T "$SERVICE" sh -lc "grep -E ' /workspace( |$|\$)' /proc/self/mountinfo | head -1" 2>/dev/null || true)"
+if [ -z "$mount_line" ]; then
+    bad "could not read /workspace mount info"
+else
+    volume_path="$(printf '%s\n' "$mount_line" | sed -nE 's#.* (/var/lib/docker/volumes/[^ ]*) /workspace .*#\1#p')"
+    case "$mount_line" in
+        *"/var/lib/docker/volumes/"*"opencode_workspace"*)
+            ok "/workspace mounted from named volume: ${volume_path:-opencode_workspace}" ;;
+        *"/var/lib/docker/volumes/"*)
+            bad "/workspace mounted from a docker volume, but not opencode_workspace: ${volume_path:-unknown}" ;;
+        *)
+            bad "/workspace not mounted from a docker volume" ;;
+    esac
+fi
+
+section "4. /workspace seeded tree"
+missing=""
+for entry in AGENTS.md docker-compose.yml models viewer skills docs packages; do
+    if ! docker compose exec -T "$SERVICE" sh -lc "[ -e /workspace/$entry ]" >/dev/null 2>&1; then
+        missing="$missing $entry"
+    fi
+done
+if [ -z "$missing" ]; then
+    ok "expected project entries present in /workspace"
+else
+    bad "missing entries under /workspace:$missing"
+fi
+
+section "5. /workspace/viewer symlinks"
+for target in node_modules packages/cadjs packages/implicitjs; do
+    link="$(docker compose exec -T "$SERVICE" sh -lc "readlink /workspace/viewer/$target" 2>/dev/null || true)"
+    if [ -n "$link" ] && [ "$link" != "/dev/null" ]; then
+        ok "viewer/$target -> $link"
+    else
+        bad "viewer/$target not a symlink"
+    fi
+done
+
+section "6. /workspace/models exists and is writable by opencode"
+if docker compose exec -T "$SERVICE" sh -lc 'test -d /workspace/models' >/dev/null 2>&1; then
+    ok "/workspace/models exists"
+else
+    bad "/workspace/models missing"
+fi
+if docker compose exec -T "$SERVICE" sh -lc 'su -s /bin/bash opencode -c "test -w /workspace/models"' >/dev/null 2>&1; then
+    ok "opencode user can write to /workspace/models"
+else
+    bad "opencode user cannot write to /workspace/models"
+fi
+
+section "7. opencode write test (creates and removes a file)"
+write_ok="$(docker compose exec -T "$SERVICE" sh -lc 'su -s /bin/bash opencode -c "f=/workspace/.compose-verify-write; touch \$f && rm \$f && echo ok"' 2>/dev/null || true)"
+if [ "$write_ok" = "ok" ]; then
+    ok "opencode wrote and removed /workspace/.compose-verify-write"
+else
+    bad "opencode write test failed: $write_ok"
+fi
+
+section "8. ttyd and viewer listening inside container"
+if docker compose exec -T "$SERVICE" sh -lc 'python3 -c "import socket,sys; s=socket.socket(); s.settimeout(2); s.connect((\"127.0.0.1\", 5080)); s.close(); print(\"ok\")"' >/dev/null 2>&1; then
+    ok "container 127.0.0.1:5080 reachable"
+else
+    bad "container 127.0.0.1:5080 not reachable"
+fi
+if docker compose exec -T "$SERVICE" sh -lc 'python3 -c "import socket,sys; s=socket.socket(); s.settimeout(2); s.connect((\"127.0.0.1\", 5173)); s.close(); print(\"ok\")"' >/dev/null 2>&1; then
+    ok "container 127.0.0.1:5173 reachable"
+else
+    bad "container 127.0.0.1:5173 not reachable"
+fi
+
+section "9. Vite dev server cwd is /workspace/viewer"
+vite_bin="$(docker compose exec -T "$SERVICE" sh -lc 'pgrep -af "node.*\\.bin/vite" | head -1' 2>/dev/null || true)"
+case "$vite_bin" in
+    *"/workspace/viewer/node_modules/.bin/vite"*) ok "vite running from /workspace/viewer";;
+    *) bad "vite binary path unexpected: $vite_bin";;
+esac
+
+section "10. viewer HTTP for ?dir=/workspace/models"
+status="$(docker compose exec -T "$SERVICE" sh -lc 'python3 -c "import urllib.request; r=urllib.request.urlopen(\"http://127.0.0.1:5173/?dir=/workspace/models\", timeout=5); print(r.status)"' 2>/dev/null || true)"
+if [ "$status" = "200" ]; then
+    ok "viewer /?dir=/workspace/models returned 200"
+else
+    bad "viewer /?dir=/workspace/models returned: $status"
+fi
+
+section "summary"
+log "passed: $pass"
+log "failed: $fail"
+if [ "$fail" -gt 0 ]; then
+    exit 1
+fi
+log "compose-verify: all checks passed"


### PR DESCRIPTION
## Summary

Roll up the `feat/docker-compose-environment` branch into `develop`. This
branch was created from `develop@fe754c0` and has accumulated the
multi-stage Docker image, the OpenCode terminal + CAD Viewer stack,
and a follow-up that swaps the `/workspace` host bind for an
image-seeded named volume.

The full diff against `develop` is 16 files / 1559 insertions, all
under `.docker/`, `docker-compose.yml`, the new `scripts/dev/`,
`.opencode/skills/`, and `docs/knowledge/`.

## Commits (oldest first)

```
c422ccf feat: add Docker scaffold files (opencode.json, .dockerignore, docker-compose.yml)
e46d814 feat: add entrypoint script (symlink workaround, tmux, ttyd)
440f6ac fix: add -A and attach-session to keep tmux in ttyd foreground
7872b25 feat: add multi-stage Dockerfile (base/python-deps/node-deps/final)
440673e fix: repair Dockerfile COPY syntax, combine pip-cache layer, reorder COPY for cache
5fe5105 fix: build-time fixes for Docker image (UID conflict, libGL, editable pip, entrypoint tolerance)
e995549 chore: add .omo to gitignore
f5da9ed fix: Docker build-time fixes (Playwright cache, viewer bind-mount shadow, Vite auto-start)
0873deb chore: add codegraph exclusion and project knowledge base
4af55a9 feat(cad-workbench): switch /workspace to a named volume with seed on first boot
```

The head commit (`4af55a9`) is the most important one to review; the
earlier nine commits are the prerequisite scaffolding.

## Head-commit detail: `4af55a9`

Switch the `cad-workbench` container from a host bind mount on
`/workspace` to a named volume populated by an image-internal seed on
first boot. This removes the host-overlay inconsistency (e.g. stale or
stray files from the host leaking into the container's view of the
project tree) and makes the runtime writable by the `opencode` user
without relying on the host UID matching the container UID.

### Files in `4af55a9`

- `docker-compose.yml` — replace `.:/workspace:cached` bind with the
  `opencode_workspace` named volume; parameterize host ports via
  `OPENCODE_TTYD_PORT` and `VIEWER_HOST_PORT`; run the container as
  root (`user: 0:0`) and pass `LOCAL_UID` / `LOCAL_GID` so the
  entrypoint can re-map the `opencode` user to the host UID/GID
  before dropping privileges.
- `.docker/Dockerfile` — copy project source to `/opt/workspace-seed`
  instead of `/workspace`; keep viewer source under `/opt/viewer-source`
  for non-shadowed Vite startup; drop the build-time
  `npx playwright install chromium` step (the dev environment already
  provides the cache).
- `.docker/entrypoint.sh` — on first boot, copy
  `/opt/workspace-seed/.` into `/workspace` when the named volume is
  empty; chown the materialized tree to the mapped `opencode` UID/GID;
  repair the seeded `/workspace/viewer/{node_modules,packages/*}`
  symlinks to point at the real image-internal cache; start the Vite
  dev server from `/workspace/viewer` so HMR sees source edits.
- `scripts/dev/compose-verify.sh` (new) — durable smoke test that
  asserts 15 runtime checks.
- `.opencode/skills/cad-workbench.md` (new) — trigger-only skill that
  wraps `scripts/dev/compose-verify.sh`.
- `docs/knowledge/tooling/docker-compose-environment.md` (new) —
  capture the bind → named volume decision, the seed-on-first-boot
  contract, the runtime UID/port overrides, and the side effects.

## Validation

`scripts/dev/compose-verify.sh` (15 / 15 checks pass) on this branch:

```
== 1. compose config ==
  [ok] opencode_workspace volume declared and bound to /workspace
  [ok] no host bind on /workspace

== 2. container status ==
  [ok] service 'cad-workbench' is running

== 3. /workspace mount is a named volume ==
  [ok] /workspace mounted from named volume: /var/lib/docker/volumes/gentle-salamander_opencode_workspace/_data

== 4. /workspace seeded tree ==
  [ok] expected project entries present in /workspace

== 5. /workspace/viewer symlinks ==
  [ok] viewer/node_modules -> /opt/viewer-node-modules/viewer/node_modules
  [ok] viewer/packages/cadjs -> /opt/viewer-node-modules/packages/cadjs
  [ok] viewer/packages/implicitjs -> /opt/viewer-node-modules/packages/implicitjs

== 6. /workspace/models exists and is writable by opencode ==
  [ok] /workspace/models exists
  [ok] opencode user can write to /workspace/models

== 7. opencode write test (creates and removes a file) ==
  [ok] opencode wrote and removed /workspace/.compose-verify-write

== 8. ttyd and viewer listening inside container ==
  [ok] container 127.0.0.1:5080 reachable
  [ok] container 127.0.0.1:5173 reachable

== 9. Vite dev server cwd is /workspace/viewer ==
  [ok] vite running from /workspace/viewer

== 10. viewer HTTP for ?dir=/workspace/models ==
  [ok] viewer /?dir=/workspace/models returned 200
```

## Side Effects

- No live host editing. Editing source on the host does not propagate
  to the running container; developers must
  `docker compose down && docker compose up --build -d` to refresh.
- First-boot copy is the source of truth. A non-empty
  `opencode_workspace` volume can mask a freshly-built image; run
  `docker compose down -v` to re-seed.
- `opencode_workspace` is not LFS-aware. LFS pointer files in the
  seed copy as plain text. Hydrate with `git lfs pull` (host or
  container) before depending on LFS-backed artifacts.

## Test plan

- [ ] CI: `scripts/test/test.sh` and related focused runners
- [ ] Manual: clean `docker compose up --build -d` with
  `LOCAL_UID` / `LOCAL_GID` left at defaults, then
  `scripts/dev/compose-verify.sh` reports 15 / 15
- [ ] Manual: `http://<host>:8081/?dir=/workspace/models` (default
  `5173`) returns the viewer
- [ ] Manual: `http://<host>:5180/` (default `5080`) returns the ttyd
  terminal

## Related

- `docs/knowledge/tooling/docker-bind-mount-shadowing.md` (predecessor
  lesson)
- `docs/knowledge/tooling/docker-user-cache-ordering.md` (predecessor
  lesson)
- `docs/superpowers/plans/2026-06-24-docker-compose-environment.md`
  (the original plan this branch executes)
