### PR TITLE
[codex] Add Discord community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,9 @@ A skills library for CAD, robotics, and hardware design agents
 
 [Docs](https://www.cadskills.xyz) | [Demo](https://demo.cadskills.xyz)
 
+[![Join Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/5FGB9DwJYU)
 [![GitHub stars](https://img.shields.io/github/stars/earthtojake/text-to-cad?style=for-the-badge&logo=github&label=Stars)](https://github.com/earthtojake/text-to-cad/stargazers)
-[![GitHub forks](https://img.shields.io/github/forks/earthtojake/text-to-cad?style=for-the-badge&logo=github&label=Forks)](https://github.com/earthtojake/text-to-cad/network/members)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge)](LICENSE)
-[![Follow @earthtojake](https://img.shields.io/badge/Follow-%40earthtojake-000000?style=for-the-badge&logo=x)](https://x.com/earthtojake)
-[![Python](https://img.shields.io/badge/Python-3.11+-3776AB?style=for-the-badge&logo=python&logoColor=white)](skills/cad/requirements.txt)
-[![build123d](https://img.shields.io/badge/build123d-CAD-00A676?style=for-the-badge)](https://github.com/gumyr/build123d)
-[![OCP](https://img.shields.io/badge/OCP-OpenCascade-2F80ED?style=for-the-badge)](skills/cad/requirements.txt)
-[![STEP](https://img.shields.io/badge/STEP-Export-4A5568?style=for-the-badge)](skills/cad/SKILL.md)
-[![STL](https://img.shields.io/badge/STL-Export-4A5568?style=for-the-badge)](skills/cad/SKILL.md)
-[![3MF](https://img.shields.io/badge/3MF-Export-4A5568?style=for-the-badge)](skills/cad/SKILL.md)
-[![URDF](https://img.shields.io/badge/URDF-Robots-6B46C1?style=for-the-badge)](skills/urdf/SKILL.md)
-[![SDF](https://img.shields.io/badge/SDF-Simulation-6B46C1?style=for-the-badge)](skills/sdf/SKILL.md)
-[![SRDF](https://img.shields.io/badge/SRDF-MoveIt2-6B46C1?style=for-the-badge)](skills/srdf/SKILL.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ A skills library for CAD, robotics, and hardware design agents
 [![Join Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/5FGB9DwJYU)
 [![GitHub stars](https://img.shields.io/github/stars/earthtojake/text-to-cad?style=for-the-badge&logo=github&label=Stars)](https://github.com/earthtojake/text-to-cad/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge)](LICENSE)
+[![Follow @earthtojake](https://img.shields.io/badge/Follow-%40earthtojake-000000?style=for-the-badge&logo=x)](https://x.com/earthtojake)
+[![Python](https://img.shields.io/badge/Python-3.11+-3776AB?style=for-the-badge&logo=python&logoColor=white)](skills/cad/requirements.txt)
+[![STEP](https://img.shields.io/badge/STEP-Export-4A5568?style=for-the-badge)](skills/cad/SKILL.md)
+[![STL](https://img.shields.io/badge/STL-Export-4A5568?style=for-the-badge)](skills/cad/SKILL.md)
+[![3MF](https://img.shields.io/badge/3MF-Export-4A5568?style=for-the-badge)](skills/cad/SKILL.md)
+[![URDF](https://img.shields.io/badge/URDF-Robots-6B46C1?style=for-the-badge)](skills/urdf/SKILL.md)
+[![SDF](https://img.shields.io/badge/SDF-Simulation-6B46C1?style=for-the-badge)](skills/sdf/SKILL.md)
+[![SRDF](https://img.shields.io/badge/SRDF-MoveIt2-6B46C1?style=for-the-badge)](skills/srdf/SKILL.md)
 
 </div>
 

--- a/docs/src/components/site-header-client.tsx
+++ b/docs/src/components/site-header-client.tsx
@@ -10,6 +10,21 @@ import {
 } from "@/components/ui/tooltip";
 
 const GITHUB_REPO_URL = "https://github.com/earthtojake/text-to-cad";
+const DISCORD_URL = "https://discord.gg/5FGB9DwJYU";
+
+function DiscordLogo({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      fill="currentColor"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path d="M20.32 4.37a19.8 19.8 0 0 0-4.89-1.51.07.07 0 0 0-.07.03c-.21.38-.44.86-.61 1.25a18.27 18.27 0 0 0-5.49 0 12.64 12.64 0 0 0-.62-1.25.08.08 0 0 0-.07-.03 19.74 19.74 0 0 0-4.89 1.51.07.07 0 0 0-.03.03C.53 9.05-.32 13.58.1 18.06a.08.08 0 0 0 .03.06 19.9 19.9 0 0 0 5.99 3.03.08.08 0 0 0 .08-.03c.46-.63.87-1.3 1.23-1.99a.08.08 0 0 0-.04-.11 13.1 13.1 0 0 1-1.87-.89.08.08 0 0 1-.01-.13c.13-.09.25-.19.37-.29a.07.07 0 0 1 .08-.01c3.93 1.79 8.18 1.79 12.06 0a.07.07 0 0 1 .08.01c.12.1.25.2.37.29a.08.08 0 0 1-.01.13 12.3 12.3 0 0 1-1.87.89.08.08 0 0 0-.04.11c.36.7.77 1.36 1.23 1.99a.08.08 0 0 0 .08.03 19.84 19.84 0 0 0 6-3.03.08.08 0 0 0 .03-.05c.5-5.18-.84-9.67-3.55-13.66a.06.06 0 0 0-.02-.04ZM8.02 15.33c-1.18 0-2.16-1.09-2.16-2.42s.96-2.42 2.16-2.42c1.21 0 2.18 1.1 2.16 2.42 0 1.33-.96 2.42-2.16 2.42Zm7.98 0c-1.18 0-2.16-1.09-2.16-2.42s.96-2.42 2.16-2.42c1.21 0 2.18 1.1 2.16 2.42 0 1.33-.95 2.42-2.16 2.42Z" />
+    </svg>
+  );
+}
 
 function GitHubLogo({ className }: { className?: string }) {
   return (
@@ -110,6 +125,26 @@ export function SiteHeaderClient({
               DEMO
             </a>
           </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                asChild
+                variant="outline"
+                size="icon"
+                className="card-glow h-8 w-8 border-border bg-card text-foreground hover:bg-secondary hover:text-primary"
+              >
+                <a
+                  href={DISCORD_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label="Join the CAD Skills Discord"
+                >
+                  <DiscordLogo className="size-3.5" />
+                </a>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Discord</TooltipContent>
+          </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
               <Button

--- a/docs/src/components/site-header-client.tsx
+++ b/docs/src/components/site-header-client.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/ui/tooltip";
 
 const GITHUB_REPO_URL = "https://github.com/earthtojake/text-to-cad";
-const DISCORD_URL = "https://discord.gg/5FGB9DwJYU";
 
 function DiscordLogo({ className }: { className?: string }) {
   return (
@@ -67,9 +66,11 @@ function VersionLink({ version }: { version: string }) {
 
 export function SiteHeaderClient({
   githubStars,
+  discordUrl,
   version,
 }: {
   githubStars: number | null;
+  discordUrl: string;
   version: string;
 }) {
   const githubLabel =
@@ -134,7 +135,7 @@ export function SiteHeaderClient({
                 className="card-glow h-8 w-8 border-border bg-card text-foreground hover:bg-secondary hover:text-primary"
               >
                 <a
-                  href={DISCORD_URL}
+                  href={discordUrl}
                   target="_blank"
                   rel="noreferrer"
                   aria-label="Join the CAD Skills Discord"

--- a/docs/src/components/site-header.tsx
+++ b/docs/src/components/site-header.tsx
@@ -3,6 +3,27 @@ import packageJson from "../../package.json";
 
 const GITHUB_REPO_API_URL =
   "https://api.github.com/repos/earthtojake/text-to-cad";
+const DEFAULT_DISCORD_URL = "https://discord.gg/5FGB9DwJYU";
+
+function normalizeDiscordUrl(value: string | undefined) {
+  const rawValue = String(value || "").trim();
+  if (!rawValue) {
+    return DEFAULT_DISCORD_URL;
+  }
+
+  const urlValue = /^[a-z][a-z\d+.-]*:\/\//i.test(rawValue)
+    ? rawValue
+    : `https://${rawValue.replace(/^\/+/, "")}`;
+
+  try {
+    const url = new URL(urlValue);
+    return ["http:", "https:"].includes(url.protocol)
+      ? url.href
+      : DEFAULT_DISCORD_URL;
+  } catch {
+    return DEFAULT_DISCORD_URL;
+  }
+}
 
 async function getGitHubStars() {
   try {
@@ -32,6 +53,7 @@ export async function SiteHeader() {
   return (
     <SiteHeaderClient
       githubStars={githubStars}
+      discordUrl={normalizeDiscordUrl(process.env.DISCORD_URL)}
       version={packageJson.version}
     />
   );

--- a/viewer/.env.example
+++ b/viewer/.env.example
@@ -9,6 +9,8 @@ VIEWER_ASSET_BACKEND=local-fs
 # VIEWER_DEFAULT_FILE=assemblies/robot-arm/robot-arm.step
 # Override the default repo/release links.
 # VIEWER_GITHUB_URL=https://github.com/<owner>/<repo>
+# Override the default Discord community link.
+# VIEWER_DISCORD_URL=https://discord.gg/<invite>
 # VIEWER_ALLOWED_HOSTS=localhost,127.0.0.1
 # VIEWER_MOVEIT2_WS_URL=ws://127.0.0.1:8765
 # VIEWER_CAD_PYTHON=./.venv/bin/python

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -129,6 +129,7 @@ Important environment variables:
   version label links to the matching GitHub release tag. For GitHub-hosted
   repositories, the Viewer also checks the latest release and lightly marks the
   version label when a newer release is available.
+- `VIEWER_DISCORD_URL`: optional top-bar Discord community link target.
 - `VIEWER_ALLOWED_HOSTS`: extra hostnames accepted by local Vite dev and
   production servers.
 - `VIEWER_MOVEIT2_WS_URL`: optional websocket URL for SRDF MoveIt2 controls.

--- a/viewer/src/client/components/workbench/CadWorkspaceTopBar.js
+++ b/viewer/src/client/components/workbench/CadWorkspaceTopBar.js
@@ -682,6 +682,15 @@ function GitHubMark(props) {
   );
 }
 
+function DiscordMark(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M20.32 4.37a19.8 19.8 0 0 0-4.89-1.51.07.07 0 0 0-.07.03c-.21.38-.44.86-.61 1.25a18.27 18.27 0 0 0-5.49 0 12.64 12.64 0 0 0-.62-1.25.08.08 0 0 0-.07-.03 19.74 19.74 0 0 0-4.89 1.51.07.07 0 0 0-.03.03C.53 9.05-.32 13.58.1 18.06a.08.08 0 0 0 .03.06 19.9 19.9 0 0 0 5.99 3.03.08.08 0 0 0 .08-.03c.46-.63.87-1.3 1.23-1.99a.08.08 0 0 0-.04-.11 13.1 13.1 0 0 1-1.87-.89.08.08 0 0 1-.01-.13c.13-.09.25-.19.37-.29a.07.07 0 0 1 .08-.01c3.93 1.79 8.18 1.79 12.06 0a.07.07 0 0 1 .08.01c.12.1.25.2.37.29a.08.08 0 0 1-.01.13 12.3 12.3 0 0 1-1.87.89.08.08 0 0 0-.04.11c.36.7.77 1.36 1.23 1.99a.08.08 0 0 0 .08.03 19.84 19.84 0 0 0 6-3.03.08.08 0 0 0 .03-.05c.5-5.18-.84-9.67-3.55-13.66a.06.06 0 0 0-.02-.04ZM8.02 15.33c-1.18 0-2.16-1.09-2.16-2.42s.96-2.42 2.16-2.42c1.21 0 2.18 1.1 2.16 2.42 0 1.33-.96 2.42-2.16 2.42Zm7.98 0c-1.18 0-2.16-1.09-2.16-2.42s.96-2.42 2.16-2.42c1.21 0 2.18 1.1 2.16 2.42 0 1.33-.95 2.42-2.16 2.42Z" />
+    </svg>
+  );
+}
+
+const DISCORD_URL = "https://discord.gg/5FGB9DwJYU";
 const topBarIconButtonClasses = "size-7";
 const topBarIconClasses = "size-4";
 const latestReleaseCacheKeyPrefix = "cad-viewer:latest-release:v1:";
@@ -1279,6 +1288,18 @@ export default function CadWorkspaceTopBar({
             releaseUrl={releaseUrl}
             releaseCheck={releaseCheck}
           />
+          <Button
+            asChild
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Join the CAD Skills Discord"
+            title="Join the CAD Skills Discord"
+            className={topBarIconButtonClasses}
+          >
+            <a href={DISCORD_URL} target="_blank" rel="noreferrer">
+              <DiscordMark className={topBarIconClasses} />
+            </a>
+          </Button>
           {githubUrl ? (
             <Button
               asChild

--- a/viewer/src/client/components/workbench/CadWorkspaceTopBar.js
+++ b/viewer/src/client/components/workbench/CadWorkspaceTopBar.js
@@ -24,6 +24,7 @@ import {
   isViewerReleaseNewer,
   viewerGithubLatestReleaseApiUrl,
   viewerGithubLatestReleaseUrl,
+  normalizeViewerDiscordUrl,
   normalizeViewerGithubUrl,
   viewerGithubReleaseUrl,
   viewerSkillsInstallCommandFromText
@@ -690,7 +691,6 @@ function DiscordMark(props) {
   );
 }
 
-const DISCORD_URL = "https://discord.gg/5FGB9DwJYU";
 const topBarIconButtonClasses = "size-7";
 const topBarIconClasses = "size-4";
 const latestReleaseCacheKeyPrefix = "cad-viewer:latest-release:v1:";
@@ -1101,6 +1101,7 @@ export default function CadWorkspaceTopBar({
   navigationAvailable = true
 }) {
   const viewerVersion = String(viewerPackage.version || "").trim();
+  const discordUrl = normalizeViewerDiscordUrl(import.meta.env?.VIEWER_DISCORD_URL);
   const githubUrl = normalizeViewerGithubUrl(import.meta.env?.VIEWER_GITHUB_URL);
   const releaseUrl = viewerGithubReleaseUrl(viewerVersion, githubUrl);
   const latestReleaseUrl = viewerGithubLatestReleaseUrl(githubUrl);
@@ -1296,7 +1297,7 @@ export default function CadWorkspaceTopBar({
             title="Join the CAD Skills Discord"
             className={topBarIconButtonClasses}
           >
-            <a href={DISCORD_URL} target="_blank" rel="noreferrer">
+            <a href={discordUrl} target="_blank" rel="noreferrer">
               <DiscordMark className={topBarIconClasses} />
             </a>
           </Button>

--- a/viewer/src/shared/viewerConfig.mjs
+++ b/viewer/src/shared/viewerConfig.mjs
@@ -1,4 +1,5 @@
 export const DEFAULT_VIEWER_GITHUB_URL = "https://github.com/earthtojake/text-to-cad";
+export const DEFAULT_VIEWER_DISCORD_URL = "https://discord.gg/5FGB9DwJYU";
 export const DEFAULT_VIEWER_SKILLS_INSTALL_COMMAND = "npx skills install earthtojake/text-to-cad";
 
 export function normalizeViewerDefaultFile(value = "") {
@@ -7,7 +8,11 @@ export function normalizeViewerDefaultFile(value = "") {
 }
 
 export function normalizeViewerGithubUrl(value = "", fallback = DEFAULT_VIEWER_GITHUB_URL) {
-  return normalizeViewerGithubUrlCandidate(value) || normalizeViewerGithubUrlCandidate(fallback);
+  return normalizeHttpUrlCandidate(value) || normalizeHttpUrlCandidate(fallback);
+}
+
+export function normalizeViewerDiscordUrl(value = "", fallback = DEFAULT_VIEWER_DISCORD_URL) {
+  return normalizeHttpUrlCandidate(value) || normalizeHttpUrlCandidate(fallback);
 }
 
 export function viewerGithubRepositoryUrl(value = "", fallback = DEFAULT_VIEWER_GITHUB_URL) {
@@ -116,7 +121,7 @@ export function viewerSkillsInstallCommandFromText(
   return String(fallback || "").trim();
 }
 
-function normalizeViewerGithubUrlCandidate(value = "") {
+function normalizeHttpUrlCandidate(value = "") {
   const rawValue = String(value ?? "").trim();
   if (!rawValue) {
     return "";

--- a/viewer/src/shared/viewerConfig.test.mjs
+++ b/viewer/src/shared/viewerConfig.test.mjs
@@ -2,11 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  DEFAULT_VIEWER_DISCORD_URL,
   DEFAULT_VIEWER_GITHUB_URL,
   DEFAULT_VIEWER_SKILLS_INSTALL_COMMAND,
   isViewerReleaseMajorMinorNewer,
   isViewerReleaseNewer,
   normalizeViewerDefaultFile,
+  normalizeViewerDiscordUrl,
   normalizeViewerGithubUrl,
   normalizeViewerSkillsInstallCommand,
   viewerGithubLatestReleaseApiUrl,
@@ -40,6 +42,21 @@ test("normalizeViewerGithubUrl falls back to a configured default", () => {
   assert.equal(
     normalizeViewerGithubUrl("", "github.com/example/default"),
     "https://github.com/example/default"
+  );
+});
+
+test("normalizeViewerDiscordUrl defaults to the CAD Skills Discord invite", () => {
+  assert.equal(normalizeViewerDiscordUrl(""), DEFAULT_VIEWER_DISCORD_URL);
+});
+
+test("normalizeViewerDiscordUrl accepts configured invite URLs", () => {
+  assert.equal(
+    normalizeViewerDiscordUrl("discord.gg/example"),
+    "https://discord.gg/example"
+  );
+  assert.equal(
+    normalizeViewerDiscordUrl("https://example.com/community"),
+    "https://example.com/community"
   );
 });
 


### PR DESCRIPTION
## Summary

- Tighten the README badge row by removing the forks plus build123d/OCP dependency badges while keeping Discord, GitHub stars, license, X, Python, CAD export, and robot-description badges.
- Add a Discord community button before the GitHub button in the docs header and make the docs target configurable with `DISCORD_URL`.
- Add the same Discord community button before the GitHub button in the CAD Viewer top bar and make the viewer target configurable with `VIEWER_DISCORD_URL`.

## Impact

This makes the community link more visible while reducing visual clutter in the README and keeping the docs/viewer navigation consistent. Deployments can override the Discord invite without code changes.

## Checks

- `node --test viewer/src/shared/viewerConfig.test.mjs`
- `npm --prefix docs run check`
- `npm --prefix viewer run test`
- `npm --prefix viewer run build`
- pre-commit bundle freshness checks during `git commit`