### PR TITLE
Preserve GLB material opacity in CAD viewer

### DIFF
--- a/packages/cadjs/src/common/cadScene.js
+++ b/packages/cadjs/src/common/cadScene.js
@@ -599,6 +599,11 @@ function sourceColorForPart(THREE, part, meshData) {
   return readSourceColor(THREE, part?.color || meshData?.sourceColor);
 }
 
+function sourceOpacityForPart(part, fallback = 1) {
+  const opacity = Number(part?.opacity);
+  return Number.isFinite(opacity) ? clamp(opacity, 0, 1) : fallback;
+}
+
 function meshUsesPartSourceColors(meshData, parts) {
   const renderableParts = Array.isArray(parts) ? parts : [];
   const partColors = renderableParts
@@ -608,6 +613,14 @@ function meshUsesPartSourceColors(meshData, parts) {
     return false;
   }
   return partColors.length !== renderableParts.length || new Set(partColors).size > 1;
+}
+
+function meshUsesPartSourceOpacity(parts) {
+  const renderableParts = Array.isArray(parts) ? parts : [];
+  return renderableParts.some((part) => {
+    const opacity = Number(part?.opacity);
+    return Number.isFinite(opacity) && clamp(opacity, 0, 1) < 0.999;
+  });
 }
 
 function emptyLineGeometry(THREE) {
@@ -1018,7 +1031,10 @@ export function applyMaterialSettingsToRecord(THREE, record, materialSettings, {
   record.material.metalness = clamp(Number(materialSettings.metalness) || 0, 0, 1);
   record.material.clearcoat = clamp(Number(materialSettings.clearcoat) || 0, 0, 1);
   record.material.clearcoatRoughness = clamp(Number(materialSettings.clearcoatRoughness) || 0, 0, 1);
-  record.baseOpacity = clamp(displayModeSurfaceOpacity(displayMode, materialSettings.opacity), 0, 1);
+  const sourceOpacity = Number.isFinite(Number(record.sourceOpacity))
+    ? clamp(Number(record.sourceOpacity), 0, 1)
+    : 1;
+  record.baseOpacity = clamp(displayModeSurfaceOpacity(displayMode, materialSettings.opacity) * sourceOpacity, 0, 1);
   record.material.opacity = record.baseOpacity;
   record.material.transparent = record.baseOpacity < 0.999;
   record.material.depthWrite = displayMode === CAD_DISPLAY_MODE.TRANSPARENT ? false : record.baseOpacity >= 0.999;
@@ -1711,7 +1727,7 @@ function resolvePartsToRender(meshData, theme, settings) {
     if (pickableParts.length) {
       return pickableParts;
     }
-    if (meshUsesPartSourceColors(meshData, parts)) {
+    if (meshUsesPartSourceColors(meshData, parts) || meshUsesPartSourceOpacity(parts)) {
       return parts;
     }
     const hasFillRotation = theme?.materials?.cycleColors === true &&
@@ -1775,6 +1791,7 @@ function buildDisplayRecords(THREE, runtime, meshData, settings) {
       edgeSettings.enabled &&
       geometryHasSurfaceEdgeAttributes(geometryEntry.geometry);
     const sourceColor = sourceColorForPart(THREE, part, meshData);
+    const sourceOpacity = sourceOpacityForPart(part);
     const hasSourceColor = sourceVertexColors || !!sourceColor;
     const hasVertexColors = !forceFill && sourceVertexColors;
     const baseColor = resolveSourceBaseColor(THREE, {
@@ -1825,6 +1842,7 @@ function buildDisplayRecords(THREE, runtime, meshData, settings) {
       edgeMaterial: null,
       baseColor,
       sourceColor,
+      sourceOpacity,
       baseTransform,
       partCenter: readBoundsCenter(THREE, part?.bounds || bounds),
       partBounds: part?.bounds || part?.sourceBounds || bounds,

--- a/packages/cadjs/src/common/cadScene.test.js
+++ b/packages/cadjs/src/common/cadScene.test.js
@@ -540,6 +540,51 @@ test("buildModel display modes control edges, transparency, and flat surfaces", 
   unshadedScene.dispose();
 });
 
+test("buildModel applies source part opacity from GLB material metadata", () => {
+  const meshData = sampleMeshData();
+  meshData.parts = meshData.parts.map((part, index) => index === 0
+    ? { ...part, color: "#ff0000", opacity: 0.2, hasSourceColors: true }
+    : part
+  );
+  const scene = buildModel(THREE, meshData, {
+    theme: cloneThemeSettings("workbench"),
+    renderPartsIndividually: true
+  });
+
+  const left = scene.displayRecords.find((record) => record.partId === "left");
+
+  assert.equal(left.baseOpacity, 0.2);
+  assert.equal(left.material.opacity, 0.2);
+  assert.equal(left.material.transparent, true);
+  assert.equal(left.material.depthWrite, false);
+  scene.dispose();
+});
+
+test("buildModel uses part records when only source opacity differs", () => {
+  const meshData = sampleMeshData();
+  meshData.sourceColor = "#ff0000";
+  meshData.has_source_colors = true;
+  meshData.parts = meshData.parts.map((part) => ({
+    ...part,
+    color: "#ff0000",
+    opacity: 0.2,
+    hasSourceColors: true
+  }));
+  const scene = buildModel(THREE, meshData, {
+    theme: cloneThemeSettings("workbench"),
+    renderPartsIndividually: false
+  });
+
+  assert.equal(scene.displayRecords.length, 2);
+  for (const record of scene.displayRecords) {
+    assert.equal(record.baseOpacity, 0.2);
+    assert.equal(record.material.opacity, 0.2);
+    assert.equal(record.material.transparent, true);
+    assert.equal(record.material.depthWrite, false);
+  }
+  scene.dispose();
+});
+
 test("buildModel ignores deprecated mesh edge detail and keeps wireframe all-edge mode", () => {
   const baseTheme = cloneThemeSettings("workbench");
   const deprecatedDetailScene = buildModel(THREE, squareMeshData(), {

--- a/packages/cadjs/src/lib/render/glbMeshData.js
+++ b/packages/cadjs/src/lib/render/glbMeshData.js
@@ -90,7 +90,18 @@ function colorFromMaterial(material, useSourceColors, {
   return {
     rgb: [material.color.r, material.color.g, material.color.b],
     hex: `#${material.color.getHexString()}`,
+    opacity: materialOpacity(material, rawMaterial),
   };
+}
+
+function materialOpacity(material, rawMaterial = null) {
+  const materialValue = Number(material?.opacity);
+  if (Number.isFinite(materialValue)) {
+    return Math.min(Math.max(materialValue, 0), 1);
+  }
+  const rawAlpha = rawBaseColorFactor(rawMaterial)?.[3];
+  const rawValue = Number(rawAlpha);
+  return Number.isFinite(rawValue) ? Math.min(Math.max(rawValue, 0), 1) : 1;
 }
 
 function materialForGroup(material, group) {
@@ -271,6 +282,7 @@ function inspectGlbPrimitive(
     name: label || id,
     label: label || id,
     color: color?.hex || "",
+    opacity: color ? color.opacity : 1,
     hasSourceColors: Boolean(color),
     vertexCount,
     triangleCount,
@@ -356,6 +368,7 @@ function writeGlbPrimitive(THREE, descriptor, output, offsets) {
     label: descriptor.label,
     nodeType: "part",
     color: descriptor.color,
+    opacity: descriptor.opacity,
     hasSourceColors: descriptor.hasSourceColors,
     bounds: boundsFromAccumulator(partBounds),
     vertexOffset,

--- a/packages/cadjs/src/lib/render/glbMeshData.test.js
+++ b/packages/cadjs/src/lib/render/glbMeshData.test.js
@@ -506,6 +506,18 @@ test("STEP GLB mesh data preserves non-gray material colors", async () => {
   assert.equal(meshData.parts[0].hasSourceColors, true);
 });
 
+test("STEP GLB mesh data preserves source material opacity", async () => {
+  const meshData = await buildMeshDataFromGlbBuffer(makeOccurrenceGlb({
+    stepTopology: true,
+    materialBaseColor: [1, 0, 0, 0.2]
+  }));
+
+  assert.equal(meshData.has_source_colors, true);
+  assert.equal(meshData.parts[0].color, "#ff0000");
+  assert.equal(meshData.parts[0].opacity, 0.2);
+  assert.equal(meshData.parts[0].hasSourceColors, true);
+});
+
 test("STEP GLB mesh data preserves colored primitives alongside generated default materials", async () => {
   const meshData = await buildMeshDataFromGlbBuffer(makeTwoPrimitiveOccurrenceGlb({
     stepTopology: true,


### PR DESCRIPTION
## Summary

- Preserve GLB material opacity while converting GLB meshes into cadjs meshData parts.
- Apply source part opacity when building CAD scene materials, so STEP/GLB materials with alpha render translucent in the browser viewer.
- Auto-render parts individually when source material opacity differs, even when `renderPartsIndividually` is false, to avoid silently flattening away part-level opacity.

## Why

Some STEP-to-GLB pipelines preserve transparency as `baseColorFactor[3]` / loaded Three.js material opacity, but do not always set glTF `alphaMode`. FreeCAD can display the STEP material transparency correctly, while CAD Explorer could lose opacity after converting GLB nodes into internal meshData because only RGB/hex color was carried forward.

## Quick Reproduction

1. Generate or open a STEP-derived GLB whose material has `pbrMetallicRoughness.baseColorFactor[3] < 1`, for example `0.2`, but no explicit `alphaMode: BLEND`.
2. Load the same source model in a CAD tool such as FreeCAD and confirm the STEP material appears translucent.
3. Load the STEP/GLB through CAD Explorer.
4. Before this change, the browser viewer renders the part as opaque because the GLB-to-meshData conversion keeps RGB/hex color but drops material opacity.
5. After this change, the part-level opacity is preserved and applied to the generated Three.js material.

A focused unit-level reproduction is included in the tests by using GLB material metadata with alpha but without `alphaMode`, then verifying that `meshData.parts[*].opacity` and the final CAD scene material opacity are preserved.

## Tests

```bash
node --test packages/cadjs/src/common/cadScene.test.js packages/cadjs/src/lib/render/glbMeshData.test.js
```

Result: 27 tests passed.