### PR TITLE
Fix production build check broken by the urdf/srdf/sdf runtime removal

### DIFF
--- a/scripts/github-workflows/check-builds.sh
+++ b/scripts/github-workflows/check-builds.sh
@@ -62,9 +62,7 @@ check_no_symlinks() {
 check_no_symlinks "viewer/packages"
 check_no_symlinks "skills/cad/scripts/packages"
 check_no_symlinks "skills/cad-viewer/scripts/viewer"
-check_no_symlinks "skills/urdf/scripts/packages"
-check_no_symlinks "skills/srdf/scripts/packages"
-check_no_symlinks "skills/sdf/scripts/packages"
+check_no_symlinks "skills/dxf/scripts/packages"
 check_no_symlinks "plugins/cad/skills"
 
 if [ "$RUN_BUNDLE_CHECK" -eq 1 ]; then


### PR DESCRIPTION
Follow-up to #128's CI verification of `release/0.4.0`. While replicating the `Test` workflow locally against the merged branch (it only auto-runs for `develop`), the "Check production bundle layout" step failed:

```
Missing production bundle path: skills/urdf/scripts/packages
```

This is pre-existing breakage from #127, which turned the URDF/SRDF/SDF skills into stdlib-only validators and deleted their `scripts/packages` runtimes, but left `scripts/github-workflows/check-builds.sh` requiring those paths. It fails on `release/0.4.0` with or without #128, and would block the `Release` publish job (which runs the same script).

- Remove the stale `skills/{urdf,srdf,sdf}/scripts/packages` entries.
- Add `skills/dxf/scripts/packages`, which is produced by the bundle but was never checked — the same class of omission in the other direction.

Verified locally on the merged `release/0.4.0` by running the full CI sequence: version check, symlink layout, `bundle.sh --clean`, `check-builds.sh --skip-bundle-check` (fails before this fix, passes after), `test-docs.sh`, and `test.sh` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD8MuDhyw9uXcszqtHpetJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VD8MuDhyw9uXcszqtHpetJ)_