### PR TITLE
cadgen: edit-path perf wins (AST closure hash, classification cache, single BREP serialize)

### DIFF
--- a/design/edit-path-perf-notes.md
+++ b/design/edit-path-perf-notes.md
@@ -2,15 +2,30 @@
 
 ## Status (executed 2026-07-07 on `claude/cadgen-edit-path-perf`)
 
-- **A2 comment-insensitive closure hashing — DONE** (`74dbc192`): AST-based
+- **A2 comment-insensitive closure hashing — DONE** (`f7e8de7b`): AST-based
   closure hashes; comment/whitespace edits now warm-skip, migration-safe.
-- **A3 stdin closure footgun — DONE** (`74dbc192`): `<stdin>`/`-c` `__main__`
+- **A3 stdin closure footgun — DONE** (`f7e8de7b`): `<stdin>`/`-c` `__main__`
   no longer marks the CWD a runtime root; staleness detection restored for
   stdin-driven builds.
-- **A4 module classification cache — DONE** (`03fc809d`): per-`__file__`
+- **A4 module classification cache — DONE** (`fb0e1834`): per-`__file__`
   first-party resolve cached across builds (helps the warm daemon most).
-- **A8 single BREP serialization — DONE** (`52428c9c`): each component's BREP
+- **A8 single BREP serialization — DONE** (`37876fe5`): each component's BREP
   serialized once for hash + worker payload.
+- **Review follow-up (adversarial audit of the above)**: `_semantic_source_hash`
+  is stat-memoized (`(mtime_ns, size)` key, 2 s settle window) — the AST pass is
+  ~200x the byte pass and ran for every closure file on every warm check
+  (~0.9 s/check on a tom-scale closure once descriptors record semantic
+  digests, with shared helpers re-parsed once per generated child); now each
+  file parses once per content change per process. Parser `MemoryError` /
+  `ast.dump` `RecursionError` on pathological-but-importable sources fall back
+  to the byte hash instead of aborting the freshness gate. `closure_hash_matches`
+  tries the byte recompute first so legacy descriptors skip the AST pass.
+  `brep_bytes_by_cid` retains bytes only for components that need a worker
+  payload (a warm rebuild no longer holds the whole assembly's BREPs in memory).
+  `closure_hash_from_files` (orphaned by the `closure_hash_matches` refactor)
+  deleted. The false-hit audit (44 adversarial vectors: type comments, literal
+  spellings, encodings, string prefixes, parenthesization, line-number-dependent
+  code) found no AST-hash collision that changes runtime behavior.
 - **A5 reuse adaptive resolution — DROPPED**: no cheap "geometry unchanged
   despite a rebuild" gate exists (it needs early cid computation, which costs
   the serialization it would save and penalizes the common cold build); the

--- a/design/edit-path-perf-notes.md
+++ b/design/edit-path-perf-notes.md
@@ -1,4 +1,38 @@
-# Edit-path performance notes (deferred work)
+# Edit-path performance notes
+
+## Status (executed 2026-07-07 on `claude/cadgen-edit-path-perf`)
+
+- **A2 comment-insensitive closure hashing — DONE** (`74dbc192`): AST-based
+  closure hashes; comment/whitespace edits now warm-skip, migration-safe.
+- **A3 stdin closure footgun — DONE** (`74dbc192`): `<stdin>`/`-c` `__main__`
+  no longer marks the CWD a runtime root; staleness detection restored for
+  stdin-driven builds.
+- **A4 module classification cache — DONE** (`03fc809d`): per-`__file__`
+  first-party resolve cached across builds (helps the warm daemon most).
+- **A8 single BREP serialization — DONE** (`52428c9c`): each component's BREP
+  serialized once for hash + worker payload.
+- **A5 reuse adaptive resolution — DROPPED**: no cheap "geometry unchanged
+  despite a rebuild" gate exists (it needs early cid computation, which costs
+  the serialization it would save and penalizes the common cold build); the
+  residual case is narrow now that comment edits skip entirely (A2).
+- **A6 tom `compound_from_instances` — NO WIN (invalid premise)**: tom already
+  composes via `robot_common.link_assembly.compound_from_instances` (OCCT
+  locations, no `.moved()` deepcopy). A cProfile of tom's `gen_step` shows the
+  compose cost is `BRepBndLib.AddOptimal_s` (~0.59 s), `BRepGProp.Surface`
+  Properties (~0.36 s), vendor-STEP `BinTools.Read_s` (~0.35 s), and child-STEP
+  hashing (~0.29 s) — build123d/model internals of tom's specific composition,
+  not instancing-addressable and out of scope for pipeline work.
+- **A1 warm-daemon default-on — NOT FLIPPED (policy)**: kept opt-in
+  (`CADGEN_WARM=1`). Flipping the global CLI default off→on has broad blast
+  radius (CI jobs would spawn+idle a daemon, sandboxes without socket bind fall
+  back inline but noisily) and is an ergonomics decision, not a pipeline fix.
+  Recommendation for agent sessions: export `CADGEN_WARM=1` in the shell/skill
+  launcher rather than change the code default.
+- **A7 geometry-identical fast path — DROPPED**: subsumed by A2.
+
+---
+
+# Original notes (deferred work, pre-execution)
 
 Recorded 2026-07-06 after the round-3 pipeline work (`36c60638..13746038`).
 Baselines measured on this branch: a comment edit in a closure file rebuilds

--- a/packages/cadgen/src/cadgen/_internal/component_package.py
+++ b/packages/cadgen/src/cadgen/_internal/component_package.py
@@ -118,33 +118,29 @@ def _component_id(source_hash: str) -> str:
     return source_hash[:16]
 
 
-def _content_hash_shape(shape: Any) -> str:
-    """sha256 of a shape's BREP bytes in its *local* (unlocated) frame.
+def _content_hash_and_bytes(shape: Any) -> tuple[str, bytes]:
+    """The content hash AND the location-stripped BREP bytes it digests, from a
+    single serialization.
 
     Two occurrences of the same part share an underlying ``TShape`` (``.moved()``
     only swaps the location), so stripping the location and serializing yields an
     identical digest for every repeat — the content-addressing that dedups the
     components. Stable across builds/processes (unlike Python ``hash``).
 
-    Triangulation and normals are excluded from the serialization so the digest is
-    geometry-only: meshing a part attaches a triangulation to its shared ``TShape``,
-    and a triangulation-sensitive hash would change after the first component is
-    built, breaking the content-addressed cache on re-hash."""
-    import io
+    Triangulation and normals are excluded so the digest is geometry-only:
+    meshing a part attaches a triangulation to its shared ``TShape``, and a
+    triangulation-sensitive hash would change after the first component is built,
+    breaking the content-addressed cache on re-hash. The same bytes are the
+    worker-build payload, so returning both avoids serializing each missing
+    component's BREP twice (once to hash, once for the payload)."""
+    brep = _shape_brep_bytes(shape)
+    return hashlib.sha256(brep).hexdigest(), brep
 
-    from OCP.BinTools import BinTools, BinTools_FormatVersion
-    from OCP.TopLoc import TopLoc_Location
 
-    unlocated = shape.wrapped.Located(TopLoc_Location())
-    stream = io.BytesIO()
-    BinTools.Write_s(
-        unlocated,
-        stream,
-        False,  # theWithTriangles
-        False,  # theWithNormals
-        BinTools_FormatVersion.BinTools_FormatVersion_CURRENT,
-    )
-    return hashlib.sha256(stream.getvalue()).hexdigest()
+def _content_hash_shape(shape: Any) -> str:
+    """sha256 of a shape's location-stripped BREP bytes (see
+    :func:`_content_hash_and_bytes`)."""
+    return _content_hash_and_bytes(shape)[0]
 
 
 def _transform_from_location(location: Any) -> list[float]:
@@ -466,16 +462,22 @@ def build_package_from_compound(
     # occurrences that genuinely share a TShape (raw-OCCT composed assemblies,
     # ``Location``-composed placements).
     hash_memo: dict[Any, str] = {}
+    # The location-stripped BREP bytes per cid, captured from the single
+    # serialization that computed the content hash, so a missing component's
+    # worker payload reuses them instead of re-serializing the same shape.
+    brep_bytes_by_cid: dict[str, bytes] = {}
 
     def _add_leaf(node: Any, world_loc: Any, occ_id: str, name: str | None = None) -> dict[str, Any]:
         try:
             memo_key = node.wrapped.TShape()
             content_hash = hash_memo.get(memo_key)
             if content_hash is None:
-                content_hash = _content_hash_shape(node)
+                content_hash, brep = _content_hash_and_bytes(node)
                 hash_memo[memo_key] = content_hash
+                brep_bytes_by_cid.setdefault(_component_id(content_hash), brep)
         except TypeError:  # unhashable TShape wrapper: correctness over the micro-optimization
-            content_hash = _content_hash_shape(node)
+            content_hash, brep = _content_hash_and_bytes(node)
+            brep_bytes_by_cid.setdefault(_component_id(content_hash), brep)
         cid = _component_id(content_hash)
         shapes.setdefault(cid, node)
         components.setdefault(cid, {"glb": _component_ref(cid), "contentHash": content_hash})
@@ -586,7 +588,9 @@ def build_package_from_compound(
     # emit identical components; XCAF auto-labels no longer leak in).
     payloads = [
         (
-            _shape_brep_bytes(shape),
+            # Reuse the BREP bytes captured when this cid was content-hashed; only
+            # re-serialize in the (unexpected) event they were not retained.
+            brep_bytes_by_cid.get(cid) or _shape_brep_bytes(shape),
             cid,
             str(comp_dir / f"{cid}.glb"),
             linear_deflection,

--- a/packages/cadgen/src/cadgen/_internal/component_package.py
+++ b/packages/cadgen/src/cadgen/_internal/component_package.py
@@ -465,7 +465,16 @@ def build_package_from_compound(
     # The location-stripped BREP bytes per cid, captured from the single
     # serialization that computed the content hash, so a missing component's
     # worker payload reuses them instead of re-serializing the same shape.
+    # Retained ONLY for cids that will actually need a worker payload (no
+    # <cid>.glb on disk yet, or --force): on the edit-path rebuild most
+    # components are already built, and retaining every BREP for the whole walk
+    # would hold the assembly's entire serialized geometry in memory at once.
     brep_bytes_by_cid: dict[str, bytes] = {}
+
+    def _retain_payload_brep(content_hash: str, brep: bytes) -> None:
+        cid = _component_id(content_hash)
+        if cid not in brep_bytes_by_cid and (force or not (comp_dir / f"{cid}.glb").exists()):
+            brep_bytes_by_cid[cid] = brep
 
     def _add_leaf(node: Any, world_loc: Any, occ_id: str, name: str | None = None) -> dict[str, Any]:
         try:
@@ -474,10 +483,10 @@ def build_package_from_compound(
             if content_hash is None:
                 content_hash, brep = _content_hash_and_bytes(node)
                 hash_memo[memo_key] = content_hash
-                brep_bytes_by_cid.setdefault(_component_id(content_hash), brep)
+                _retain_payload_brep(content_hash, brep)
         except TypeError:  # unhashable TShape wrapper: correctness over the micro-optimization
             content_hash, brep = _content_hash_and_bytes(node)
-            brep_bytes_by_cid.setdefault(_component_id(content_hash), brep)
+            _retain_payload_brep(content_hash, brep)
         cid = _component_id(content_hash)
         shapes.setdefault(cid, node)
         components.setdefault(cid, {"glb": _component_ref(cid), "contentHash": content_hash})
@@ -588,8 +597,9 @@ def build_package_from_compound(
     # emit identical components; XCAF auto-labels no longer leak in).
     payloads = [
         (
-            # Reuse the BREP bytes captured when this cid was content-hashed; only
-            # re-serialize in the (unexpected) event they were not retained.
+            # Reuse the BREP bytes captured when this cid was content-hashed;
+            # re-serialize only when the GLB present at capture time vanished
+            # before the missing-scan above (so the bytes were not retained).
             brep_bytes_by_cid.get(cid) or _shape_brep_bytes(shape),
             cid,
             str(comp_dir / f"{cid}.glb"),

--- a/packages/cadgen/src/cadgen/_internal/drawing_package.py
+++ b/packages/cadgen/src/cadgen/_internal/drawing_package.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from cadgen._internal.file_metadata import text_to_cad_identity_metadata, write_dxf_text_to_cad_metadata
 from cadgen._internal.source_hash import (
     PythonSourceClosure,
-    closure_hash_from_files,
+    closure_hash_matches,
     python_source_hash,
 )
 from cadgen.catalog import render_package_dir
@@ -202,5 +202,4 @@ def drawing_package_current(script_path: Path) -> bool:
     closure_files = descriptor.get("sourceClosureFiles")
     if not closure_hash or not isinstance(closure_files, list) or not closure_files:
         return False
-    recomputed = closure_hash_from_files(closure_files, base=resolved_script.parent)
-    return recomputed is not None and recomputed == closure_hash
+    return closure_hash_matches(closure_hash, closure_files, base=resolved_script.parent)

--- a/packages/cadgen/src/cadgen/_internal/generation.py
+++ b/packages/cadgen/src/cadgen/_internal/generation.py
@@ -58,7 +58,7 @@ from cadgen._internal.source_hash import (
     PythonSourceClosure,
     PythonSourceHash,
     capture_runtime_closure,
-    closure_hash_from_files,
+    closure_hash_matches,
     evict_first_party_modules,
     python_source_hash,
     record_first_party_execution,
@@ -1948,8 +1948,7 @@ def _manifest_source_closure_unchanged(manifest: Mapping[str, object], base: Pat
     recorded_files = manifest.get("sourceClosureFiles")
     if not recorded_hash or not isinstance(recorded_files, list) or not recorded_files:
         return False
-    current_hash = closure_hash_from_files(recorded_files, base=base)
-    return current_hash is not None and current_hash == recorded_hash
+    return closure_hash_matches(recorded_hash, recorded_files, base=base)
 
 
 def _assembly_is_current(spec: EntrySpec) -> bool:
@@ -2031,8 +2030,9 @@ def _generated_child_is_stale(child_spec: EntrySpec, *, force: bool) -> bool:
         recorded_hash = str(manifest.get("sourceClosureHash") or "").strip()
         recorded_files = manifest.get("sourceClosureFiles")
         if recorded_hash and isinstance(recorded_files, list) and recorded_files:
-            current_hash = closure_hash_from_files(recorded_files, base=child_spec.step_path.parent)
-            return current_hash is None or current_hash != recorded_hash
+            return not closure_hash_matches(
+                recorded_hash, recorded_files, base=child_spec.step_path.parent
+            )
         recorded_source_hash = str(manifest.get("sourceHash") or "").strip()
         if recorded_source_hash:
             return python_source_hash(child_spec.script_path).source_hash != recorded_source_hash

--- a/packages/cadgen/src/cadgen/_internal/source_hash.py
+++ b/packages/cadgen/src/cadgen/_internal/source_hash.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 
+import ast
 import contextlib
 import hashlib
 import os
@@ -65,6 +66,29 @@ def _sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _semantic_source_hash(path: Path) -> str:
+    """Content hash that ignores comments, blank lines, and formatting for
+    Python sources — so a comment/whitespace-only edit to a generator or a
+    shared helper does not invalidate the model's closure — while staying
+    sensitive to every semantic change (including docstrings). Non-``.py``
+    closure inputs (e.g. composed child STEP files) keep the byte hash.
+
+    Hashes the parsed AST dumped WITHOUT position attributes. A bytecode /
+    ``marshal`` digest would NOT be comment-insensitive: inserting a comment
+    line shifts ``co_firstlineno`` and the line table. ``ast.dump`` defaults to
+    ``include_attributes=False``, which omits line/column numbers while keeping
+    the full semantic structure. Falls back to the byte hash on an unreadable
+    or unparseable source (so a syntactically broken generator is never treated
+    as unchanged just because its AST could not be built)."""
+    if path.suffix != ".py":
+        return _sha256_file(path)
+    try:
+        tree = ast.parse(path.read_bytes())
+    except (OSError, SyntaxError, ValueError):
+        return _sha256_file(path)
+    return "ast1:" + hashlib.sha256(ast.dump(tree).encode("utf-8")).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -152,10 +176,19 @@ def _runtime_roots() -> tuple[Path, ...]:
     main_module = sys.modules.get("__main__")
     main_file = getattr(main_module, "__file__", None)
     if main_file:
+        # Only a real on-disk launcher is runtime. Interactive / stdin / ``-c``
+        # entry points set ``__file__`` to a placeholder like ``<stdin>`` or
+        # ``<string>``, whose ``resolve().parent`` is the CWD — adding that would
+        # wrongly mark the model folder (and its sibling helper modules) as
+        # runtime, drop them from the recorded closure, and silently disable
+        # staleness detection for stdin/`-c`-driven builds. ``is_file()`` rejects
+        # every ``<...>`` placeholder while still catching the CLI launcher.
         try:
-            roots.append(Path(main_file).resolve().parent)
+            resolved_main = Path(main_file).resolve()
         except OSError:
-            pass
+            resolved_main = None
+        if resolved_main is not None and resolved_main.is_file():
+            roots.append(resolved_main.parent)
     return tuple(roots)
 
 
@@ -287,7 +320,7 @@ def closure_for_files(script_path: Path, files: object, *, base: Path) -> Python
     pairs: list[tuple[str, str]] = []
     for path in paths:
         try:
-            file_hash = _sha256_file(path)
+            file_hash = _semantic_source_hash(path)
         except OSError:
             continue
         pairs.append((_relative_to_base(path, base_dir), file_hash))
@@ -328,12 +361,7 @@ def capture_runtime_closure(
     return closure_for_files(script_path, dependency_files, base=base)
 
 
-def closure_hash_from_files(relative_files: object, *, base: Path) -> str | None:
-    """Recompute a closure hash from a previously recorded ``base``-relative file list.
-
-    Returns ``None`` when any recorded file is missing, which callers treat as
-    "stale" (rebuild rather than risk reusing geometry built from absent
-    sources)."""
+def _recompute_closure_hash(relative_files: object, *, base: Path, hasher) -> str | None:
     base_dir = base.expanduser().resolve()
     pairs: list[tuple[str, str]] = []
     for relative in relative_files:
@@ -344,9 +372,38 @@ def closure_hash_from_files(relative_files: object, *, base: Path) -> str | None
         if resolved is None:
             return None
         try:
-            pairs.append((rel, _sha256_file(resolved)))
+            pairs.append((rel, hasher(resolved)))
         except OSError:
             return None
     if not pairs:
         return None
     return _closure_hash_for_pairs(pairs)
+
+
+def closure_hash_from_files(relative_files: object, *, base: Path) -> str | None:
+    """Recompute the canonical (semantic) closure hash from a previously recorded
+    ``base``-relative file list.
+
+    Returns ``None`` when any recorded file is missing, which callers treat as
+    "stale" (rebuild rather than risk reusing geometry built from absent
+    sources)."""
+    return _recompute_closure_hash(relative_files, base=base, hasher=_semantic_source_hash)
+
+
+def closure_hash_matches(recorded_hash: object, relative_files: object, *, base: Path) -> bool:
+    """Whether a recorded closure hash still matches the current sources.
+
+    Accepts EITHER the current semantic (AST) recompute OR the legacy byte
+    recompute: descriptors written before comment-insensitive hashing recorded a
+    byte-based digest, and must keep validating (no mass rebuild on upgrade)
+    until their next genuine rebuild re-records the semantic digest. A missing
+    file (either recompute returns ``None``) is not a match — the caller rebuilds.
+    """
+    recorded = str(recorded_hash or "").strip()
+    if not recorded:
+        return False
+    for hasher in (_semantic_source_hash, _sha256_file):
+        current = _recompute_closure_hash(relative_files, base=base, hasher=hasher)
+        if current is not None and current == recorded:
+            return True
+    return False

--- a/packages/cadgen/src/cadgen/_internal/source_hash.py
+++ b/packages/cadgen/src/cadgen/_internal/source_hash.py
@@ -8,6 +8,7 @@ import hashlib
 import os
 import sys
 import sysconfig
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -68,6 +69,25 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+# (path string) -> (st_mtime_ns, st_size, hash). The AST pass is ~200x the byte
+# pass (ast.parse + ast.dump dominate), and a warm freshness check recomputes it
+# for EVERY closure file — the parent gate plus one _generated_child_is_stale
+# per generated child, which re-hashes the shared helper modules each time. The
+# stat key makes each file parse once per actual content change instead of once
+# per check (the warm daemon and multi-child builds are the big winners, same as
+# A4). Two safety rules make a stale hit impossible rather than merely unlikely:
+# stat is taken BEFORE the read (a write racing the read leaves an entry keyed
+# by a stat the changed file no longer matches — a spurious recompute, never a
+# stale hash), and a file is only cached once its mtime has SETTLED (see
+# _SEMANTIC_HASH_SETTLE_NS): filesystem mtime clocks can be coarser than a
+# nanosecond, so a same-size rewrite landing in the same clock tick as the
+# cached stat would otherwise be invisible. Freshly-edited files therefore
+# re-hash for a couple of seconds — one file, exactly while it is being edited —
+# and the settled majority of the closure stays cached.
+_SEMANTIC_HASH_CACHE: dict[str, tuple[int, int, str]] = {}
+_SEMANTIC_HASH_SETTLE_NS = 2_000_000_000
+
+
 def _semantic_source_hash(path: Path) -> str:
     """Content hash that ignores comments, blank lines, and formatting for
     Python sources — so a comment/whitespace-only edit to a generator or a
@@ -79,16 +99,33 @@ def _semantic_source_hash(path: Path) -> str:
     ``marshal`` digest would NOT be comment-insensitive: inserting a comment
     line shifts ``co_firstlineno`` and the line table. ``ast.dump`` defaults to
     ``include_attributes=False``, which omits line/column numbers while keeping
-    the full semantic structure. Falls back to the byte hash on an unreadable
-    or unparseable source (so a syntactically broken generator is never treated
-    as unchanged just because its AST could not be built)."""
+    the full semantic structure. Falls back to the byte hash on an unreadable or
+    unparseable source (so a syntactically broken generator is never treated as
+    unchanged just because its AST could not be built). MemoryError /
+    RecursionError take the same fallback: the parser raises MemoryError on
+    pathological nesting, and ``ast.dump`` can exceed the recursion limit on a
+    deep-but-importable tree — a freshness gate must degrade to byte
+    sensitivity, not abort the build."""
     if path.suffix != ".py":
         return _sha256_file(path)
     try:
-        tree = ast.parse(path.read_bytes())
-    except (OSError, SyntaxError, ValueError):
-        return _sha256_file(path)
-    return "ast1:" + hashlib.sha256(ast.dump(tree).encode("utf-8")).hexdigest()
+        stat = path.stat()
+    except OSError:
+        stat = None
+    key = str(path)
+    if stat is not None:
+        cached = _SEMANTIC_HASH_CACHE.get(key)
+        if cached is not None and cached[0] == stat.st_mtime_ns and cached[1] == stat.st_size:
+            return cached[2]
+    try:
+        dumped = ast.dump(ast.parse(path.read_bytes()))
+    except (OSError, SyntaxError, ValueError, MemoryError, RecursionError):
+        result = _sha256_file(path)
+    else:
+        result = "ast1:" + hashlib.sha256(dumped.encode("utf-8")).hexdigest()
+    if stat is not None and time.time_ns() - stat.st_mtime_ns > _SEMANTIC_HASH_SETTLE_NS:
+        _SEMANTIC_HASH_CACHE[key] = (stat.st_mtime_ns, stat.st_size, result)
+    return result
 
 
 @dataclass(frozen=True)
@@ -405,16 +442,6 @@ def _recompute_closure_hash(relative_files: object, *, base: Path, hasher) -> st
     return _closure_hash_for_pairs(pairs)
 
 
-def closure_hash_from_files(relative_files: object, *, base: Path) -> str | None:
-    """Recompute the canonical (semantic) closure hash from a previously recorded
-    ``base``-relative file list.
-
-    Returns ``None`` when any recorded file is missing, which callers treat as
-    "stale" (rebuild rather than risk reusing geometry built from absent
-    sources)."""
-    return _recompute_closure_hash(relative_files, base=base, hasher=_semantic_source_hash)
-
-
 def closure_hash_matches(recorded_hash: object, relative_files: object, *, base: Path) -> bool:
     """Whether a recorded closure hash still matches the current sources.
 
@@ -427,6 +454,15 @@ def closure_hash_matches(recorded_hash: object, relative_files: object, *, base:
     recorded = str(recorded_hash or "").strip()
     if not recorded:
         return False
+    # Semantic pass first: with the stat memo it costs one stat per settled
+    # closure file on the no-edit steady state (every rebuild records semantic
+    # digests), whereas the byte pass re-reads every file's full contents each
+    # check. The byte pass runs only when the semantic recompute misses — i.e.
+    # for legacy (byte-recorded) descriptors, which pay one AST parse per file
+    # per process (memoized thereafter) until their next genuine rebuild
+    # re-records them. Order cannot affect the outcome: a semantic record's
+    # per-file ``ast1:`` hashes can never equal an all-byte recompute's hex
+    # digests.
     for hasher in (_semantic_source_hash, _sha256_file):
         current = _recompute_closure_hash(relative_files, base=base, hasher=hasher)
         if current is not None and current == recorded:

--- a/packages/cadgen/src/cadgen/_internal/source_hash.py
+++ b/packages/cadgen/src/cadgen/_internal/source_hash.py
@@ -200,10 +200,38 @@ def _excluded_roots() -> tuple[Path, ...]:
     return (*_interpreter_roots(), *_runtime_roots())
 
 
+@functools.lru_cache(maxsize=None)
 def is_first_party_source_file(path: Path) -> bool:
     """True for a ``.py`` file that counts as model-side code: not stdlib, not
-    site-packages, and not part of the running generation runtime."""
+    site-packages, and not part of the running generation runtime.
+
+    Memoized: a resolved path's classification is stable for the process (the
+    excluded roots are themselves cached and environment-derived), and the audit
+    hook calls this for every executed module body."""
     return path.suffix == ".py" and not any(_is_within(path, root) for root in _excluded_roots())
+
+
+# Cache the per-module resolve()+classify keyed by the RAW ``__file__`` string.
+# ``repo_local_loaded_modules`` runs over ALL of ``sys.modules`` (thousands of
+# entries once numpy/OCP/etc. are imported) on every evict AND every closure
+# capture; the ``Path(...).resolve()`` realpath is the dominant cost and its
+# result never changes for a given file, so one lookup per distinct file per
+# process replaces a realpath-storm per build (~0.2-0.7 s on a warm build).
+_MISSING = object()
+_MODULE_FILE_FIRST_PARTY: dict[str, Path | None] = {}
+
+
+def _first_party_path_for_module_file(file_name: str) -> Path | None:
+    cached = _MODULE_FILE_FIRST_PARTY.get(file_name, _MISSING)
+    if cached is not _MISSING:
+        return cached
+    try:
+        path = Path(file_name).resolve()
+    except OSError:
+        path = None
+    result = path if (path is not None and is_first_party_source_file(path)) else None
+    _MODULE_FILE_FIRST_PARTY[file_name] = result
+    return result
 
 
 def repo_local_loaded_modules(module_names: object) -> dict[str, Path]:
@@ -217,11 +245,8 @@ def repo_local_loaded_modules(module_names: object) -> dict[str, Path]:
         file_name = getattr(module, "__file__", None)
         if not file_name:
             continue
-        try:
-            path = Path(file_name).resolve()
-        except OSError:
-            continue
-        if is_first_party_source_file(path):
+        path = _first_party_path_for_module_file(file_name)
+        if path is not None:
             result[name] = path
     return result
 

--- a/tests/python/skills/cad/cadgen/test_component_package_build.py
+++ b/tests/python/skills/cad/cadgen/test_component_package_build.py
@@ -144,5 +144,19 @@ class PayloadUnreadableFallbackTests(unittest.TestCase):
             self.assertTrue((package_dir / cid_entry["glb"]).is_file())
 
 
+class SingleSerializationTests(unittest.TestCase):
+    def test_content_hash_and_bytes_match_split_helpers(self) -> None:
+        # A8: one serialization must yield exactly the bytes _shape_brep_bytes
+        # would and the hash _content_hash_shape would, so cids and worker
+        # payloads (hence emitted GLBs) are unchanged.
+        import build123d
+        from cadgen._internal import component_package as cp
+
+        shape = build123d.Box(11, 7, 3).moved(build123d.Location((4, 2, 1)))
+        combined_hash, combined_bytes = cp._content_hash_and_bytes(shape)
+        self.assertEqual(combined_bytes, cp._shape_brep_bytes(shape))
+        self.assertEqual(combined_hash, cp._content_hash_shape(shape))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/python/skills/cad/cadgen/test_generation.py
+++ b/tests/python/skills/cad/cadgen/test_generation.py
@@ -733,9 +733,16 @@ class CadGenerationTests(unittest.TestCase):
         cad_generation.generate_dxf_targets([str(script_path)])
         self.assertEqual("gen_dxf\n", calls_path.read_text(encoding="utf-8"))
 
-        # A source edit invalidates the recorded closure -> rebuild.
+        # A comment-only edit does NOT change the semantic closure -> still skips.
         script_path.write_text(
             script_path.read_text(encoding="utf-8") + "\n# changed\n", encoding="utf-8"
+        )
+        cad_generation.generate_dxf_targets([str(script_path)])
+        self.assertEqual("gen_dxf\n", calls_path.read_text(encoding="utf-8"))
+
+        # A semantic source edit invalidates the recorded closure -> rebuild.
+        script_path.write_text(
+            script_path.read_text(encoding="utf-8") + "\n_EDIT_MARKER = 1\n", encoding="utf-8"
         )
         cad_generation.generate_dxf_targets([str(script_path)])
         self.assertEqual("gen_dxf\ngen_dxf\n", calls_path.read_text(encoding="utf-8"))
@@ -2148,7 +2155,11 @@ class CadGenerationTests(unittest.TestCase):
         self.assertTrue(cad_generation._generated_child_is_stale(spec, force=True))
 
         original = script.read_text(encoding="utf-8")
+        # A comment-only edit is semantically invisible -> NOT stale.
         script.write_text(original + "\n# tweak\n", encoding="utf-8")
+        self.assertFalse(cad_generation._generated_child_is_stale(spec, force=False))
+        # A semantic own-file edit IS detected.
+        script.write_text(original + "\n_EDIT_MARKER = 1\n", encoding="utf-8")
         self.assertTrue(cad_generation._generated_child_is_stale(spec, force=False))
         script.write_text(original, encoding="utf-8")
         self.assertFalse(cad_generation._generated_child_is_stale(spec, force=False))

--- a/tests/python/skills/cad/cadgen/test_semantic_closure_hash.py
+++ b/tests/python/skills/cad/cadgen/test_semantic_closure_hash.py
@@ -78,6 +78,72 @@ class SemanticClosureHashTests(unittest.TestCase):
             root = Path(tmp)
             self.assertFalse(source_hash.closure_hash_matches("abc", ["gone.py"], base=root))
 
+    def test_deep_but_importable_source_falls_back_instead_of_raising(self) -> None:
+        # 'x = 1 + 1 + ... + 1' compiles and imports fine, but ast.dump on the
+        # deep tree can exceed the recursion limit (the exact depth depends on
+        # the ambient stack, so pin the limit low to force it). The freshness
+        # gate must degrade to byte sensitivity, never abort the build.
+        import sys
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            deep = self._write(root, "deep.py", "x = 1" + " + 1" * 2000 + "\n")
+            compile(deep.read_text(encoding="utf-8"), str(deep), "exec")  # importable
+            limit = sys.getrecursionlimit()
+            sys.setrecursionlimit(200)
+            try:
+                hash_a = source_hash._semantic_source_hash(deep)
+            finally:
+                sys.setrecursionlimit(limit)
+            self.assertEqual(hash_a, source_hash._sha256_file(deep))  # byte fallback
+
+    def test_pathological_nesting_falls_back_instead_of_raising(self) -> None:
+        # A unary-minus chain overflows the CPython parser stack (MemoryError);
+        # the hash must fall back to bytes, not propagate out of the gate.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            nested = self._write(root, "nested.py", "x = " + "-" * 100000 + "1\n")
+            hash_a = source_hash._semantic_source_hash(nested)
+            self.assertFalse(hash_a.startswith("ast1:"))
+            self.assertFalse(source_hash.closure_hash_matches("abc", ["nested.py"], base=root))
+
+
+class SemanticHashMemoTests(unittest.TestCase):
+    def setUp(self) -> None:
+        source_hash._SEMANTIC_HASH_CACHE.clear()
+
+    tearDown = setUp
+
+    def test_settled_file_is_cached_and_fresh_file_is_not(self) -> None:
+        import os
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "gen.py"
+            path.write_text("R = 5\n", encoding="utf-8")
+            # Freshly written (mtime = now): hashed but not cached — a same-size
+            # rewrite within one coarse filesystem clock tick must stay visible.
+            source_hash._semantic_source_hash(path)
+            self.assertNotIn(str(path), source_hash._SEMANTIC_HASH_CACHE)
+            # Settled (mtime in the past): cached under (mtime_ns, size).
+            os.utime(path, ns=(path.stat().st_atime_ns, path.stat().st_mtime_ns - 10**10))
+            first = source_hash._semantic_source_hash(path)
+            self.assertIn(str(path), source_hash._SEMANTIC_HASH_CACHE)
+            self.assertEqual(first, source_hash._semantic_source_hash(path))
+
+    def test_same_size_edit_with_new_mtime_recomputes(self) -> None:
+        import os
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "gen.py"
+            path.write_text("R = 5\n", encoding="utf-8")
+            os.utime(path, ns=(path.stat().st_atime_ns, path.stat().st_mtime_ns - 10**10))
+            first = source_hash._semantic_source_hash(path)
+            self.assertIn(str(path), source_hash._SEMANTIC_HASH_CACHE)
+            # Same byte length, different semantics, different (settled) mtime.
+            path.write_text("R = 6\n", encoding="utf-8")
+            os.utime(path, ns=(path.stat().st_atime_ns, path.stat().st_mtime_ns - 10**9 * 5))
+            self.assertNotEqual(first, source_hash._semantic_source_hash(path))
+
 
 class RuntimeRootsStdinFootgunTests(unittest.TestCase):
     def test_placeholder_main_file_does_not_mark_cwd_as_runtime(self) -> None:
@@ -102,6 +168,10 @@ class RuntimeRootsStdinFootgunTests(unittest.TestCase):
             else:
                 main.__file__ = original
             source_hash._runtime_roots.cache_clear()
+            # _excluded_roots composes _runtime_roots and caches independently:
+            # drop it too so no classification computed inside the mutation
+            # window can outlive the restore.
+            source_hash._excluded_roots.cache_clear()
 
     def test_real_launcher_file_is_a_runtime_root(self) -> None:
         import sys

--- a/tests/python/skills/cad/cadgen/test_semantic_closure_hash.py
+++ b/tests/python/skills/cad/cadgen/test_semantic_closure_hash.py
@@ -1,0 +1,130 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from cadgen._internal import source_hash
+
+
+def _closure(script: Path, base: Path):
+    return source_hash.closure_for_files(script, [], base=base)
+
+
+class SemanticClosureHashTests(unittest.TestCase):
+    def _write(self, root: Path, name: str, text: str) -> Path:
+        path = root / name
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def test_comment_and_whitespace_edits_do_not_change_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            a = self._write(root, "gen.py", "def gen_step():\n    return build(radius=5)\n")
+            hash_a = _closure(a, root).closure_hash
+            # add a comment, blank lines, and reindent-free formatting
+            a.write_text(
+                "# a new comment\n\n"
+                "def gen_step():\n"
+                "    return build(radius=5)   # trailing comment\n\n\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(hash_a, _closure(a, root).closure_hash)
+
+    def test_docstring_change_changes_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            a = self._write(root, "gen.py", 'def gen_step():\n    "one"\n    return 1\n')
+            hash_a = _closure(a, root).closure_hash
+            a.write_text('def gen_step():\n    "two"\n    return 1\n', encoding="utf-8")
+            self.assertNotEqual(hash_a, _closure(a, root).closure_hash)
+
+    def test_real_code_change_changes_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            a = self._write(root, "gen.py", "R = 5\ndef gen_step():\n    return R\n")
+            hash_a = _closure(a, root).closure_hash
+            a.write_text("R = 6\ndef gen_step():\n    return R\n", encoding="utf-8")
+            self.assertNotEqual(hash_a, _closure(a, root).closure_hash)
+
+    def test_syntax_error_falls_back_to_byte_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            a = self._write(root, "broken.py", "def gen_step(:\n    return 1\n")
+            hash_a = _closure(a, root).closure_hash
+            # a comment edit on an unparseable file DOES change the (byte) hash
+            a.write_text("# c\ndef gen_step(:\n    return 1\n", encoding="utf-8")
+            self.assertNotEqual(hash_a, _closure(a, root).closure_hash)
+
+    def test_matches_accepts_legacy_byte_recorded_hash(self) -> None:
+        # Migration: a descriptor recorded with the old byte-based digest must
+        # still validate as unchanged so no mass rebuild happens on upgrade.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            a = self._write(root, "gen.py", "def gen_step():\n    return 1\n")
+            legacy = source_hash._recompute_closure_hash(
+                ["gen.py"], base=root, hasher=source_hash._sha256_file
+            )
+            self.assertTrue(source_hash.closure_hash_matches(legacy, ["gen.py"], base=root))
+
+    def test_matches_accepts_semantic_hash_after_comment_edit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            a = self._write(root, "gen.py", "def gen_step():\n    return 1\n")
+            semantic = _closure(a, root).closure_hash
+            a.write_text("# comment\ndef gen_step():\n    return 1\n", encoding="utf-8")
+            self.assertTrue(source_hash.closure_hash_matches(semantic, ["gen.py"], base=root))
+
+    def test_matches_rejects_missing_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertFalse(source_hash.closure_hash_matches("abc", ["gone.py"], base=root))
+
+
+class RuntimeRootsStdinFootgunTests(unittest.TestCase):
+    def test_placeholder_main_file_does_not_mark_cwd_as_runtime(self) -> None:
+        # A stdin / `-c` driven build sets __main__.__file__ to '<stdin>', whose
+        # resolve().parent is the CWD; that must NOT be treated as a runtime root
+        # (which would exclude the model + its sibling helpers from the closure
+        # and silently disable staleness detection).
+        import sys
+
+        main = sys.modules["__main__"]
+        original = getattr(main, "__file__", None)
+        source_hash._runtime_roots.cache_clear()
+        try:
+            main.__file__ = "<stdin>"
+            source_hash._runtime_roots.cache_clear()
+            roots = source_hash._runtime_roots()
+            self.assertNotIn(Path.cwd().resolve(), roots)
+        finally:
+            if original is None:
+                if hasattr(main, "__file__"):
+                    del main.__file__
+            else:
+                main.__file__ = original
+            source_hash._runtime_roots.cache_clear()
+
+    def test_real_launcher_file_is_a_runtime_root(self) -> None:
+        import sys
+
+        main = sys.modules["__main__"]
+        original = getattr(main, "__file__", None)
+        with tempfile.TemporaryDirectory() as tmp:
+            launcher = Path(tmp) / "__main__.py"
+            launcher.write_text("# launcher\n", encoding="utf-8")
+            source_hash._runtime_roots.cache_clear()
+            try:
+                main.__file__ = str(launcher)
+                source_hash._runtime_roots.cache_clear()
+                roots = source_hash._runtime_roots()
+                self.assertIn(launcher.parent.resolve(), roots)
+            finally:
+                if original is None:
+                    if hasattr(main, "__file__"):
+                        del main.__file__
+                else:
+                    main.__file__ = original
+                source_hash._runtime_roots.cache_clear()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/skills/cad/cadgen/test_source_closure_and_cache.py
+++ b/tests/python/skills/cad/cadgen/test_source_closure_and_cache.py
@@ -43,22 +43,22 @@ class SourceClosureTests(unittest.TestCase):
             # The script and its dependency are both recorded.
             self.assertEqual(2, len(closure.files))
 
-            # Re-hashing the recorded file list reproduces the same hash.
-            self.assertEqual(
-                closure.closure_hash,
-                cad_source_hash.closure_hash_from_files(closure.files, base=base),
+            # Re-checking the recorded file list against the recorded hash matches.
+            self.assertTrue(
+                cad_source_hash.closure_hash_matches(closure.closure_hash, closure.files, base=base)
             )
 
-            # Editing a dependency changes the recomputed hash (stale).
+            # A semantic edit to a dependency invalidates the recorded hash (stale).
             dep.write_text("VALUE = 2\n", encoding="utf-8")
-            self.assertNotEqual(
-                closure.closure_hash,
-                cad_source_hash.closure_hash_from_files(closure.files, base=base),
+            self.assertFalse(
+                cad_source_hash.closure_hash_matches(closure.closure_hash, closure.files, base=base)
             )
 
-            # A missing recorded file yields None (callers treat as stale).
+            # A missing recorded file is never a match (callers treat as stale).
             dep.unlink()
-            self.assertIsNone(cad_source_hash.closure_hash_from_files(closure.files, base=base))
+            self.assertFalse(
+                cad_source_hash.closure_hash_matches(closure.closure_hash, closure.files, base=base)
+            )
 
     def test_capture_runtime_closure_includes_imported_repo_local_modules(self) -> None:
         with temporary_directory(prefix="closure-capture-") as raw_dir:


### PR DESCRIPTION
## Summary

Edit-path performance wins for CAD generation (`packages/cadgen`), targeting the warm-daemon rebuild loop. Four optimizations shipped (A2/A3/A4/A8); three ranked candidates (A5/A6/A1) were investigated and declined with measurements. Full rationale in `design/edit-path-perf-notes.md`.

Measured baseline (this branch): a comment-only edit rebuilt falcon_heavy in ~5.3 s / tom in ~12.7 s. After these changes such edits become a **~47 ms warm skip**.

## What's included

- **A2 — comment-insensitive closure hashing** (`source_hash.py`). Closure files are hashed by their AST, not raw bytes, so comment/whitespace edits no longer force a rebuild (they warm-skip). Migration-safe: both the byte-hash and the semantic hash are accepted, so existing descriptors stay valid.
- **A3 — stdin closure footgun fix** (`source_hash.py`). A `python - <<EOF`-driven build set `__main__.__file__ = '<stdin>'`, which made `_runtime_roots()` treat the CWD as a runtime root and silently disabled staleness detection for that artifact. Fixed, so stdin-driven builds detect staleness correctly again.
- **A4 — module first-party classification cache** (`source_hash.py` / `generation.py`). The per-build `sys.modules` walk that classifies each module first-party vs third-party (0.23–0.68 s/build, ~30% of a warm falcon build) is now cached per `__file__` across builds.
- **A8 — single BREP serialization** (`component_package.py`). Each component's BREP is serialized once and reused for both the source-closure hash and the worker payload, instead of twice.

## Declined (with evidence, in the design notes)

- **A5 reuse adaptive resolution** — the only gate that would help needs early cid computation, which costs the serialization it saves; residual case is narrow now that comment edits skip entirely (A2).
- **A6 tom `compound_from_instances`** — invalid premise: tom already composes that way; a cProfile shows the cost is build123d/BREP internals, not instancing-addressable.
- **A1 warm-daemon default-on** — kept opt-in (`CADGEN_WARM=1`); flipping the global CLI default has broad blast radius (CI/sandboxes) and is an ergonomics call, not a pipeline fix.

## Verification

- Full cadgen Python suite: **189 passed, 2 skipped** (main-checkout venv). The new `test_semantic_closure_hash.py` (+130 lines) covers the AST-hash semantics and the migration dual-hash path.
- `scripts/bundle/bundle.sh --check` and `scripts/dev/setup-symlinks.sh --check` clean; no generated/bundled outputs affected (source-only change under the dev symlink layout).
- No binary/CAD artifacts in the diff.
- Pre-PR adversarial audit (closure-hash false-hit / classification-cache staleness / BREP-serialize aliasing / diff-hygiene) — results summarized in the PR thread.

## Notes for the reviewer

- **CI:** `test.yml` triggers only on `develop`, so this PR (targeting `release/0.4.0`) shows no checks; verified locally.
- The dominant risk class here is a **false cache hit** (two semantically different sources hashing the same → stale geometry). That's exactly what the adversarial audit and `test_semantic_closure_hash.py` target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
