### PR TITLE
viewer: add STEP "Open in <CAD app>" context-menu integrations

### DIFF
--- a/viewer/server_py/backend.py
+++ b/viewer/server_py/backend.py
@@ -8,8 +8,11 @@ out to cadgen.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import re
+import shutil
 from urllib.parse import urlsplit, parse_qs, unquote
 
 IMPLICIT_EXPORT_FORMATS = ("glb", "stl", "3mf")
@@ -29,6 +32,21 @@ from .save_dialog import pick_save_destination
 from .urls import local_asset_url_for_path
 
 _STEP_EXPORT_FORMAT_SUFFIX = {"step": "step", "stl": "stl", "3mf": "3mf", "glb": "glb"}
+
+# Git LFS pointer files are ~130 bytes of text starting with this line; serving
+# one to an external CAD app hands it unparseable bytes.
+_GIT_LFS_POINTER_PREFIX = b"version https://git-lfs.github.com/spec/v1"
+
+_STEP_EXPORT_CACHE_DIRNAME = "exports"
+
+
+def is_git_lfs_pointer(file_path: str) -> bool:
+    try:
+        with open(file_path, "rb") as handle:
+            head = handle.read(512)
+    except OSError:
+        return False
+    return head.startswith(_GIT_LFS_POINTER_PREFIX)
 
 
 def _to_posix(value: str) -> str:
@@ -501,6 +519,97 @@ class LocalAssetBackend:
         output_file_ref = _to_posix(os.path.relpath(output_path, resolved_root["rootPath"]))
         return {"ok": True, "fallback": True, "path": output_path, "filename": os.path.basename(output_path),
                 "format": format_name, "catalogChanged": True, "outputFileRef": output_file_ref}
+
+    # POST /__cad/open-in — ensure a real .step exists on disk for the entry:
+    # imported entries resolve to their own file; generated entries export into a
+    # content-hash-keyed cache under the (gitignored) render package dir so
+    # repeated opens skip the tens-of-seconds gen_step re-run.
+    def materialize_step_output(self, file_ref, resolved_root):
+        resolved = self.resolve_step_source(file_ref, resolved_root)
+        step_path = resolved["stepPath"]
+        source_path = resolved["sourcePath"]
+        if not (step_path == resolved_root["rootPath"] or scanner.path_is_inside(step_path, resolved_root["rootPath"])):
+            raise ValueError("Requested file is outside the active CAD Viewer root")
+        if not source_path:
+            if not os.path.isfile(step_path):
+                raise ValueError(f"STEP file not found: {step_path}")
+            if is_git_lfs_pointer(step_path):
+                raise ValueError(
+                    f"{os.path.basename(step_path)} is an unhydrated Git LFS pointer. "
+                    f"Run `git lfs checkout {_to_posix(step_path)}` and retry."
+                )
+            return {"path": step_path, "materialized": False}
+        package_dir = scanner.render_package_dir(source_path)
+        cache_key = self._step_export_cache_key(source_path, package_dir)
+        exports_dir = os.path.join(package_dir, _STEP_EXPORT_CACHE_DIRNAME)
+        cache_path = os.path.join(exports_dir, cache_key, os.path.basename(step_path))
+        if os.path.isfile(cache_path):
+            return {"path": cache_path, "materialized": False, "cached": True}
+        ctx = self._scan_context(resolved_root)
+        args = ["--repo-root", ctx["scanRepoRoot"], "--step", step_path, "--format", "step",
+                "--out", cache_path, "--source-path", source_path]
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        result = cadgen_bridge.run_cadgen("cadgen.step_export_target", args, ctx["scanRepoRoot"])
+        if not result.get("ok") or not os.path.isfile(cache_path):
+            raise ValueError(str(result.get("error") or "STEP export failed"))
+        self._prune_step_export_cache(exports_dir, cache_key)
+        return {"path": cache_path, "materialized": True}
+
+    def _step_export_cache_key(self, source_path, package_dir):
+        """Content hash over the generator's source closure (the descriptor's
+        sourceClosureFiles when present, else just the source file). Any hash
+        works as a cache key as long as reads and writes agree — this does not
+        have to match cadgen's own closure hash."""
+        closure = []
+        try:
+            with open(os.path.join(package_dir, "assembly.json"), "r", encoding="utf-8") as handle:
+                descriptor = json.load(handle)
+            if isinstance(descriptor, dict) and isinstance(descriptor.get("sourceClosureFiles"), list):
+                closure = [str(rel or "") for rel in descriptor["sourceClosureFiles"] if str(rel or "")]
+        except (OSError, ValueError):
+            closure = []
+        model_folder = os.path.dirname(os.path.abspath(source_path))
+        paths = sorted({os.path.abspath(os.path.join(model_folder, rel)) for rel in closure})
+        if not paths:
+            paths = [os.path.abspath(source_path)]
+        hasher = hashlib.sha256()
+        for path in paths:
+            hasher.update(_to_posix(os.path.relpath(path, model_folder)).encode("utf-8"))
+            hasher.update(b"\0")
+            hasher.update((scanner._sha256_file(path) or "").encode("utf-8"))
+            hasher.update(b"\0")
+        return hasher.hexdigest()[:32]
+
+    def _prune_step_export_cache(self, exports_dir, keep_key):
+        try:
+            entries = os.listdir(exports_dir)
+        except OSError:
+            return
+        for name in entries:
+            if name == keep_key:
+                continue
+            stale = os.path.join(exports_dir, name)
+            if os.path.isdir(stale):
+                shutil.rmtree(stale, ignore_errors=True)
+
+    # POST /__cad/reveal — the on-disk path the OS file manager should select for
+    # an entry asset, confined to the active root like every asset route.
+    def reveal_target_path(self, file_ref, asset, resolved_root):
+        normalized = normalized_file_ref(file_ref)
+        if not normalized:
+            raise ValueError("Missing file")
+        candidate = self.file_path_from_ref(normalized, resolved_root)
+        if not (candidate == resolved_root["rootPath"] or scanner.path_is_inside(candidate, resolved_root["rootPath"])):
+            raise ForbiddenAssetError("Forbidden")
+        if str(asset or "output").strip().lower() == "source":
+            try:
+                resolved = self.resolve_step_source(file_ref, resolved_root)
+                candidate = resolved["sourcePath"] or resolved["stepPath"]
+            except ValueError:
+                pass
+        if not os.path.exists(candidate):
+            raise ValueError(f"Output file not found: {os.path.basename(candidate)}")
+        return candidate
 
     def file_path_from_ref(self, file_ref: str, resolved_root: dict) -> str:
         normalized = normalized_file_ref(file_ref)

--- a/viewer/server_py/integrations.py
+++ b/viewer/server_py/integrations.py
@@ -1,0 +1,465 @@
+"""Local "Open in <CAD app>" integrations: detection, launch, and reveal.
+
+Serves GET /__cad/integrations (which allowlisted desktop CAD apps are installed
+on this machine) and the launch half of POST /__cad/open-in and POST /__cad/reveal.
+Everything is a subprocess/stdlib probe (no pyobjc/winreg deps beyond the stdlib),
+mirroring save_dialog.py's per-platform-function + graceful-degradation shape.
+
+Security invariants (the request layer relies on these):
+- The client only ever names an ``appId``; the executable/bundle and argv shape
+  come from the server-side allowlist below. Arbitrary app names/paths are never
+  accepted.
+- The file argument must be an absolute, existing ``.step``/``.stp`` path. Values
+  starting with ``-`` or containing ``://`` are rejected before any spawn: macOS
+  ``open`` treats URL-looking strings as scheme launches and leading dashes as
+  flags (CWE-88 argument injection).
+- Spawns use argument vectors, never a shell.
+
+Env seams (tests/headless, same pattern as VIEWER_SAVE_DIALOG_FORCE_PATH):
+- ``VIEWER_OPEN_IN_PLATFORM``: force "darwin" | "win32" | "linux" recipes.
+- ``VIEWER_OPEN_IN_FORCE_INSTALLED``: comma list of app ids to report installed,
+  each optionally ``id=/detected/path``.
+- ``VIEWER_DISABLE_APP_LAUNCH=1``: never spawn; return the argv that would run.
+
+FreeCAD gotcha encoded below: ``open -a FreeCAD file.step`` silently drops the
+file (its Apple-event handler only honors .fcstd), so FreeCAD launches exec the
+bundle binary directly with ``--single-instance``.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import sys
+from urllib.parse import quote
+
+STEP_OPEN_EXTENSIONS = (".step", ".stp")
+
+_FUSION_WEBDEPLOY_DARWIN = "~/Library/Application Support/Autodesk/webdeploy/production"
+
+
+def integration_platform() -> str:
+    forced = str(os.environ.get("VIEWER_OPEN_IN_PLATFORM") or "").strip().lower()
+    if forced in ("darwin", "win32", "linux"):
+        return forced
+    if sys.platform == "darwin":
+        return "darwin"
+    if sys.platform.startswith("win"):
+        return "win32"
+    return "linux"
+
+
+def _expand(path: str) -> str:
+    return os.path.expanduser(os.path.expandvars(path))
+
+
+def _first_existing_dir(*candidates):
+    for candidate in candidates:
+        path = _expand(candidate)
+        if os.path.isdir(path):
+            return path
+    return ""
+
+
+def _first_existing_file(*candidates):
+    for candidate in candidates:
+        path = _expand(candidate)
+        if os.path.isfile(path):
+            return path
+    return ""
+
+
+def _first_glob_file(*patterns):
+    for pattern in patterns:
+        matches = sorted(glob.glob(_expand(pattern)), reverse=True)
+        for match in matches:
+            if os.path.isfile(match):
+                return match
+    return ""
+
+
+def _which(*names):
+    from shutil import which
+
+    for name in names:
+        found = which(name)
+        if found:
+            return found
+    return ""
+
+
+def _win_registry_value(root_name: str, key_path: str, value_name: str = ""):
+    try:
+        import winreg
+    except ImportError:
+        return ""
+    root = {"HKLM": winreg.HKEY_LOCAL_MACHINE, "HKCU": winreg.HKEY_CURRENT_USER,
+            "HKCR": winreg.HKEY_CLASSES_ROOT}.get(root_name)
+    if root is None:
+        return ""
+    try:
+        with winreg.OpenKey(root, key_path) as key:
+            value, _kind = winreg.QueryValueEx(key, value_name)
+            return str(value or "").strip().strip('"')
+    except OSError:
+        return ""
+
+
+def _win_registry_key_exists(root_name: str, key_path: str) -> bool:
+    try:
+        import winreg
+    except ImportError:
+        return False
+    root = {"HKLM": winreg.HKEY_LOCAL_MACHINE, "HKCU": winreg.HKEY_CURRENT_USER,
+            "HKCR": winreg.HKEY_CLASSES_ROOT}.get(root_name)
+    if root is None:
+        return False
+    try:
+        with winreg.OpenKey(root, key_path):
+            return True
+    except OSError:
+        return False
+
+
+def _win_solidworks_setup_exe():
+    try:
+        import winreg
+    except ImportError:
+        return ""
+    try:
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\SolidWorks") as parent:
+            index = 0
+            years = []
+            while True:
+                try:
+                    name = winreg.EnumKey(parent, index)
+                except OSError:
+                    break
+                index += 1
+                if name.upper().startswith("SOLIDWORKS 2"):
+                    years.append(name)
+            for name in sorted(years, reverse=True):
+                folder = _win_registry_value("HKLM", rf"SOFTWARE\SolidWorks\{name}\Setup", "SolidWorks Folder")
+                if folder:
+                    exe = os.path.join(folder, "SLDWORKS.exe")
+                    if os.path.isfile(exe):
+                        return exe
+    except OSError:
+        pass
+    return ""
+
+
+# --- per-app probes: return the detected app path/exe ("" when not installed) ---
+def _probe_freecad_darwin():
+    return _first_existing_dir("/Applications/FreeCAD.app", "~/Applications/FreeCAD.app")
+
+
+def _probe_freecad_win32():
+    return (
+        _win_registry_value("HKLM", r"Software\Microsoft\Windows\CurrentVersion\App Paths\FreeCAD.exe")
+        or _win_registry_value("HKCU", r"Software\Microsoft\Windows\CurrentVersion\App Paths\FreeCAD.exe")
+        or _first_glob_file(r"C:\Program Files\FreeCAD*\bin\FreeCAD.exe",
+                            r"%LOCALAPPDATA%\Programs\FreeCAD*\bin\FreeCAD.exe")
+    )
+
+
+def _probe_fusion_darwin():
+    # Fusion installs under the per-user webdeploy tree, NOT /Applications, and
+    # Spotlight does not index ~/Library — stat the known locations directly.
+    return _first_existing_dir(
+        "~/Applications/Autodesk Fusion.app",
+        "~/Applications/Autodesk Fusion 360.app",
+        os.path.join(_FUSION_WEBDEPLOY_DARWIN, "Autodesk Fusion 360.app"),
+        _FUSION_WEBDEPLOY_DARWIN,
+    )
+
+
+def _probe_fusion_win32():
+    if _win_registry_key_exists("HKCU", r"Software\Classes\fusion360"):
+        return "fusion360"
+    if _first_existing_dir(r"%LOCALAPPDATA%\Autodesk\webdeploy\production"):
+        return "fusion360"
+    return ""
+
+
+def _probe_rhino_darwin():
+    return _first_existing_dir("/Applications/Rhino 8.app", "/Applications/Rhinoceros.app")
+
+
+def _probe_rhino_win32():
+    install = _win_registry_value("HKLM", r"SOFTWARE\McNeel\Rhinoceros\8.0\Install", "Path")
+    if install:
+        exe = os.path.join(install, "System", "Rhino.exe")
+        if os.path.isfile(exe):
+            return exe
+    return _first_glob_file(r"C:\Program Files\Rhino 8\System\Rhino.exe")
+
+
+def _probe_edrawings_darwin():
+    return _first_existing_dir("/Applications/eDrawings.app")
+
+
+def _probe_edrawings_win32():
+    return _first_glob_file(r"C:\Program Files\SOLIDWORKS Corp\eDrawings*\eDrawings.exe",
+                            r"C:\Program Files\Common Files\eDrawings*\eDrawings.exe")
+
+
+def _probe_cad_assistant_darwin():
+    return _first_existing_dir("/Applications/CAD Assistant.app", "/Applications/CADAssistant.app")
+
+
+def _probe_shapr3d_darwin():
+    return _first_existing_dir("/Applications/Shapr3D.app")
+
+
+def _probe_plasticity_darwin():
+    return _first_existing_dir("/Applications/Plasticity.app")
+
+
+def _probe_plasticity_win32():
+    return _first_glob_file(r"%LOCALAPPDATA%\Programs\Plasticity\Plasticity.exe")
+
+
+# --- launch command builders: (detected, file_path) -> argv ---
+def _open_with_bundle(detected, file_path):
+    return ["open", "-a", detected, file_path]
+
+
+def _freecad_darwin_command(detected, file_path):
+    return [os.path.join(detected, "Contents", "MacOS", "FreeCAD"), "--single-instance", file_path]
+
+
+def _single_instance_exe_command(detected, file_path):
+    return [detected, "--single-instance", file_path]
+
+
+def fusion_open_url(file_path: str) -> str:
+    return "fusion360://host/?command=open&file=" + quote(file_path, safe="")
+
+
+def _fusion_darwin_command(detected, file_path):
+    del detected
+    return ["open", fusion_open_url(file_path)]
+
+
+def _fusion_win32_command(detected, file_path):
+    del detected
+    return ["os.startfile", fusion_open_url(file_path)]
+
+
+def _exe_file_command(detected, file_path):
+    return [detected, file_path]
+
+
+def _system_default_darwin(detected, file_path):
+    del detected
+    return ["open", file_path]
+
+
+def _system_default_win32(detected, file_path):
+    del detected
+    return ["os.startfile", file_path]
+
+
+def _system_default_linux(detected, file_path):
+    del detected
+    return ["xdg-open", file_path]
+
+
+def _always(_value="system"):
+    return lambda: _value
+
+
+APP_INTEGRATIONS = (
+    {
+        "id": "freecad",
+        "name": "FreeCAD",
+        "platforms": {
+            "darwin": {"probe": _probe_freecad_darwin, "command": _freecad_darwin_command},
+            "win32": {"probe": _probe_freecad_win32, "command": _single_instance_exe_command},
+            "linux": {"probe": lambda: _which("freecad"), "command": _single_instance_exe_command},
+        },
+    },
+    {
+        "id": "fusion360",
+        "name": "Autodesk Fusion",
+        "platforms": {
+            "darwin": {"probe": _probe_fusion_darwin, "command": _fusion_darwin_command},
+            "win32": {"probe": _probe_fusion_win32, "command": _fusion_win32_command},
+        },
+    },
+    {
+        "id": "rhino",
+        "name": "Rhino 8",
+        "platforms": {
+            "darwin": {"probe": _probe_rhino_darwin, "command": _open_with_bundle},
+            "win32": {"probe": _probe_rhino_win32, "command": _exe_file_command},
+        },
+    },
+    {
+        "id": "shapr3d",
+        "name": "Shapr3D",
+        "platforms": {
+            "darwin": {"probe": _probe_shapr3d_darwin, "command": _open_with_bundle},
+        },
+    },
+    {
+        "id": "plasticity",
+        "name": "Plasticity",
+        "platforms": {
+            "darwin": {"probe": _probe_plasticity_darwin, "command": _open_with_bundle},
+            "win32": {"probe": _probe_plasticity_win32, "command": _exe_file_command},
+            "linux": {"probe": lambda: _which("plasticity"), "command": _exe_file_command},
+        },
+    },
+    {
+        "id": "edrawings",
+        "name": "eDrawings",
+        "platforms": {
+            "darwin": {"probe": _probe_edrawings_darwin, "command": _open_with_bundle},
+            "win32": {"probe": _probe_edrawings_win32, "command": _exe_file_command},
+        },
+    },
+    {
+        "id": "cad-assistant",
+        "name": "CAD Assistant",
+        "platforms": {
+            "darwin": {"probe": _probe_cad_assistant_darwin, "command": _open_with_bundle},
+        },
+    },
+    {
+        "id": "solidworks",
+        "name": "SOLIDWORKS",
+        "platforms": {
+            "win32": {"probe": _win_solidworks_setup_exe, "command": _exe_file_command},
+        },
+    },
+    {
+        "id": "system-default",
+        "name": "System Default",
+        "platforms": {
+            "darwin": {"probe": _always(), "command": _system_default_darwin},
+            "win32": {"probe": _always(), "command": _system_default_win32},
+            "linux": {"probe": _always(), "command": _system_default_linux},
+        },
+    },
+)
+
+
+def _forced_installed() -> dict:
+    forced = {}
+    raw = str(os.environ.get("VIEWER_OPEN_IN_FORCE_INSTALLED") or "").strip()
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        app_id, _, detected = token.partition("=")
+        forced[app_id.strip()] = detected.strip() or "forced"
+    return forced
+
+
+def _detect(app: dict, platform: str, forced: dict) -> str:
+    if app["id"] in forced:
+        return forced[app["id"]]
+    spec = app["platforms"].get(platform)
+    if not spec:
+        return ""
+    try:
+        return str(spec["probe"]() or "")
+    except Exception:  # noqa: BLE001 — a broken probe means "not installed", never a 500
+        return ""
+
+
+def list_integration_targets() -> dict:
+    platform = integration_platform()
+    forced = _forced_installed()
+    targets = []
+    for app in APP_INTEGRATIONS:
+        if platform not in app["platforms"]:
+            continue
+        targets.append({
+            "id": app["id"],
+            "name": app["name"],
+            "installed": bool(_detect(app, platform, forced)),
+        })
+    return {"platform": platform, "targets": targets}
+
+
+def validate_open_target_path(file_path: str) -> str:
+    path = str(file_path or "").strip()
+    if not path or not os.path.isabs(path):
+        raise ValueError("Open in app requires an absolute STEP file path")
+    if path.startswith("-") or "://" in path:
+        raise ValueError("Invalid STEP file path")
+    resolved = os.path.realpath(path)
+    if os.path.splitext(resolved)[1].lower() not in STEP_OPEN_EXTENSIONS:
+        raise ValueError("Only STEP/STP files can be opened in a CAD app")
+    if not os.path.isfile(resolved):
+        raise ValueError(f"STEP file not found: {resolved}")
+    return resolved
+
+
+def _spawn_detached(argv) -> None:
+    if argv and argv[0] == "os.startfile":
+        os.startfile(argv[1])  # noqa: PTH — Windows-only ShellExecute wrapper
+        return
+    kwargs = {"stdin": subprocess.DEVNULL, "stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL}
+    if os.name == "nt":
+        kwargs["creationflags"] = 0x00000008  # DETACHED_PROCESS
+    else:
+        kwargs["start_new_session"] = True
+    subprocess.Popen(argv, **kwargs)  # noqa: S603 — argv comes from the server-side allowlist
+
+
+def launch_integration(app_id: str, file_path: str) -> dict:
+    """Open ``file_path`` in the allowlisted app. Returns
+    ``{ok, appId, appName, command?}`` (command only when spawning is disabled)."""
+    normalized_id = str(app_id or "").strip()
+    app = next((a for a in APP_INTEGRATIONS if a["id"] == normalized_id), None)
+    if not app:
+        raise ValueError(f"Unknown Open-in app: {app_id or '(missing)'}")
+    platform = integration_platform()
+    spec = app["platforms"].get(platform)
+    if not spec:
+        raise ValueError(f"{app['name']} is not available on this platform")
+    detected = _detect(app, platform, _forced_installed())
+    if not detected:
+        raise ValueError(f"{app['name']} is not installed")
+    resolved = validate_open_target_path(file_path)
+    argv = spec["command"](detected, resolved)
+    payload = {"ok": True, "appId": app["id"], "appName": app["name"]}
+    if os.environ.get("VIEWER_DISABLE_APP_LAUNCH") == "1":
+        payload["command"] = list(argv)
+        return payload
+    try:
+        _spawn_detached(argv)
+    except OSError as exc:
+        raise ValueError(f"Failed to launch {app['name']}: {exc}") from exc
+    return payload
+
+
+def reveal_command(file_path: str, platform: str = "") -> list:
+    platform = platform or integration_platform()
+    if platform == "darwin":
+        return ["open", "-R", file_path]
+    if platform == "win32":
+        return ["explorer.exe", f"/select,{file_path}"]
+    return ["xdg-open", os.path.dirname(file_path)]
+
+
+def reveal_in_file_manager(file_path: str) -> dict:
+    path = str(file_path or "").strip()
+    if not path or not os.path.isabs(path) or path.startswith("-") or "://" in path:
+        raise ValueError("Reveal requires an absolute file path")
+    resolved = os.path.realpath(path)
+    if not os.path.exists(resolved):
+        raise ValueError(f"File not found: {resolved}")
+    argv = reveal_command(resolved)
+    if os.environ.get("VIEWER_DISABLE_APP_LAUNCH") == "1":
+        return {"ok": True, "command": list(argv)}
+    try:
+        _spawn_detached(argv)
+    except OSError as exc:
+        raise ValueError(f"Failed to reveal file: {exc}") from exc
+    return {"ok": True}

--- a/viewer/server_py/server.py
+++ b/viewer/server_py/server.py
@@ -2,10 +2,13 @@
 
 Serves the /__cad/* contract the unchanged client consumes. Implemented routes
 (parity-verified core): GET /__cad/server, GET /__cad/catalog, GET /__cad/asset,
-GET /__cad/download, POST /__cad/implicit-export
-(client-side-export write contract). Static dist/SPA, legacy Referer assets,
-/__cad/artifact, and /__cad/step-export are TODO (cadgen-integration + serving
-phases).
+GET /__cad/download, GET /__cad/integrations, POST /__cad/artifact,
+POST /__cad/step-export, POST /__cad/implicit-export, POST /__cad/open-in,
+POST /__cad/reveal, plus static dist/SPA and legacy Referer assets.
+
+POST /__cad/open-in and /__cad/reveal touch the local machine (launch a CAD app /
+select a file in the OS file manager), so they additionally require loopback
+Host and Origin headers (see _local_action_forbidden).
 
 Run: python -m server_py.server --dir <abs-models-root> [--port N] [--host H]
 
@@ -29,16 +32,19 @@ from urllib.parse import urlsplit, parse_qs, unquote
 if __package__ in (None, ""):
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from server_py import backend as backend_mod
+    from server_py import integrations as integrations_mod
     from server_py import server_info as server_info_mod
     from server_py import encoding as enc
     from server_py.content_types import content_type_for_static_asset
 else:
     from . import backend as backend_mod
+    from . import integrations as integrations_mod
     from . import server_info as server_info_mod
     from . import encoding as enc
     from .content_types import content_type_for_static_asset
 
-LOCAL_SERVER_FEATURES = ["dynamic-root", "relative-dir-query", "default-dir"]
+LOCAL_SERVER_FEATURES = ["dynamic-root", "relative-dir-query", "default-dir", "open-in-integrations"]
+_LOOPBACK_HOSTNAMES = frozenset(["localhost", "127.0.0.1", "::1"])
 _BAD_PERCENT_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
 
 
@@ -47,6 +53,26 @@ def _strict_decode_uri_component(value: str) -> str:
     if _BAD_PERCENT_RE.search(value):
         raise ValueError("URI malformed")
     return unquote(value)
+
+
+def _allowed_local_hostnames() -> frozenset:
+    extra = {
+        token.strip().lower()
+        for token in str(os.environ.get("VIEWER_ALLOWED_HOSTS") or "").split(",")
+        if token.strip()
+    }
+    return _LOOPBACK_HOSTNAMES | extra
+
+
+def _hostname_from_header(value: str, *, is_origin: bool = False) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    try:
+        hostname = urlsplit(text if is_origin else f"//{text}").hostname
+    except ValueError:
+        return ""
+    return str(hostname or "").lower()
 
 
 def _sibling_file_ref(source_file_ref: str, relative_file_ref: str) -> str:
@@ -139,6 +165,8 @@ class Handler(BaseHTTPRequestHandler):
                 self._serve_asset(q, download=False)
             elif path == "/__cad/download":
                 self._serve_asset(q, download=True)
+            elif path == "/__cad/integrations":
+                self._send_json(200, {"ok": True, **integrations_mod.list_integration_targets()})
             elif self._legacy_cad_asset(path, q):
                 pass  # served (or 403) by the legacy Referer-based handler
             else:
@@ -157,6 +185,10 @@ class Handler(BaseHTTPRequestHandler):
                 self._step_export(q)
             elif path == "/__cad/implicit-export":
                 self._implicit_export(q)
+            elif path == "/__cad/open-in":
+                self._open_in(q)
+            elif path == "/__cad/reveal":
+                self._reveal(q)
             else:
                 self.send_response(405)
                 self.send_header("allow", "POST")
@@ -349,6 +381,58 @@ class Handler(BaseHTTPRequestHandler):
             "downloadUrl": download_url,
             "filename": result.get("filename"),
         })
+
+    def _local_action_forbidden(self) -> bool:
+        """Cross-site defense for routes that act on the local machine (launch a
+        CAD app / reveal in the OS file manager): Host and Origin must both
+        resolve to loopback (or a VIEWER_ALLOWED_HOSTS name). Hostname-only —
+        vite dev mode proxies the browser's Host/Origin verbatim, so the port is
+        the vite port, never this server's. Origin may be absent (non-browser
+        same-machine callers); a present non-loopback Origin means another web
+        origin is driving the request (CSRF / DNS rebinding)."""
+        allowed = _allowed_local_hostnames()
+        host = _hostname_from_header(self.headers.get("host"))
+        if host and host not in allowed:
+            return True
+        origin = str(self.headers.get("origin") or "").strip()
+        if origin:
+            # "null" (sandboxed iframes, file:// pages) counts as foreign: a
+            # cross-site sandboxed iframe can form-POST here with Origin: null.
+            origin_host = _hostname_from_header(origin, is_origin=True)
+            if not origin_host or origin_host not in allowed:
+                return True
+        return False
+
+    def _open_in(self, q):
+        if self._local_action_forbidden():
+            self._send_json(403, {"ok": False, "error": "Forbidden"})
+            return
+        resolved = _Ctx.backend.resolve_request_root(q.get("dir", ""))
+        materialized = _Ctx.backend.materialize_step_output(q.get("file", ""), resolved)
+        launched = integrations_mod.launch_integration(q.get("app", ""), materialized["path"])
+        payload = {
+            "ok": True,
+            "appId": launched["appId"],
+            "appName": launched["appName"],
+            "path": materialized["path"],
+            "filename": os.path.basename(materialized["path"]),
+            "materialized": bool(materialized.get("materialized")),
+        }
+        if launched.get("command"):
+            payload["command"] = launched["command"]
+        self._send_json(200, payload)
+
+    def _reveal(self, q):
+        if self._local_action_forbidden():
+            self._send_json(403, {"ok": False, "error": "Forbidden"})
+            return
+        resolved = _Ctx.backend.resolve_request_root(q.get("dir", ""))
+        target = _Ctx.backend.reveal_target_path(q.get("file", ""), q.get("asset", "output"), resolved)
+        result = integrations_mod.reveal_in_file_manager(target)
+        payload = {"ok": True, "path": target}
+        if result.get("command"):
+            payload["command"] = result["command"]
+        self._send_json(200, payload)
 
 
 def main(argv=None):

--- a/viewer/server_py/tests/test_http_open_in.py
+++ b/viewer/server_py/tests/test_http_open_in.py
@@ -1,0 +1,169 @@
+"""HTTP-level tests for GET /__cad/integrations, POST /__cad/open-in, and
+POST /__cad/reveal — a real ThreadingHTTPServer on an ephemeral loopback port,
+with app launching disabled via the integrations env seams."""
+
+import http.client
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from server_py import backend as backend_mod  # noqa: E402
+from server_py import server as server_mod  # noqa: E402
+
+_ENV_KEYS = (
+    "VIEWER_OPEN_IN_PLATFORM",
+    "VIEWER_OPEN_IN_FORCE_INSTALLED",
+    "VIEWER_DISABLE_APP_LAUNCH",
+    "VIEWER_ALLOWED_HOSTS",
+)
+
+
+class OpenInHttpRoutes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls.root = os.path.realpath(cls._tmp.name)
+        cls.step_path = os.path.join(cls.root, "part.step")
+        with open(cls.step_path, "w", encoding="utf-8") as handle:
+            handle.write("ISO-10303-21;\nEND-ISO-10303-21;\n")
+        server_mod._Ctx.directory_root = cls.root
+        server_mod._Ctx.dist_root = os.path.join(cls.root, "dist")
+        server_mod._Ctx.backend = backend_mod.LocalAssetBackend(directory_root=cls.root, root_dir=cls.root)
+        cls.httpd = ThreadingHTTPServer(("127.0.0.1", 0), server_mod.Handler)
+        server_mod._Ctx.port = cls.httpd.server_address[1]
+        cls.port = cls.httpd.server_address[1]
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        cls.thread.join(timeout=5)
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in _ENV_KEYS}
+        for k in _ENV_KEYS:
+            os.environ.pop(k, None)
+        os.environ["VIEWER_DISABLE_APP_LAUNCH"] = "1"
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "darwin"
+        os.environ["VIEWER_OPEN_IN_FORCE_INSTALLED"] = "freecad=/Applications/FreeCAD.app"
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _request(self, method, path, headers=None):
+        conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=10)
+        try:
+            conn.request(method, path, headers=headers or {})
+            response = conn.getresponse()
+            body = response.read()
+        finally:
+            conn.close()
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except ValueError:
+            payload = None
+        return response.status, payload
+
+    def _open_in_path(self, file_path=None, app="freecad"):
+        from urllib.parse import quote
+        return f"/__cad/open-in?file={quote(file_path or self.step_path, safe='')}&app={quote(app, safe='')}"
+
+    def test_get_integrations_lists_targets(self):
+        status, payload = self._request("GET", "/__cad/integrations")
+        self.assertEqual(status, 200)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["platform"], "darwin")
+        targets = {t["id"]: t for t in payload["targets"]}
+        self.assertTrue(targets["freecad"]["installed"])
+        self.assertTrue(targets["system-default"]["installed"])
+
+    def test_open_in_launches_allowlisted_app(self):
+        status, payload = self._request("POST", self._open_in_path())
+        self.assertEqual(status, 200)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["appId"], "freecad")
+        self.assertEqual(payload["filename"], "part.step")
+        self.assertFalse(payload["materialized"])
+        self.assertEqual(payload["command"][0], "/Applications/FreeCAD.app/Contents/MacOS/FreeCAD")
+
+    def test_open_in_rejects_foreign_origin(self):
+        status, payload = self._request(
+            "POST", self._open_in_path(), headers={"Origin": "https://evil.example"})
+        self.assertEqual(status, 403)
+        self.assertFalse(payload["ok"])
+
+    def test_open_in_rejects_null_origin(self):
+        status, _payload = self._request(
+            "POST", self._open_in_path(), headers={"Origin": "null"})
+        self.assertEqual(status, 403)
+
+    def test_open_in_rejects_foreign_host(self):
+        # DNS-rebinding shape: the request reaches loopback but Host is a public name.
+        status, _payload = self._request(
+            "POST", self._open_in_path(), headers={"Host": "evil.example:443"})
+        self.assertEqual(status, 403)
+
+    def test_open_in_allows_loopback_origin_on_other_port(self):
+        # vite dev mode: the browser origin carries the vite port, not this server's.
+        status, payload = self._request(
+            "POST", self._open_in_path(), headers={"Origin": "http://127.0.0.1:5173"})
+        self.assertEqual(status, 200)
+        self.assertTrue(payload["ok"])
+
+    def test_open_in_rejects_unknown_app(self):
+        status, payload = self._request("POST", self._open_in_path(app="netcat"))
+        self.assertEqual(status, 400)
+        self.assertIn("Unknown", payload["error"])
+
+    def test_open_in_rejects_file_outside_root(self):
+        status, payload = self._request("POST", self._open_in_path(file_path="/etc/hosts"))
+        self.assertEqual(status, 400)
+        self.assertFalse(payload["ok"])
+
+    def test_open_in_rejects_lfs_pointer(self):
+        pointer = os.path.join(self.root, "pointer.step")
+        with open(pointer, "w", encoding="utf-8") as handle:
+            handle.write("version https://git-lfs.github.com/spec/v1\noid sha256:abc\nsize 42\n")
+        status, payload = self._request("POST", self._open_in_path(file_path=pointer))
+        self.assertEqual(status, 400)
+        self.assertIn("git lfs checkout", payload["error"])
+
+    def test_reveal_selects_entry_file(self):
+        from urllib.parse import quote
+        status, payload = self._request(
+            "POST", f"/__cad/reveal?file={quote(self.step_path, safe='')}&asset=output")
+        self.assertEqual(status, 200)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["command"], ["open", "-R", self.step_path])
+
+    def test_reveal_missing_file_is_an_error(self):
+        from urllib.parse import quote
+        missing = os.path.join(self.root, "absent.step")
+        status, payload = self._request(
+            "POST", f"/__cad/reveal?file={quote(missing, safe='')}&asset=output")
+        self.assertEqual(status, 400)
+        self.assertIn("not found", payload["error"].lower())
+
+    def test_reveal_outside_root_forbidden(self):
+        from urllib.parse import quote
+        status, _payload = self._request(
+            "POST", f"/__cad/reveal?file={quote('/etc/hosts', safe='')}&asset=output")
+        self.assertEqual(status, 403)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/server_py/tests/test_integrations.py
+++ b/viewer/server_py/tests/test_integrations.py
@@ -1,0 +1,232 @@
+"""Unit tests for the Open-in integrations module (detection env seams, launch
+recipes, validation) and the backend STEP materialization cache."""
+
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from server_py import backend as backend_mod  # noqa: E402
+from server_py import integrations  # noqa: E402
+
+_ENV_KEYS = (
+    "VIEWER_OPEN_IN_PLATFORM",
+    "VIEWER_OPEN_IN_FORCE_INSTALLED",
+    "VIEWER_DISABLE_APP_LAUNCH",
+)
+
+
+class _EnvIsolatedTest(unittest.TestCase):
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in _ENV_KEYS}
+        for k in _ENV_KEYS:
+            os.environ.pop(k, None)
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class IntegrationTargets(_EnvIsolatedTest):
+    def test_platform_filtering_darwin(self):
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "darwin"
+        payload = integrations.list_integration_targets()
+        ids = [t["id"] for t in payload["targets"]]
+        self.assertEqual(payload["platform"], "darwin")
+        self.assertIn("freecad", ids)
+        self.assertIn("fusion360", ids)
+        self.assertNotIn("solidworks", ids)
+        self.assertEqual(ids[-1], "system-default")
+
+    def test_platform_filtering_win32(self):
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "win32"
+        ids = [t["id"] for t in integrations.list_integration_targets()["targets"]]
+        self.assertIn("solidworks", ids)
+        self.assertNotIn("cad-assistant", ids)
+
+    def test_system_default_always_installed(self):
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "linux"
+        targets = {t["id"]: t for t in integrations.list_integration_targets()["targets"]}
+        self.assertTrue(targets["system-default"]["installed"])
+
+    def test_forced_installed(self):
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "darwin"
+        os.environ["VIEWER_OPEN_IN_FORCE_INSTALLED"] = "freecad=/Applications/FreeCAD.app, rhino"
+        targets = {t["id"]: t for t in integrations.list_integration_targets()["targets"]}
+        self.assertTrue(targets["freecad"]["installed"])
+        self.assertTrue(targets["rhino"]["installed"])
+
+
+class LaunchRecipes(_EnvIsolatedTest):
+    def setUp(self):
+        super().setUp()
+        os.environ["VIEWER_DISABLE_APP_LAUNCH"] = "1"
+        self._tmp = tempfile.TemporaryDirectory()
+        self.step_path = os.path.join(self._tmp.name, "part.step")
+        with open(self.step_path, "w", encoding="utf-8") as handle:
+            handle.write("ISO-10303-21;\nEND-ISO-10303-21;\n")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        super().tearDown()
+
+    def test_freecad_darwin_execs_bundle_binary(self):
+        # NOT `open -a`: FreeCAD's Apple-event handler drops non-.fcstd files.
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "darwin"
+        os.environ["VIEWER_OPEN_IN_FORCE_INSTALLED"] = "freecad=/Applications/FreeCAD.app"
+        result = integrations.launch_integration("freecad", self.step_path)
+        self.assertEqual(result["command"], [
+            "/Applications/FreeCAD.app/Contents/MacOS/FreeCAD",
+            "--single-instance",
+            os.path.realpath(self.step_path),
+        ])
+
+    def test_fusion_darwin_fires_url_scheme(self):
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "darwin"
+        os.environ["VIEWER_OPEN_IN_FORCE_INSTALLED"] = "fusion360"
+        result = integrations.launch_integration("fusion360", self.step_path)
+        self.assertEqual(result["command"][0], "open")
+        url = result["command"][1]
+        self.assertTrue(url.startswith("fusion360://host/?command=open&file="))
+        self.assertNotIn(os.path.realpath(self.step_path), url)  # path must be URL-encoded
+        self.assertIn("%2Fpart.step", url)
+
+    def test_bundle_apps_open_with_detected_path(self):
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "darwin"
+        os.environ["VIEWER_OPEN_IN_FORCE_INSTALLED"] = "rhino=/Applications/Rhino 8.app"
+        result = integrations.launch_integration("rhino", self.step_path)
+        self.assertEqual(result["command"], [
+            "open", "-a", "/Applications/Rhino 8.app", os.path.realpath(self.step_path),
+        ])
+
+    def test_system_default_per_platform(self):
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "darwin"
+        self.assertEqual(
+            integrations.launch_integration("system-default", self.step_path)["command"][0], "open")
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "win32"
+        self.assertEqual(
+            integrations.launch_integration("system-default", self.step_path)["command"][0], "os.startfile")
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "linux"
+        self.assertEqual(
+            integrations.launch_integration("system-default", self.step_path)["command"][0], "xdg-open")
+
+    def test_unknown_app_rejected(self):
+        with self.assertRaises(ValueError):
+            integrations.launch_integration("evil-app", self.step_path)
+
+    def test_not_installed_rejected(self):
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "darwin"
+        os.environ["VIEWER_OPEN_IN_FORCE_INSTALLED"] = ""
+        # Probe a machine-independent miss: solidworks has no darwin recipe at all.
+        with self.assertRaises(ValueError):
+            integrations.launch_integration("solidworks", self.step_path)
+
+    def test_relative_path_rejected(self):
+        with self.assertRaises(ValueError):
+            integrations.launch_integration("system-default", "part.step")
+
+    def test_non_step_extension_rejected(self):
+        other = os.path.join(self._tmp.name, "part.stl")
+        with open(other, "w", encoding="utf-8") as handle:
+            handle.write("solid\n")
+        with self.assertRaises(ValueError):
+            integrations.launch_integration("system-default", other)
+
+    def test_url_like_path_rejected(self):
+        with self.assertRaises(ValueError):
+            integrations.launch_integration("system-default", "http://evil.example/part.step")
+
+    def test_reveal_command_per_platform(self):
+        self.assertEqual(integrations.reveal_command("/tmp/a.step", "darwin"), ["open", "-R", "/tmp/a.step"])
+        self.assertEqual(integrations.reveal_command("C:\\m\\a.step", "win32"), ["explorer.exe", "/select,C:\\m\\a.step"])
+        self.assertEqual(integrations.reveal_command("/tmp/a.step", "linux"), ["xdg-open", "/tmp"])
+
+    def test_reveal_disabled_returns_command(self):
+        os.environ["VIEWER_OPEN_IN_PLATFORM"] = "darwin"
+        result = integrations.reveal_in_file_manager(self.step_path)
+        self.assertEqual(result["command"], ["open", "-R", os.path.realpath(self.step_path)])
+
+
+class StepMaterialization(_EnvIsolatedTest):
+    def setUp(self):
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.realpath(self._tmp.name)
+        self.backend = backend_mod.LocalAssetBackend(directory_root=self.root, root_dir=self.root)
+        self.resolved = self.backend.resolve_root(self.root)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        super().tearDown()
+
+    def _write(self, name, text):
+        path = os.path.join(self.root, name)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        return path
+
+    def test_imported_step_resolves_to_itself(self):
+        step = self._write("part.step", "ISO-10303-21;\nEND-ISO-10303-21;\n")
+        result = self.backend.materialize_step_output(step, self.resolved)
+        self.assertEqual(result, {"path": step, "materialized": False})
+
+    def test_lfs_pointer_rejected(self):
+        step = self._write(
+            "part.step",
+            "version https://git-lfs.github.com/spec/v1\noid sha256:abc\nsize 42\n",
+        )
+        with self.assertRaisesRegex(ValueError, "git lfs checkout"):
+            self.backend.materialize_step_output(step, self.resolved)
+
+    def test_generated_export_caches_by_source_content(self):
+        source = self._write("box.step.py", "def gen_step():\n    return None\n")
+        calls = []
+
+        def fake_run_cadgen(module, args, repo_root):
+            calls.append((module, list(args)))
+            out = args[args.index("--out") + 1]
+            os.makedirs(os.path.dirname(out), exist_ok=True)
+            with open(out, "w", encoding="utf-8") as handle:
+                handle.write("ISO-10303-21;\n")
+            return {"ok": True, "path": out}
+
+        original = backend_mod.cadgen_bridge.run_cadgen
+        backend_mod.cadgen_bridge.run_cadgen = fake_run_cadgen
+        try:
+            first = self.backend.materialize_step_output(source, self.resolved)
+            self.assertTrue(first["materialized"])
+            self.assertTrue(first["path"].endswith("box.step"))
+            self.assertIn(os.path.join("__cadgen__", "models"), first["path"])
+
+            second = self.backend.materialize_step_output(source, self.resolved)
+            self.assertEqual(second["path"], first["path"])
+            self.assertFalse(second["materialized"])
+            self.assertEqual(len(calls), 1)
+
+            self._write("box.step.py", "def gen_step():\n    return 'changed'\n")
+            third = self.backend.materialize_step_output(source, self.resolved)
+            self.assertTrue(third["materialized"])
+            self.assertNotEqual(third["path"], first["path"])
+            self.assertEqual(len(calls), 2)
+            # The stale cache entry is pruned once the new export lands.
+            self.assertFalse(os.path.exists(first["path"]))
+        finally:
+            backend_mod.cadgen_bridge.run_cadgen = original
+
+    def test_outside_root_rejected(self):
+        with tempfile.TemporaryDirectory() as other:
+            step = os.path.join(os.path.realpath(other), "part.step")
+            with open(step, "w", encoding="utf-8") as handle:
+                handle.write("ISO-10303-21;\n")
+            with self.assertRaises(ValueError):
+                self.backend.materialize_step_output(step, self.resolved)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -309,6 +309,11 @@ import {
   requestStepExport,
   stepExportFormatLabel
 } from "@/workbench/stepExport";
+import {
+  fetchOpenInTargets,
+  openInBusyKey,
+  requestOpenInApp
+} from "@/workbench/openInApps";
 
 const DEFAULT_DOCUMENT_TITLE = "CAD Viewer";
 // Single user-facing label for "the viewer is (re)generating the render artifacts a STEP model
@@ -1159,6 +1164,7 @@ export default function CadWorkspace({
   const [stepUpdateInProgress, setStepUpdateInProgress] = useState(false);
   const [screenshotStatus, setScreenshotStatus] = useState("");
   const [fileAccessBusyKey, setFileAccessBusyKey] = useState("");
+  const [openInTargets, setOpenInTargets] = useState([]);
   const [persistenceStatus, setPersistenceStatus] = useState("");
   const [motionErrorStatus, setMotionErrorStatus] = useState("");
   const [moveit2ServerLive, setMoveIt2ServerLive] = useState(false);
@@ -1705,6 +1711,30 @@ export default function CadWorkspace({
       }
     });
   }, [directoryAutoEnterDir]);
+
+  useEffect(() => {
+    // Local backend only: which desktop CAD apps can /__cad/open-in launch.
+    // Older servers without the route yield [] (menu section stays hidden).
+    if (typeof window === "undefined" || !fileRevealAvailable) {
+      setOpenInTargets([]);
+      return undefined;
+    }
+    const controller = new AbortController();
+    let active = true;
+    fetchOpenInTargets({ signal: controller.signal }).then((targets) => {
+      if (active) {
+        setOpenInTargets(targets);
+      }
+    }).catch(() => {
+      if (active) {
+        setOpenInTargets([]);
+      }
+    });
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [fileRevealAvailable]);
 
   useEffect(() => {
     let active = true;
@@ -8161,6 +8191,30 @@ export default function CadWorkspace({
     }
   }, []);
 
+  const handleOpenInApp = useCallback(async (entry, target) => {
+    const fileRef = entry ? fileKey(entry) : "";
+    const appId = String(target?.id || "").trim();
+    const appName = String(target?.name || "").trim() || appId;
+    if (!fileRef || !appId || typeof window === "undefined") {
+      return;
+    }
+    const busyKey = openInBusyKey(fileRef, appId);
+    setCopyStatus("");
+    setScreenshotStatus("");
+    setFileAccessBusyKey(busyKey);
+    try {
+      // Generated models may need a STEP export first (seconds to ~30s+).
+      setCopyStatus(`Opening in ${appName}...`);
+      const payload = await requestOpenInApp({ file: fileRef, app: appId });
+      const filename = String(payload?.filename || "").trim();
+      setCopyStatus(filename ? `Opened ${filename} in ${appName}` : `Opened in ${appName}`);
+    } catch (error) {
+      setCopyStatus(error instanceof Error ? error.message : `Failed to open in ${appName}`);
+    } finally {
+      setFileAccessBusyKey((current) => (current === busyKey ? "" : current));
+    }
+  }, []);
+
   const handleDrawingStrokesChange = useCallback((nextStrokes) => {
     const normalized = cloneDrawingStrokes(nextStrokes);
     const current = drawingStrokesRef.current;
@@ -8585,9 +8639,11 @@ export default function CadWorkspace({
           canCopyFileAssetLinks={fileLinkCopyAvailable}
           canCopyFileAssetPaths={filePathCopyAvailable}
           fileAccessBusyKey={fileAccessBusyKey}
+          openInTargets={openInTargets}
           onDownloadFileAsset={handleDownloadFileAsset}
           onExportImplicitFile={handleExportImplicitFile}
           onExportStepFile={handleExportStepFile}
+          onOpenInApp={handleOpenInApp}
           onRevealFileAsset={handleRevealFileAsset}
           onRevealInExplorerView={handleRevealEntryInExplorerView}
           onCopyFileAssetReference={handleCopyFileAssetReference}
@@ -8625,9 +8681,11 @@ export default function CadWorkspace({
               canCopyFileAssetLinks={fileLinkCopyAvailable}
               canCopyFileAssetPaths={filePathCopyAvailable}
               fileAccessBusyKey={fileAccessBusyKey}
+              openInTargets={openInTargets}
               onDownloadFileAsset={handleDownloadFileAsset}
               onExportImplicitFile={handleExportImplicitFile}
               onExportStepFile={handleExportStepFile}
+              onOpenInApp={handleOpenInApp}
               onRevealFileAsset={handleRevealFileAsset}
               onRevealInExplorerView={handleRevealEntryInExplorerView}
               onCopyFileAssetReference={handleCopyFileAssetReference}

--- a/viewer/src/client/components/ui/context-menu.jsx
+++ b/viewer/src/client/components/ui/context-menu.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { ChevronRight } from "lucide-react";
 import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
 
 import { cn } from "@/ui/utils";
@@ -87,11 +88,61 @@ function ContextMenuSeparator({
   );
 }
 
+function ContextMenuSub({
+  ...props
+}) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />;
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  showChevron = true,
+  ...props
+}) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showChevron ? <ChevronRight className="ml-auto size-4" /> : null}
+    </ContextMenuPrimitive.SubTrigger>
+  );
+}
+
+function ContextMenuSubContent({
+  className,
+  ...props
+}) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.SubContent
+        data-slot="context-menu-sub-content"
+        className={cn(
+          "cad-glass-popover z-50 min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg animate-in fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
 export {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuLabel,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 };

--- a/viewer/src/client/components/workbench/CadWorkspaceTopBar.js
+++ b/viewer/src/client/components/workbench/CadWorkspaceTopBar.js
@@ -225,9 +225,11 @@ function BreadcrumbDirectoryMenuItems({
   canCopyFileAssetLinks = false,
   canCopyFileAssetPaths = false,
   fileAccessBusyKey = "",
+  openInTargets = [],
   onDownloadFileAsset,
   onExportImplicitFile,
   onExportStepFile,
+  onOpenInApp,
   onRevealFileAsset,
   onCopyFileAssetReference
 }) {
@@ -262,9 +264,11 @@ function BreadcrumbDirectoryMenuItems({
           canCopyFileAssetLinks={canCopyFileAssetLinks}
           canCopyFileAssetPaths={canCopyFileAssetPaths}
           fileAccessBusyKey={fileAccessBusyKey}
+          openInTargets={openInTargets}
           onDownloadFileAsset={onDownloadFileAsset}
           onExportImplicitFile={onExportImplicitFile}
           onExportStepFile={onExportStepFile}
+          onOpenInApp={onOpenInApp}
           onRevealFileAsset={onRevealFileAsset}
           onCopyFileAssetReference={onCopyFileAssetReference}
         />
@@ -289,9 +293,11 @@ function BreadcrumbDirectoryMenuItems({
         canCopyFileAssetLinks={canCopyFileAssetLinks}
         canCopyFileAssetPaths={canCopyFileAssetPaths}
         fileAccessBusyKey={fileAccessBusyKey}
+        openInTargets={openInTargets}
         onDownloadFileAsset={onDownloadFileAsset}
         onExportImplicitFile={onExportImplicitFile}
         onExportStepFile={onExportStepFile}
+        onOpenInApp={onOpenInApp}
         onRevealFileAsset={onRevealFileAsset}
         onCopyFileAssetReference={onCopyFileAssetReference}
       />
@@ -329,9 +335,11 @@ function BreadcrumbDirectorySubMenu({
   canCopyFileAssetLinks = false,
   canCopyFileAssetPaths = false,
   fileAccessBusyKey = "",
+  openInTargets = [],
   onDownloadFileAsset,
   onExportImplicitFile,
   onExportStepFile,
+  onOpenInApp,
   onRevealFileAsset,
   onCopyFileAssetReference
 }) {
@@ -365,9 +373,11 @@ function BreadcrumbDirectorySubMenu({
             canCopyFileAssetLinks={canCopyFileAssetLinks}
             canCopyFileAssetPaths={canCopyFileAssetPaths}
             fileAccessBusyKey={fileAccessBusyKey}
+            openInTargets={openInTargets}
             onDownloadFileAsset={onDownloadFileAsset}
             onExportImplicitFile={onExportImplicitFile}
             onExportStepFile={onExportStepFile}
+            onOpenInApp={onOpenInApp}
             onRevealFileAsset={onRevealFileAsset}
             onCopyFileAssetReference={onCopyFileAssetReference}
           />
@@ -395,9 +405,11 @@ function BreadcrumbNodeDropdown({
   canCopyFileAssetLinks = false,
   canCopyFileAssetPaths = false,
   fileAccessBusyKey = "",
+  openInTargets = [],
   onDownloadFileAsset,
   onExportImplicitFile,
   onExportStepFile,
+  onOpenInApp,
   onRevealFileAsset,
   onRevealInExplorerView,
   onCopyFileAssetReference,
@@ -438,9 +450,11 @@ function BreadcrumbNodeDropdown({
         canCopyFileAssetLinks={canCopyFileAssetLinks}
         canCopyFileAssetPaths={canCopyFileAssetPaths}
         busyKey={fileAccessBusyKey}
+        openInTargets={openInTargets}
         onDownloadFileAsset={onDownloadFileAsset}
         onExportImplicitFile={onExportImplicitFile}
         onExportStepFile={onExportStepFile}
+        onOpenInApp={onOpenInApp}
         onRevealFileAsset={onRevealFileAsset}
         onRevealInExplorerView={onRevealInExplorerView}
         onCopyFileAssetReference={onCopyFileAssetReference}
@@ -487,9 +501,11 @@ function BreadcrumbNodeDropdown({
       canCopyFileAssetLinks={canCopyFileAssetLinks}
       canCopyFileAssetPaths={canCopyFileAssetPaths}
       busyKey={fileAccessBusyKey}
+      openInTargets={openInTargets}
       onDownloadFileAsset={onDownloadFileAsset}
       onExportImplicitFile={onExportImplicitFile}
       onExportStepFile={onExportStepFile}
+      onOpenInApp={onOpenInApp}
       onRevealFileAsset={onRevealFileAsset}
       onRevealInExplorerView={onRevealInExplorerView}
       onCopyFileAssetReference={onCopyFileAssetReference}
@@ -519,9 +535,11 @@ function BreadcrumbNodeDropdown({
             canCopyFileAssetLinks={canCopyFileAssetLinks}
             canCopyFileAssetPaths={canCopyFileAssetPaths}
             fileAccessBusyKey={fileAccessBusyKey}
+            openInTargets={openInTargets}
             onDownloadFileAsset={onDownloadFileAsset}
             onExportImplicitFile={onExportImplicitFile}
             onExportStepFile={onExportStepFile}
+            onOpenInApp={onOpenInApp}
             onRevealFileAsset={onRevealFileAsset}
             onCopyFileAssetReference={onCopyFileAssetReference}
           />
@@ -547,9 +565,11 @@ function BreadcrumbEllipsisDropdown({
   canCopyFileAssetLinks = false,
   canCopyFileAssetPaths = false,
   fileAccessBusyKey = "",
+  openInTargets = [],
   onDownloadFileAsset,
   onExportImplicitFile,
   onExportStepFile,
+  onOpenInApp,
   onRevealFileAsset,
   onCopyFileAssetReference,
   title
@@ -594,9 +614,11 @@ function BreadcrumbEllipsisDropdown({
                   canCopyFileAssetLinks={canCopyFileAssetLinks}
                   canCopyFileAssetPaths={canCopyFileAssetPaths}
                   fileAccessBusyKey={fileAccessBusyKey}
+                  openInTargets={openInTargets}
                   onDownloadFileAsset={onDownloadFileAsset}
                   onExportImplicitFile={onExportImplicitFile}
                   onExportStepFile={onExportStepFile}
+                  onOpenInApp={onOpenInApp}
                   onRevealFileAsset={onRevealFileAsset}
                   onCopyFileAssetReference={onCopyFileAssetReference}
                 />
@@ -622,9 +644,11 @@ function BreadcrumbEllipsisDropdown({
                   canCopyFileAssetLinks={canCopyFileAssetLinks}
                   canCopyFileAssetPaths={canCopyFileAssetPaths}
                   fileAccessBusyKey={fileAccessBusyKey}
+                  openInTargets={openInTargets}
                   onDownloadFileAsset={onDownloadFileAsset}
                   onExportImplicitFile={onExportImplicitFile}
                   onExportStepFile={onExportStepFile}
+                  onOpenInApp={onOpenInApp}
                   onRevealFileAsset={onRevealFileAsset}
                   onCopyFileAssetReference={onCopyFileAssetReference}
                 />
@@ -1070,9 +1094,11 @@ export default function CadWorkspaceTopBar({
   canCopyFileAssetLinks = false,
   canCopyFileAssetPaths = false,
   fileAccessBusyKey = "",
+  openInTargets = [],
   onDownloadFileAsset,
   onExportImplicitFile,
   onExportStepFile,
+  onOpenInApp,
   onRevealFileAsset,
   onRevealInExplorerView,
   onCopyFileAssetReference,
@@ -1170,9 +1196,11 @@ export default function CadWorkspaceTopBar({
                   canCopyFileAssetLinks={canCopyFileAssetLinks}
                   canCopyFileAssetPaths={canCopyFileAssetPaths}
                   fileAccessBusyKey={fileAccessBusyKey}
+                  openInTargets={openInTargets}
                   onDownloadFileAsset={onDownloadFileAsset}
                   onExportImplicitFile={onExportImplicitFile}
                   onExportStepFile={onExportStepFile}
+                  onOpenInApp={onOpenInApp}
                   onRevealFileAsset={onRevealFileAsset}
                   onRevealInExplorerView={onRevealInExplorerView}
                   onCopyFileAssetReference={onCopyFileAssetReference}
@@ -1202,9 +1230,11 @@ export default function CadWorkspaceTopBar({
                       canCopyFileAssetLinks={canCopyFileAssetLinks}
                       canCopyFileAssetPaths={canCopyFileAssetPaths}
                       fileAccessBusyKey={fileAccessBusyKey}
+                      openInTargets={openInTargets}
                       onDownloadFileAsset={onDownloadFileAsset}
                       onExportImplicitFile={onExportImplicitFile}
                       onExportStepFile={onExportStepFile}
+                      onOpenInApp={onOpenInApp}
                       onRevealFileAsset={onRevealFileAsset}
                       onCopyFileAssetReference={onCopyFileAssetReference}
                       title={selectedFileTitle}
@@ -1228,9 +1258,11 @@ export default function CadWorkspaceTopBar({
                       canCopyFileAssetLinks={canCopyFileAssetLinks}
                       canCopyFileAssetPaths={canCopyFileAssetPaths}
                       fileAccessBusyKey={fileAccessBusyKey}
+                      openInTargets={openInTargets}
                       onDownloadFileAsset={onDownloadFileAsset}
                       onExportImplicitFile={onExportImplicitFile}
                       onExportStepFile={onExportStepFile}
+                      onOpenInApp={onOpenInApp}
                       onRevealFileAsset={onRevealFileAsset}
                       onRevealInExplorerView={onRevealInExplorerView}
                       onCopyFileAssetReference={onCopyFileAssetReference}

--- a/viewer/src/client/components/workbench/FileAccessContextMenu.jsx
+++ b/viewer/src/client/components/workbench/FileAccessContextMenu.jsx
@@ -3,16 +3,64 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger
 } from "@/components/ui/context-menu";
 import { fileAccessAssetsForEntry } from "@/workbench/fileAccessAssets";
 import { IMPLICIT_EXPORT_FORMATS } from "@/workbench/implicitExport";
+import { openInBusyKey } from "@/workbench/openInApps";
 import { STEP_EXPORT_FORMATS, isImportedStepEntry, stepExportItemLabel } from "@/workbench/stepExport";
 
 // Entries whose geometry can be exported to STEP/3MF/STL/GLB via the server export endpoint.
 function isStepExportEntry(entry) {
   const kind = String(entry?.kind || "").trim().toLowerCase();
   return kind === "step" || kind === "assembly";
+}
+
+function OpenInSection({
+  entry,
+  openInTargets = [],
+  busyKey = "",
+  onOpenInApp
+}) {
+  if (
+    typeof onOpenInApp !== "function" ||
+    !isStepExportEntry(entry) ||
+    !Array.isArray(openInTargets) ||
+    !openInTargets.length
+  ) {
+    return null;
+  }
+  const fileRef = String(entry?.file || entry?.id || "").trim();
+  return (
+    <>
+      <ContextMenuSub>
+        <ContextMenuSubTrigger className="text-xs">
+          <span className="min-w-0 truncate">Open in</span>
+        </ContextMenuSubTrigger>
+        <ContextMenuSubContent className="w-52">
+          {openInTargets.map((target) => (
+            <ContextMenuItem
+              key={target.id}
+              className="text-xs"
+              disabled={!target.installed || busyKey === openInBusyKey(fileRef, target.id)}
+              onSelect={() => {
+                onOpenInApp(entry, target);
+              }}
+            >
+              <span className="min-w-0 truncate">{target.name}</span>
+              {!target.installed ? (
+                <span className="ml-auto text-[10px] text-muted-foreground">Not installed</span>
+              ) : null}
+            </ContextMenuItem>
+          ))}
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+      <ContextMenuSeparator />
+    </>
+  );
 }
 
 function ExplorerViewSection({
@@ -178,9 +226,11 @@ export default function FileAccessContextMenu({
   canCopyFileAssetLinks = false,
   canCopyFileAssetPaths = false,
   busyKey = "",
+  openInTargets = [],
   onDownloadFileAsset,
   onExportImplicitFile,
   onExportStepFile,
+  onOpenInApp,
   onRevealFileAsset,
   onRevealInExplorerView,
   onCopyFileAssetReference,
@@ -191,12 +241,14 @@ export default function FileAccessContextMenu({
   const implicitExportAvailable = entry && typeof onExportImplicitFile === "function" &&
     String(entry?.kind || "").trim().toLowerCase() === "implicit";
   const stepExportAvailable = entry && typeof onExportStepFile === "function" && isStepExportEntry(entry);
-  if (!revealInExplorerViewAvailable && !assetActionsAvailable && !implicitExportAvailable && !stepExportAvailable) {
+  const openInAvailable = entry && typeof onOpenInApp === "function" && isStepExportEntry(entry) &&
+    Array.isArray(openInTargets) && openInTargets.length > 0;
+  if (!revealInExplorerViewAvailable && !assetActionsAvailable && !implicitExportAvailable && !stepExportAvailable && !openInAvailable) {
     return children;
   }
 
   const assets = fileAccessAssetsForEntry(entry);
-  if (!revealInExplorerViewAvailable && !assets.output && !implicitExportAvailable && !stepExportAvailable) {
+  if (!revealInExplorerViewAvailable && !assets.output && !implicitExportAvailable && !stepExportAvailable && !openInAvailable) {
     return children;
   }
 
@@ -206,6 +258,12 @@ export default function FileAccessContextMenu({
         {children}
       </ContextMenuTrigger>
       <ContextMenuContent className="w-64">
+        <OpenInSection
+          entry={entry}
+          openInTargets={openInTargets}
+          busyKey={busyKey}
+          onOpenInApp={onOpenInApp}
+        />
         {!assets.output || !assetActionsAvailable ? (
           <ExplorerViewSection
             entry={entry}

--- a/viewer/src/client/components/workbench/FileViewerSidebar.js
+++ b/viewer/src/client/components/workbench/FileViewerSidebar.js
@@ -102,9 +102,11 @@ function FileEntryButton({
   canCopyFileAssetLinks = false,
   canCopyFileAssetPaths = false,
   fileAccessBusyKey = "",
+  openInTargets = [],
   onDownloadFileAsset,
   onExportImplicitFile,
   onExportStepFile,
+  onOpenInApp,
   onRevealFileAsset,
   onRevealInExplorerView,
   onCopyFileAssetReference,
@@ -184,9 +186,11 @@ function FileEntryButton({
       canCopyFileAssetLinks={canCopyFileAssetLinks}
       canCopyFileAssetPaths={canCopyFileAssetPaths}
       busyKey={fileAccessBusyKey}
+      openInTargets={openInTargets}
       onDownloadFileAsset={onDownloadFileAsset}
       onExportImplicitFile={onExportImplicitFile}
       onExportStepFile={onExportStepFile}
+      onOpenInApp={onOpenInApp}
       onRevealFileAsset={onRevealFileAsset}
       onRevealInExplorerView={onRevealInExplorerView}
       onCopyFileAssetReference={onCopyFileAssetReference}
@@ -216,9 +220,11 @@ function DirectoryNode({
   canCopyFileAssetLinks = false,
   canCopyFileAssetPaths = false,
   fileAccessBusyKey = "",
+  openInTargets = [],
   onDownloadFileAsset,
   onExportImplicitFile,
   onExportStepFile,
+  onOpenInApp,
   onRevealFileAsset,
   onRevealInExplorerView,
   onCopyFileAssetReference,
@@ -285,9 +291,11 @@ function DirectoryNode({
                     canCopyFileAssetLinks={canCopyFileAssetLinks}
                     canCopyFileAssetPaths={canCopyFileAssetPaths}
                     fileAccessBusyKey={fileAccessBusyKey}
+                    openInTargets={openInTargets}
                     onDownloadFileAsset={onDownloadFileAsset}
                     onExportImplicitFile={onExportImplicitFile}
                     onExportStepFile={onExportStepFile}
+                    onOpenInApp={onOpenInApp}
                     onRevealFileAsset={onRevealFileAsset}
                     onRevealInExplorerView={onRevealInExplorerView}
                     onCopyFileAssetReference={onCopyFileAssetReference}
@@ -314,9 +322,11 @@ function DirectoryNode({
                     canCopyFileAssetLinks={canCopyFileAssetLinks}
                     canCopyFileAssetPaths={canCopyFileAssetPaths}
                     fileAccessBusyKey={fileAccessBusyKey}
+                    openInTargets={openInTargets}
                     onDownloadFileAsset={onDownloadFileAsset}
                     onExportImplicitFile={onExportImplicitFile}
                     onExportStepFile={onExportStepFile}
+                    onOpenInApp={onOpenInApp}
                     onRevealFileAsset={onRevealFileAsset}
                     onRevealInExplorerView={onRevealInExplorerView}
                     onCopyFileAssetReference={onCopyFileAssetReference}
@@ -477,9 +487,11 @@ function FileViewerContents({
   canCopyFileAssetLinks = false,
   canCopyFileAssetPaths = false,
   fileAccessBusyKey = "",
+  openInTargets = [],
   onDownloadFileAsset,
   onExportImplicitFile,
   onExportStepFile,
+  onOpenInApp,
   onRevealFileAsset,
   onRevealInExplorerView,
   onCopyFileAssetReference,
@@ -546,9 +558,11 @@ function FileViewerContents({
                           canCopyFileAssetLinks={canCopyFileAssetLinks}
                           canCopyFileAssetPaths={canCopyFileAssetPaths}
                           fileAccessBusyKey={fileAccessBusyKey}
+                          openInTargets={openInTargets}
                           onDownloadFileAsset={onDownloadFileAsset}
                           onExportImplicitFile={onExportImplicitFile}
                           onExportStepFile={onExportStepFile}
+                          onOpenInApp={onOpenInApp}
                           onRevealFileAsset={onRevealFileAsset}
                           onRevealInExplorerView={onRevealInExplorerView}
                           onCopyFileAssetReference={onCopyFileAssetReference}
@@ -574,9 +588,11 @@ function FileViewerContents({
                           canCopyFileAssetLinks={canCopyFileAssetLinks}
                           canCopyFileAssetPaths={canCopyFileAssetPaths}
                           fileAccessBusyKey={fileAccessBusyKey}
+                          openInTargets={openInTargets}
                           onDownloadFileAsset={onDownloadFileAsset}
                           onExportImplicitFile={onExportImplicitFile}
                           onExportStepFile={onExportStepFile}
+                          onOpenInApp={onOpenInApp}
                           onRevealFileAsset={onRevealFileAsset}
                           onRevealInExplorerView={onRevealInExplorerView}
                           onCopyFileAssetReference={onCopyFileAssetReference}
@@ -626,9 +642,11 @@ export default function FileViewerSidebar({
   canCopyFileAssetLinks = false,
   canCopyFileAssetPaths = false,
   fileAccessBusyKey = "",
+  openInTargets = [],
   onDownloadFileAsset,
   onExportImplicitFile,
   onExportStepFile,
+  onOpenInApp,
   onRevealFileAsset,
   onRevealInExplorerView,
   onCopyFileAssetReference,
@@ -670,9 +688,11 @@ export default function FileViewerSidebar({
       canCopyFileAssetLinks={canCopyFileAssetLinks}
       canCopyFileAssetPaths={canCopyFileAssetPaths}
       fileAccessBusyKey={fileAccessBusyKey}
+      openInTargets={openInTargets}
       onDownloadFileAsset={onDownloadFileAsset}
       onExportImplicitFile={onExportImplicitFile}
       onExportStepFile={onExportStepFile}
+      onOpenInApp={onOpenInApp}
       onRevealFileAsset={onRevealFileAsset}
       onRevealInExplorerView={onRevealInExplorerView}
       onCopyFileAssetReference={onCopyFileAssetReference}

--- a/viewer/src/client/workbench/openInApps.js
+++ b/viewer/src/client/workbench/openInApps.js
@@ -1,0 +1,66 @@
+// "Open in <CAD app>" client helpers: list the server-detected desktop CAD apps
+// (GET /__cad/integrations) and hand a STEP entry to one (POST /__cad/open-in).
+// The server owns the app allowlist and launch recipes; the client only ever
+// names an app id.
+
+export function normalizedOpenInTargets(payload) {
+  const targets = Array.isArray(payload?.targets) ? payload.targets : [];
+  return targets
+    .map((target) => ({
+      id: String(target?.id || "").trim(),
+      name: String(target?.name || "").trim(),
+      installed: target?.installed === true,
+    }))
+    .filter((target) => target.id && target.name);
+}
+
+export async function fetchOpenInTargets({ signal } = {}) {
+  const response = await fetch("/__cad/integrations", { cache: "no-store", signal });
+  if (!response.ok) {
+    return [];
+  }
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    return [];
+  }
+  return normalizedOpenInTargets(payload);
+}
+
+export function openInBusyKey(fileRef, appId) {
+  const ref = String(fileRef || "").trim();
+  const app = String(appId || "").trim();
+  return ref && app ? `${ref}:open-in:${app}` : "";
+}
+
+export function openInRequestUrl(fileRef, appId) {
+  return `/__cad/open-in?file=${encodeURIComponent(String(fileRef || ""))}&app=${encodeURIComponent(String(appId || ""))}`;
+}
+
+// Resolves to the server payload ({ ok, appId, appName, filename, path,
+// materialized }); throws with the server's error message on failure.
+export async function requestOpenInApp({ file, app } = {}) {
+  const fileRef = String(file || "").trim().replace(/\\/g, "/");
+  const appId = String(app || "").trim();
+  if (!fileRef) {
+    throw new Error("Missing STEP file");
+  }
+  if (!appId) {
+    throw new Error("Missing Open-in app");
+  }
+  const response = await fetch(openInRequestUrl(fileRef, appId), {
+    method: "POST",
+    cache: "no-store",
+  });
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+  if (!response.ok || !payload?.ok) {
+    throw new Error(String(payload?.error || `Open in app failed with HTTP ${response.status}`));
+  }
+  return payload;
+}

--- a/viewer/src/client/workbench/openInApps.test.js
+++ b/viewer/src/client/workbench/openInApps.test.js
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import {
+  fetchOpenInTargets,
+  normalizedOpenInTargets,
+  openInBusyKey,
+  openInRequestUrl,
+  requestOpenInApp
+} from "./openInApps.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function jsonResponse(payload, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    json: async () => payload,
+  };
+}
+
+test("normalizedOpenInTargets keeps only well-formed targets", () => {
+  const targets = normalizedOpenInTargets({
+    targets: [
+      { id: "freecad", name: "FreeCAD", installed: true },
+      { id: "fusion360", name: "Autodesk Fusion", installed: "yes" },
+      { id: "", name: "Nameless" },
+      { name: "No id" },
+      null,
+    ],
+  });
+  assert.deepEqual(targets, [
+    { id: "freecad", name: "FreeCAD", installed: true },
+    { id: "fusion360", name: "Autodesk Fusion", installed: false },
+  ]);
+});
+
+test("normalizedOpenInTargets tolerates malformed payloads", () => {
+  assert.deepEqual(normalizedOpenInTargets(null), []);
+  assert.deepEqual(normalizedOpenInTargets({ targets: "nope" }), []);
+});
+
+test("openInBusyKey needs both parts", () => {
+  assert.equal(openInBusyKey("/models/part.step", "freecad"), "/models/part.step:open-in:freecad");
+  assert.equal(openInBusyKey("", "freecad"), "");
+  assert.equal(openInBusyKey("/models/part.step", ""), "");
+});
+
+test("openInRequestUrl encodes both params", () => {
+  assert.equal(
+    openInRequestUrl("/models/my part.step", "system-default"),
+    "/__cad/open-in?file=%2Fmodels%2Fmy%20part.step&app=system-default"
+  );
+});
+
+test("fetchOpenInTargets returns [] on HTTP failure (older servers)", async () => {
+  globalThis.fetch = async () => jsonResponse({}, { ok: false, status: 405 });
+  assert.deepEqual(await fetchOpenInTargets(), []);
+});
+
+test("fetchOpenInTargets normalizes the server payload", async () => {
+  globalThis.fetch = async () => jsonResponse({
+    ok: true,
+    targets: [{ id: "freecad", name: "FreeCAD", installed: true }],
+  });
+  assert.deepEqual(await fetchOpenInTargets(), [
+    { id: "freecad", name: "FreeCAD", installed: true },
+  ]);
+});
+
+test("requestOpenInApp posts and returns the payload", async () => {
+  const requests = [];
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url, options });
+    return jsonResponse({ ok: true, appId: "freecad", appName: "FreeCAD", filename: "part.step" });
+  };
+  const payload = await requestOpenInApp({ file: "/models/part.step", app: "freecad" });
+  assert.equal(payload.appName, "FreeCAD");
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].options.method, "POST");
+  assert.equal(requests[0].url, "/__cad/open-in?file=%2Fmodels%2Fpart.step&app=freecad");
+});
+
+test("requestOpenInApp surfaces the server error message", async () => {
+  globalThis.fetch = async () => jsonResponse({ ok: false, error: "FreeCAD is not installed" }, { ok: false, status: 400 });
+  await assert.rejects(
+    requestOpenInApp({ file: "/models/part.step", app: "freecad" }),
+    /FreeCAD is not installed/
+  );
+});
+
+test("requestOpenInApp validates its inputs before fetching", async () => {
+  globalThis.fetch = async () => {
+    throw new Error("should not fetch");
+  };
+  await assert.rejects(requestOpenInApp({ file: "", app: "freecad" }), /Missing STEP file/);
+  await assert.rejects(requestOpenInApp({ file: "/models/part.step", app: "" }), /Missing Open-in app/);
+});


### PR DESCRIPTION
## Summary
- New "Open in" submenu on STEP/assembly file context menus that hands the model to a locally installed desktop CAD app (FreeCAD, Autodesk Fusion, Rhino 8, Shapr3D, Plasticity, eDrawings, CAD Assistant, SOLIDWORKS on Windows, System Default), backed by new server_py routes GET /__cad/integrations and POST /__cad/open-in.
- Reimplements POST /__cad/reveal in server_py, fixing a live 405 regression (the 0.4.0 client's "Reveal in Folder" had no server route since the Node backend was deleted).
- Generated models with no .step on disk materialize one on demand via cadgen.step_export_target, cached by source-content hash under the gitignored __cadgen__ package dir so repeated opens skip the gen_step re-run; unhydrated Git LFS pointers are rejected with a git lfs checkout hint.
- App detection and launch recipes are server-side only (stdlib path/registry probes, allowlisted argv exec, no shell) -- the client only ever sends an appId. Both new local-action POST routes require loopback Host and Origin (hostname-only, so the Vite dev proxy's verbatim-forwarded headers still pass), blocking cross-site form posts, Origin: null sandboxed iframes, and DNS rebinding.
- Cloud integrations (Onshape, 3dviewer.net) are intentionally out of scope for this PR.

## Test plan
- [x] python3 -m unittest discover -s viewer/server_py/tests -t viewer -- 85 pass (incl. 31 new: app detection/launch-recipe unit tests + a live ThreadingHTTPServer HTTP route harness, the first for server_py)
- [x] node viewer/scripts/run-tests.mjs -- 257 pass (incl. 9 new client helper tests)
- [x] npm --prefix viewer run build -- clean
- [x] scripts/bundle/bundle.sh pre-commit check -- passed
- [x] Manual end-to-end against a live server: /__cad/integrations detection JSON, /__cad/open-in launch command construction, 403 on foreign Origin/Host, clean error for a not-installed app, /__cad/reveal happy path
- [ ] Not verified on a machine with real CAD apps installed: fusion360:// with a POSIX file path (Autodesk's documented examples all use Windows paths), and whether Shapr3D/Plasticity accept open-by-document vs. only in-app import -- both are isolated to single functions in viewer/server_py/integrations.py if a fix is needed

Generated with Claude Code
