### PR TITLE
Update python version from 3.11 to 3.12.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ git switch -c my-change
 Create the repo-local Python development environment:
 
 ```bash
-python3.11 -m venv .venv
+python3.12 -m venv .venv
 ./.venv/bin/python -m pip install --upgrade pip
 ./.venv/bin/python -m pip install -r requirements-dev.txt
 ```

--- a/packages/cadpy/pyproject.toml
+++ b/packages/cadpy/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "cadpy"
 version = "0.3.8"
 description = "Shared STEP/GLB topology artifact generation runtime for CAD skills."
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
   "build123d",
   "cadquery-ocp",

--- a/packages/cadpy_metadata/pyproject.toml
+++ b/packages/cadpy_metadata/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "cadpy-metadata"
 version = "0.3.8"
 description = "Dependency-free metadata helpers for Python-generated CAD outputs."
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = []
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
# Problem

Installing `requirements-dev.txt` using a python3.11 venv causes an error since `viewer/moveit2-server` requires python3.12

https://github.com/earthtojake/text-to-cad/blob/622c258fbdea64614056bfe33f3d3f183021a374/viewer/moveit2_server/pyproject.toml#L9

In fact, the github action already uses python 3.12.

https://github.com/earthtojake/text-to-cad/blob/622c258fbdea64614056bfe33f3d3f183021a374/.github/actions/setup-deps/action.yml#L12

## Steps to reproduce error

Following the CONTRIBUTING.md guidelines
```
uv venv --python 3.11
source .venv/bin/activate
uv pip install -r requirements-dev.txt
```
produces the error:
```
  × No solution found when resolving dependencies:
  ╰─▶ Because the current Python version (3.11.14) does not satisfy Python>=3.12 and moveit2-server==0.3.8
      depends on Python>=3.12, we can conclude that moveit2-server==0.3.8 cannot be used.
      And because only moveit2-server==0.3.8 is available and you require moveit2-server, we can conclude that
      your requirements are unsatisfiable.
```


# Solution

Update the contributing docs and every reference from python 3.11 to 3.12.