### PR TITLE
Viewer: require a valid CAD Python backend at startup

### DIFF
--- a/viewer/docs/backend.md
+++ b/viewer/docs/backend.md
@@ -66,6 +66,11 @@ viewer carries a generated, installable copy under `viewer/packages/cadgen`; run
 install `viewer/requirements.txt` into the Python runtime used by the viewer.
 The generated cad-viewer skill runtime bundles that same installable package
 under `scripts/viewer/packages/cadgen` and does not need the repository root.
+Before binding its HTTP port, the Viewer validates that its selected Python can
+import `OCP`, `build123d`, and `cadgen.step_artifact`. Startup fails instead of
+serving a Viewer that cannot build missing artifacts. Set
+`VIEWER_CAD_PYTHON=/absolute/path/to/python` when the CAD environment is not in
+the checkout's `.venv`.
 
 Vite dev mounts this backend for:
 

--- a/viewer/server_py/cadgen_bridge.py
+++ b/viewer/server_py/cadgen_bridge.py
@@ -25,6 +25,12 @@ _PYTHONPATH_REL_CANDIDATES = [
     os.path.join("viewer", "packages", "cadgen", "src"),
     os.path.join("packages", "cadgen", "src"),
 ]
+_CAD_BACKEND_PROBE = (
+    "import OCP\n"
+    "import build123d\n"
+    "import cadgen.step_artifact\n"
+)
+_CAD_BACKEND_PROBE_TIMEOUT_SECONDS = 30
 
 
 def _find_up_dir(rel: str, start: str) -> str:
@@ -59,6 +65,57 @@ def cadgen_pythonpath(repo_root: str) -> str:
             seen.add(entry)
             deduped.append(entry)
     return os.pathsep.join(deduped)
+
+
+def probe_cadgen_runtime(repo_root: str) -> dict:
+    """Validate the current interpreter in an isolated child process.
+
+    The long-lived HTTP server intentionally does not import OpenCascade. This
+    probe exercises the exact interpreter and PYTHONPATH that artifact workers
+    inherit, while keeping OCP out of the server process itself.
+    """
+    env = dict(os.environ)
+    pythonpath = cadgen_pythonpath(repo_root)
+    if pythonpath:
+        env["PYTHONPATH"] = pythonpath
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", _CAD_BACKEND_PROBE],
+            cwd=repo_root if repo_root and os.path.isdir(repo_root) else None,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=_CAD_BACKEND_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "python": sys.executable,
+            "error": f"CAD backend validation timed out after {_CAD_BACKEND_PROBE_TIMEOUT_SECONDS}s.",
+        }
+    except OSError as exc:
+        return {"ok": False, "python": sys.executable, "error": str(exc)}
+    if proc.returncode == 0:
+        return {"ok": True, "python": sys.executable, "error": ""}
+    detail = (proc.stderr or proc.stdout or f"probe exited with code {proc.returncode}").strip()
+    if len(detail) > 4000:
+        detail = detail[-4000:]
+    return {"ok": False, "python": sys.executable, "error": detail}
+
+
+def require_cadgen_runtime(repo_root: str) -> dict:
+    result = probe_cadgen_runtime(repo_root)
+    if result.get("ok"):
+        return result
+    python = result.get("python") or sys.executable
+    detail = result.get("error") or "Unknown CAD backend validation error."
+    raise RuntimeError(
+        "CAD Viewer requires a working CAD Python backend before startup.\n"
+        f"Selected interpreter: {python}\n"
+        "Required imports: OCP, build123d, cadgen.step_artifact\n"
+        f"{detail}\n"
+        "Set VIEWER_CAD_PYTHON to an absolute Python path with the viewer CAD requirements installed."
+    )
 
 
 def run_cadgen(module: str, args, repo_root: str) -> dict:

--- a/viewer/server_py/server.py
+++ b/viewer/server_py/server.py
@@ -29,11 +29,13 @@ from urllib.parse import urlsplit, parse_qs, unquote
 if __package__ in (None, ""):
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from server_py import backend as backend_mod
+    from server_py import cadgen_bridge
     from server_py import server_info as server_info_mod
     from server_py import encoding as enc
     from server_py.content_types import content_type_for_static_asset
 else:
     from . import backend as backend_mod
+    from . import cadgen_bridge
     from . import server_info as server_info_mod
     from . import encoding as enc
     from .content_types import content_type_for_static_asset
@@ -360,6 +362,15 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     directory_root = os.path.abspath(args.dir or os.getcwd())
+    if not os.path.isdir(directory_root):
+        print(f"--dir is not a directory: {directory_root}", file=sys.stderr)
+        return 1
+    if os.environ.get("VIEWER_CAD_BACKEND_VALIDATED") != "1":
+        try:
+            cadgen_bridge.require_cadgen_runtime(directory_root)
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
     _Ctx.directory_root = directory_root
     # viewer app root is the parent of this server_py package -> dist is <viewer>/dist.
     viewer_app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -374,7 +385,8 @@ def main(argv=None):
         httpd.serve_forever()
     except KeyboardInterrupt:
         httpd.shutdown()
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/viewer/server_py/start_viewer.py
+++ b/viewer/server_py/start_viewer.py
@@ -25,9 +25,11 @@ import sys
 
 if __package__ in (None, ""):
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from server_py import cadgen_bridge
     from server_py.encoding import url_search_params_encode
     from server_py.server_info import DEFAULT_VIEWER_PORT, DEFAULT_VIEWER_HOST
 else:
+    from . import cadgen_bridge
     from .encoding import url_search_params_encode
     from .server_info import DEFAULT_VIEWER_PORT, DEFAULT_VIEWER_HOST
 
@@ -56,6 +58,7 @@ def spawn_backend(host: str, port: int, directory: str):
     """Spawn the Python backend (serves the built dist + /__cad) on host:port."""
     env = dict(os.environ)
     env["PYTHONPATH"] = os.pathsep.join([_VIEWER_APP_ROOT, env.get("PYTHONPATH", "")]).rstrip(os.pathsep)
+    env["VIEWER_CAD_BACKEND_VALIDATED"] = "1"
     cmd = [sys.executable, "-m", "server_py.server", "--host", host, "--port", str(port), "--dir", os.path.abspath(directory)]
     return subprocess.Popen(cmd, env=env)
 
@@ -81,6 +84,12 @@ def main(argv=None):
             f"Rerun with --port <n> to use a different port.",
             file=sys.stderr,
         )
+        return 1
+
+    try:
+        cadgen_bridge.require_cadgen_runtime(directory)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
         return 1
 
     url = viewer_url(host, port, directory)

--- a/viewer/server_py/tests/test_export.py
+++ b/viewer/server_py/tests/test_export.py
@@ -2,8 +2,10 @@
 
 import os
 import pathlib
+import subprocess
 import sys
 import unittest
+from unittest import mock
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 
@@ -44,6 +46,25 @@ class CadpyPythonpath(unittest.TestCase):
             self.skipTest("packages/cadgen/src not present")
         pp = cadgen_bridge.cadgen_pythonpath(str(_WORKTREE))
         self.assertIn(os.path.join("packages", "cadgen", "src"), pp)
+
+    def test_cadgen_runtime_probe_checks_required_imports(self):
+        completed = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with mock.patch.object(cadgen_bridge.subprocess, "run", return_value=completed) as run:
+            result = cadgen_bridge.probe_cadgen_runtime(str(_WORKTREE))
+        self.assertTrue(result["ok"])
+        command = run.call_args.args[0]
+        self.assertEqual(command[:2], [sys.executable, "-c"])
+        self.assertIn("import OCP", command[2])
+        self.assertIn("import build123d", command[2])
+        self.assertIn("import cadgen.step_artifact", command[2])
+
+    def test_cadgen_runtime_probe_preserves_import_failure(self):
+        completed = subprocess.CompletedProcess(
+            [], 1, stdout="", stderr="ModuleNotFoundError: No module named 'OCP'"
+        )
+        with mock.patch.object(cadgen_bridge.subprocess, "run", return_value=completed):
+            with self.assertRaisesRegex(RuntimeError, "No module named 'OCP'"):
+                cadgen_bridge.require_cadgen_runtime(str(_WORKTREE))
 
 
 if __name__ == "__main__":

--- a/viewer/server_py/tests/test_server_startup.py
+++ b/viewer/server_py/tests/test_server_startup.py
@@ -1,0 +1,52 @@
+"""Startup invariants for the runnable Python CAD Viewer backend."""
+
+import contextlib
+import io
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from server_py import server  # noqa: E402
+
+
+class ServerStartupTest(unittest.TestCase):
+    def test_invalid_cad_runtime_exits_before_binding(self):
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch.dict("os.environ", {"VIEWER_CAD_BACKEND_VALIDATED": ""}, clear=False), \
+                mock.patch.object(
+                    server.cadgen_bridge,
+                    "require_cadgen_runtime",
+                    side_effect=RuntimeError("No module named 'OCP'"),
+                ), \
+                mock.patch.object(server, "ThreadingHTTPServer") as http_server, \
+                contextlib.redirect_stderr(io.StringIO()) as stderr:
+            rc = server.main(["--dir", directory, "--port", "4321"])
+
+        self.assertEqual(rc, 1)
+        self.assertIn("No module named 'OCP'", stderr.getvalue())
+        http_server.assert_not_called()
+
+    def test_valid_cad_runtime_binds_after_probe(self):
+        with tempfile.TemporaryDirectory() as directory, \
+                mock.patch.dict("os.environ", {"VIEWER_CAD_BACKEND_VALIDATED": ""}, clear=False), \
+                mock.patch.object(
+                    server.cadgen_bridge,
+                    "require_cadgen_runtime",
+                    return_value={"ok": True},
+                ) as require_runtime, \
+                mock.patch.object(server, "ThreadingHTTPServer") as http_server, \
+                contextlib.redirect_stdout(io.StringIO()):
+            rc = server.main(["--dir", directory, "--port", "4321"])
+
+        self.assertEqual(rc, 0)
+        require_runtime.assert_called_once_with(directory)
+        http_server.assert_called_once()
+        http_server.return_value.serve_forever.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/server_py/tests/test_start_viewer.py
+++ b/viewer/server_py/tests/test_start_viewer.py
@@ -29,7 +29,7 @@ class _FakeChild:
 
 
 @contextlib.contextmanager
-def _run(argv, port_free=True, child_code=0):
+def _run(argv, port_free=True, child_code=0, cad_backend_error=""):
     """Run main() with the port probe + backend spawn stubbed; yield
     (rc, out, err, calls)."""
     calls = {"spawn": []}
@@ -39,8 +39,10 @@ def _run(argv, port_free=True, child_code=0):
         return _FakeChild(child_code)
 
     out, err = io.StringIO(), io.StringIO()
+    probe_effect = RuntimeError(cad_backend_error) if cad_backend_error else None
     with mock.patch.object(sav, "port_is_free", return_value=port_free), \
             mock.patch.object(sav, "spawn_backend", side_effect=fake_spawn), \
+            mock.patch.object(sav.cadgen_bridge, "require_cadgen_runtime", side_effect=probe_effect), \
             contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
         rc = sav.main(argv)
     yield rc, out.getvalue(), err.getvalue(), calls
@@ -81,6 +83,17 @@ class LauncherTest(unittest.TestCase):
     def test_start_propagates_child_exit_code(self):
         with _run(["--dir", self.directory], port_free=True, child_code=3) as (rc, out, err, calls):
             self.assertEqual(rc, 3)
+
+    def test_invalid_cad_backend_refuses_to_start(self):
+        with _run(
+            ["--dir", self.directory],
+            port_free=True,
+            cad_backend_error="No module named 'OCP'",
+        ) as (rc, out, err, calls):
+            self.assertEqual(rc, 1)
+            self.assertEqual(calls["spawn"], [])
+            self.assertNotIn("CAD Viewer URL:", out)
+            self.assertIn("No module named 'OCP'", err)
 
     def test_json_output_start(self):
         with _run(["--dir", self.directory, "--json"], port_free=True) as (rc, out, err, calls):

--- a/viewer/vite.config.mjs
+++ b/viewer/vite.config.mjs
@@ -99,21 +99,42 @@ function findFreePort() {
   });
 }
 
-function waitForPythonBackend(port, { timeoutMs = 20000 } = {}) {
+function waitForPythonBackend(port, { timeoutMs = 20000, child = null } = {}) {
   const deadline = Date.now() + timeoutMs;
   return new Promise((resolve) => {
-    const retry = () => {
-      if (Date.now() >= deadline) {
-        resolve(false);
+    let settled = false;
+    let retryTimer = null;
+    const finish = (ready) => {
+      if (settled) {
         return;
       }
-      setTimeout(attempt, 250);
+      settled = true;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+      }
+      child?.off("exit", handleChildExit);
+      resolve(ready);
+    };
+    const handleChildExit = () => finish(false);
+    child?.once("exit", handleChildExit);
+    const retry = () => {
+      if (settled) {
+        return;
+      }
+      if (Date.now() >= deadline) {
+        finish(false);
+        return;
+      }
+      retryTimer = setTimeout(attempt, 250);
     };
     const attempt = () => {
+      if (settled) {
+        return;
+      }
       const req = http.get({ host: "127.0.0.1", port, path: "/__cad/server", timeout: 500 }, (res) => {
         res.resume();
         if (res.statusCode === 200) {
-          resolve(true);
+          finish(true);
         } else {
           retry();
         }
@@ -121,9 +142,12 @@ function waitForPythonBackend(port, { timeoutMs = 20000 } = {}) {
       req.on("error", retry);
       req.on("timeout", () => {
         req.destroy();
-        retry();
       });
     };
+    if (child && child.exitCode !== null) {
+      finish(false);
+      return;
+    }
     attempt();
   });
 }
@@ -149,9 +173,13 @@ function cadViewerBackendProxyPlugin() {
       child.on("error", (error) => {
         console.error(`Failed to start Python CAD Viewer backend: ${error.message}`);
       });
-      const ready = await waitForPythonBackend(backendPort);
+      const ready = await waitForPythonBackend(backendPort, { child });
       if (!ready) {
-        console.warn("Python CAD Viewer backend did not become ready; /__cad will 502 until it does.");
+        if (child && child.exitCode === null) {
+          child.kill();
+        }
+        child = null;
+        throw new Error("Python CAD Viewer backend failed startup validation or did not become ready.");
       }
       // Forward every /__cad/* request (method + headers + body + streamed response) to Python.
       server.middlewares.use((req, res, next) => {


### PR DESCRIPTION
## Summary

- validate the selected Python runtime before the CAD Viewer binds its HTTP port
- require `OCP`, `build123d`, and `cadgen.step_artifact` to import successfully
- fail both production and Vite development startup when the CAD backend is unavailable
- document `VIEWER_CAD_PYTHON` and add startup regression coverage

## Root cause

When a worktree had no local `.venv`, the launcher could fall back to a system Python without the CAD dependencies. The frontend and catalog still started, but Python-generated STEP artifacts failed later with HTTP 500, surfacing as “No mesh data is available.”

The startup probe now exercises the exact interpreter and Python path inherited by artifact workers, so an invalid environment fails immediately with an actionable error instead of serving a partially working Viewer.

## Validation

- `python3 -m unittest discover -s viewer/server_py/tests -p 'test_*.py'` (59 passed, 1 skipped)
- `npm --prefix viewer test` (246 passed)
- `npm --prefix viewer run build`
- pre-commit bundle and generated-output checks
