### PR TITLE
Fix packaged CAD Viewer launcher

### DIFF
--- a/scripts/bundle/skills/bundle-cad-viewer.sh
+++ b/scripts/bundle/skills/bundle-cad-viewer.sh
@@ -355,6 +355,7 @@ write_runtime_package_json() {
   "type": "module",
   "version": "$RELEASE_VERSION",
   "scripts": {
+    "agent:start": "node scripts/start-agent-viewer.mjs",
     "serve": "node backend/server.mjs",
     "start": "node backend/server.mjs",
     "moveit2:setup": "moveit2_server/setup.sh",
@@ -424,7 +425,7 @@ sync_dir() {
 build_runtime() {
   local target_dir="$1"
   rm -rf "$target_dir"
-  mkdir -p "$target_dir/backend"
+  mkdir -p "$target_dir/backend" "$target_dir/scripts"
 
   sync_dir "$VIEWER_DIR/dist" "$target_dir/dist"
 
@@ -444,6 +445,15 @@ build_runtime() {
       --main-fields=module,main \
       --legal-comments=none \
       --outfile="$target_dir/backend/server.mjs"
+
+    "$(resolve_esbuild_bin)" "$VIEWER_DIR/scripts/start-agent-viewer.mjs" \
+      --bundle \
+      --format=esm \
+      --platform=node \
+      --target=node22 \
+      --main-fields=module,main \
+      --legal-comments=none \
+      --outfile="$target_dir/scripts/start-agent-viewer.mjs"
 
   )
 

--- a/tests/python/global/test_cad_viewer_runtime_contract.py
+++ b/tests/python/global/test_cad_viewer_runtime_contract.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from tests.python.support.paths import REPO_ROOT
+
+
+RUNTIME_DIR = REPO_ROOT / "skills" / "cad-viewer" / "scripts" / "viewer"
+
+
+class CadViewerRuntimeContractTests(unittest.TestCase):
+    def test_materialized_runtime_includes_agent_launcher(self) -> None:
+        if RUNTIME_DIR.is_symlink():
+            self.skipTest("develop uses the source Viewer symlink; production runtime is checked after bundling")
+
+        package = json.loads((RUNTIME_DIR / "package.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(package["scripts"].get("agent:start"), "node scripts/start-agent-viewer.mjs")
+        self.assertTrue((RUNTIME_DIR / "scripts" / "start-agent-viewer.mjs").is_file())
+        self.assertTrue((RUNTIME_DIR / "backend" / "server.mjs").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/scripts/start-agent-viewer.mjs
+++ b/viewer/scripts/start-agent-viewer.mjs
@@ -368,10 +368,14 @@ export function buildAgentStartCommand({
     };
   }
 
+  const bundledServerPath = path.join(resolvedPackageRoot, "backend", "server.mjs");
+  const serverPath = fs.existsSync(bundledServerPath)
+    ? bundledServerPath
+    : path.join(resolvedPackageRoot, "src", "server", "server.mjs");
   return {
     command: nodePath,
     args: [
-      path.join(resolvedPackageRoot, "src", "server", "server.mjs"),
+      serverPath,
       ...forwardedArgs,
     ],
     cwd: resolvedPackageRoot,

--- a/viewer/scripts/start-agent-viewer.test.mjs
+++ b/viewer/scripts/start-agent-viewer.test.mjs
@@ -205,6 +205,29 @@ test("resolveAgentStartCommand keeps server-only flags on the production server 
   ]);
 });
 
+test("resolveAgentStartCommand uses the bundled backend in a production runtime", async (t) => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "cad-viewer-agent-start-directory-"));
+  const packageRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cad-viewer-agent-start-runtime-"));
+  t.after(() => fs.rm(directory, { recursive: true, force: true }));
+  t.after(() => fs.rm(packageRoot, { recursive: true, force: true }));
+  await fs.mkdir(path.join(packageRoot, "backend"), { recursive: true });
+  await fs.writeFile(path.join(packageRoot, "backend", "server.mjs"), "");
+
+  const command = resolveAgentStartCommand({
+    argv: ["--viewer-start-mode", "serve", "--dir", directory],
+    env: {},
+    packageRoot,
+    nodePath: "/node",
+  });
+
+  assert.equal(command.mode, "serve");
+  assert.deepEqual(command.args, [
+    path.join(packageRoot, "backend", "server.mjs"),
+    "--dir",
+    directory,
+  ]);
+});
+
 test("isReusableAgentViewerServer uses git only when both sides report it", () => {
   assert.equal(
     isReusableAgentViewerServer({


### PR DESCRIPTION
## What changed

- include `agent:start` in the packaged CAD Viewer runtime manifest
- bundle the agent launcher as a self-contained production script
- make serve mode prefer the packaged `backend/server.mjs` entry point
- add source and materialized-runtime regression coverage

## Root cause

The development Viewer exposed `agent:start`, but the production bundle rebuilt `package.json` without that script and omitted the launcher. The source launcher also assumed `src/server/server.mjs`, while packaged runtimes contain `backend/server.mjs`.

## Validation

- Node 22 Viewer suite: 389 tests, 385 passed, 4 existing dependency skips, 0 failed
- global policy tests: 8 passed
- CAD Viewer production bundle freshness check passed
- materialized runtime contract test passed
- packaged `npm run agent:start` launched the production server and served a real STEP Viewer URL with HTTP 200
