### PR TITLE
docs(bambu-labs): document TLS verification bypass mitigation

### DIFF
--- a/skills/bambu-labs/scripts/bambu_lan_print.py
+++ b/skills/bambu-labs/scripts/bambu_lan_print.py
@@ -376,6 +376,9 @@ def discover_printer_serial(
     validate_local_host(host, allow_nonprivate_host)
     context = ssl.create_default_context()
     if not tls_verify:
+        # Bambu printer firmware serves self-signed LAN certificates; validate_local_host()
+        # above restricts this to private/loopback/link-local hosts, so disabling verification
+        # here only trusts the printer's subnet, not its actual certificate.
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
     with socket.create_connection((host, port), timeout=timeout) as raw_sock:
@@ -940,6 +943,9 @@ def upload_ftps(args: argparse.Namespace, local_path: Path, remote_path: str) ->
     validate_local_host(args.host, args.allow_nonprivate_host)
     context = ssl.create_default_context()
     if not args.tls_verify:
+        # Bambu printer firmware serves self-signed LAN certificates; validate_local_host()
+        # above restricts this to private/loopback/link-local hosts, so disabling verification
+        # here only trusts the printer's subnet, not its actual certificate.
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
     ftp = ImplicitFTP_TLS(context=context, timeout=args.timeout)
@@ -1149,6 +1155,9 @@ def publish_mqtt(
     validate_local_host(args.host, args.allow_nonprivate_host)
     context = ssl.create_default_context()
     if not args.tls_verify:
+        # Bambu printer firmware serves self-signed LAN certificates; validate_local_host()
+        # above restricts this to private/loopback/link-local hosts, so disabling verification
+        # here only trusts the printer's subnet, not its actual certificate.
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
     payload_bytes = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
@@ -1207,6 +1216,9 @@ def subscribe_mqtt_reports(
     validate_local_host(args.host, args.allow_nonprivate_host)
     context = ssl.create_default_context()
     if not args.tls_verify:
+        # Bambu printer firmware serves self-signed LAN certificates; validate_local_host()
+        # above restricts this to private/loopback/link-local hosts, so disabling verification
+        # here only trusts the printer's subnet, not its actual certificate.
         context.check_hostname = False
         context.verify_mode = ssl.CERT_NONE
     client_id = args.client_id or args.serial or f"codex-bambu-status-{int(time.time())}"


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: TLS certificate verification is disabled (`CERT_NONE`) at 4 call sites in `bambu_lan_print.py` with no in-place documentation of why this is safe.

**Evidence**: Confirmed all 4 `verify_mode = ssl.CERT_NONE` sites (lines 379-380, 943-944, 1152-1153, 1210-1211) are preceded by a call to `validate_local_host()`, which resolves the target and refuses non-private/non-loopback/non-link-local addresses unless `--allow-nonprivate-host` is passed.

**Fix**: Adds a short comment at each site cross-referencing `validate_local_host()` so the LAN-only mitigation for Bambu's self-signed printer certificates is documented in place, not only in the caller.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-tls-verify-disabled","fingerprint":"sha256:52f1dfbdcd8d2721b2e4fb4840d42a6bffa3daf5aa83a32d0ab3b5f5fbe5b115"}]}
nlpm-metadata-end -->