### PR TITLE
Add orthographic CAD markup workspace

### DIFF
--- a/viewer/scripts/start-agent-viewer.mjs
+++ b/viewer/scripts/start-agent-viewer.mjs
@@ -443,6 +443,12 @@ function serverInfoMode(serverInfo) {
   return normalizeReuseMode(serverInfo?.serverMode || serverInfo?.runtimeMode || serverInfo?.mode);
 }
 
+function serverInfoModeAllowsReuse(serverInfo, context) {
+  const currentMode = normalizeReuseMode(context?.mode);
+  const serverMode = serverInfoMode(serverInfo);
+  return !currentMode || !serverMode || currentMode === serverMode;
+}
+
 function serverInfoRequiresGitMatch(serverInfo, context) {
   const currentMode = normalizeReuseMode(context?.mode);
   const serverMode = serverInfoMode(serverInfo);
@@ -480,6 +486,7 @@ export function isReusableAgentViewerServer(serverInfo, contextOrGit = {}) {
     Number(serverInfo.serverApiVersion || 0) >= VIEWER_SERVER_API_VERSION &&
     serverInfo.dynamicRoot === true &&
     serverInfoHasFeature(serverInfo, directoryActivationFeature) &&
+    serverInfoModeAllowsReuse(serverInfo, context) &&
     serverInfoGitAllowsReuse(serverInfo, context) &&
     serverInfoVersionAllowsReuse(serverInfo, context)
   );

--- a/viewer/scripts/start-agent-viewer.test.mjs
+++ b/viewer/scripts/start-agent-viewer.test.mjs
@@ -424,6 +424,45 @@ test("resolveAgentViewerPort reuses matching registry servers before free lower 
   assert.deepEqual(probes, ["127.0.0.1:5173"]);
 });
 
+test("resolveAgentViewerPort does not reuse a packaged viewer for dev source", async () => {
+  const probes = [];
+  const result = await resolveAgentViewerPort({
+    forwardedArgs: ["--host", "127.0.0.1", "--port", "4178"],
+    git: "git-a",
+    mode: "dev",
+    viewerVersion: "0.3.2",
+    registryServers: [],
+    portScanLimit: 2,
+    probePort: async ({ host, port }) => {
+      probes.push(port);
+      if (port === 4178) {
+        return {
+          status: "viewer",
+          port,
+          baseUrl: `http://${host}:${port}`,
+          serverInfo: {
+            app: "cad-viewer",
+            serverApiVersion: 2,
+            dynamicRoot: true,
+            serverFeatures: ["directory-activation"],
+            serverMode: "serve",
+            viewerVersion: "0.3.2",
+          },
+        };
+      }
+      return {
+        status: "closed",
+        port,
+        baseUrl: `http://${host}:${port}`,
+      };
+    },
+  });
+
+  assert.equal(result.action, "start");
+  assert.equal(result.port, 4179);
+  assert.deepEqual(probes, [4178, 4179]);
+});
+
 test("resolveAgentViewerPort reuses matching-version dist servers across git branches", async () => {
   const probes = [];
   const result = await resolveAgentViewerPort({

--- a/viewer/src/client/components/CadViewer.js
+++ b/viewer/src/client/components/CadViewer.js
@@ -2082,6 +2082,7 @@ const CadViewer = forwardRef(function CadViewer({
   displaySettings = null,
   drawingEnabled = false,
   drawingTool = DRAWING_TOOL.FREEHAND,
+  drawingStyle = null,
   drawingStrokes = [],
   onDrawingStrokesChange,
   onPerspectiveChange,
@@ -2812,7 +2813,7 @@ const CadViewer = forwardRef(function CadViewer({
     setUrdfPosePickerGuidePoint((current) => (current ? null : current));
   };
 
-  const activateViewPlaneFace = (faceId) => {
+  const activateViewPlaneFace = (faceId, { animate = true } = {}) => {
     const runtime = runtimeRef.current;
     const face = VIEW_PLANE_FACE_BY_ID[faceId];
     if (!runtime || !face) {
@@ -2821,6 +2822,13 @@ const CadViewer = forwardRef(function CadViewer({
     activeViewPlaneFaceRef.current = face.id;
     setActiveViewPlaneFace(face.id);
     const transitioned = transitionCameraToViewPreset(runtime, face);
+    if (transitioned && !animate && runtime.cameraTransition) {
+      stepCameraTransition(
+        runtime,
+        runtime.cameraTransition.startTime + runtime.cameraTransition.durationMs
+      );
+      runtime.requestRender?.();
+    }
     if (transitioned) {
       defaultPerspectiveResettingRef.current = false;
       setDefaultPerspectiveDetached(true);
@@ -2919,8 +2927,8 @@ const CadViewer = forwardRef(function CadViewer({
       }
       return fitted;
     },
-    focusViewPreset(faceId) {
-      return activateViewPlaneFace(faceId);
+    focusViewPreset(faceId, options = {}) {
+      return activateViewPlaneFace(faceId, options);
     }
   }), [
     activeSelectorRuntime,
@@ -4693,6 +4701,7 @@ const CadViewer = forwardRef(function CadViewer({
     drawingIdRef,
     drawingEnabled,
     drawingTool,
+    drawingStyle,
     meshData,
     previewMode,
     viewerReadyTick,

--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -19,6 +19,7 @@ import UrdfFileSheet from "./workbench/UrdfFileSheet";
 import ViewerAlertDialog from "./workbench/ViewerAlertDialog";
 import ViewerLoadingOverlay from "./workbench/ViewerLoadingOverlay";
 import FloatingToolBar from "./workbench/FloatingToolBar";
+import ThreeViewMarkupWorkspace from "./workbench/ThreeViewMarkupWorkspace";
 import CadWorkspaceTopBar from "./workbench/CadWorkspaceTopBar";
 import CadWorkspaceHome from "./workbench/CadWorkspaceHome";
 import { useCadAssets } from "./workbench/hooks/useCadAssets";
@@ -1224,6 +1225,12 @@ export default function CadWorkspace({
   const isDesktop = viewerLayoutMode === CAD_WORKSPACE_LAYOUT_MODE.DESKTOP;
   const [fileSheetOpenIntent, setFileSheetOpenIntent] = useState(readInitialFileSheetOpen);
   const [viewerAlertOpen, setViewerAlertOpen] = useState(false);
+  const [threeViewMarkupOpen, setThreeViewMarkupOpen] = useState(() => {
+    if (typeof globalThis.window === "undefined") {
+      return false;
+    }
+    return new URLSearchParams(globalThis.window.location.search).get("markup") === "three-view";
+  });
   const [viewerRuntimeAlert, setViewerRuntimeAlert] = useState(null);
   const [customThemePresets, setCustomThemePresets] = useState(readCustomThemePresets);
   const [themeState, setThemeState] = useState(() => readDirectoryThemeSettingsState(readCustomThemePresets()));
@@ -8788,6 +8795,8 @@ export default function CadWorkspace({
                 canUndoDrawing={canUndoDrawing}
                 canRedoDrawing={canRedoDrawing}
                 drawingStrokes={drawingStrokes}
+                threeViewMarkupAvailable={isStepView && !!selectedMeshData && !viewerLoading}
+                handleOpenThreeViewMarkup={() => setThreeViewMarkupOpen(true)}
                 handleEnterPreviewMode={handleEnterPreviewMode}
                 handleScreenshotCopy={handleScreenshotCopy}
               />
@@ -9102,6 +9111,17 @@ export default function CadWorkspace({
           viewerAlert={viewerAlert}
           previewMode={previewMode}
           setViewerAlertOpen={setViewerAlertOpen}
+        />
+
+        <ThreeViewMarkupWorkspace
+          open={threeViewMarkupOpen && isStepView && !!selectedMeshData}
+          onOpenChange={setThreeViewMarkupOpen}
+          meshData={selectedMeshData}
+          modelKey={selectedKey}
+          sourceFile={fileKey(selectedEntry)}
+          renderFormat={effectiveRenderFormat}
+          themeSettings={resolvedThemeSettings}
+          displaySettings={renderDisplaySettings}
         />
       </SidebarInset>
     </SidebarProvider>

--- a/viewer/src/client/components/viewer/hooks/useViewerDrawingOverlay.js
+++ b/viewer/src/client/components/viewer/hooks/useViewerDrawingOverlay.js
@@ -9,6 +9,7 @@ export function useViewerDrawingOverlay({
   drawingIdRef,
   drawingEnabled,
   drawingTool,
+  drawingStyle,
   meshData,
   previewMode,
   viewerReadyTick,
@@ -58,6 +59,7 @@ export function useViewerDrawingOverlay({
         ...drawingStrokesRef.current,
         {
           id: `stroke-${drawingIdRef.current}`,
+          ...(drawingStyle && typeof drawingStyle === "object" ? drawingStyle : {}),
           ...stroke
         }
       ]);
@@ -86,6 +88,7 @@ export function useViewerDrawingOverlay({
       drawingDraftRef.current = {
         id: "__draft__",
         tool: drawingTool,
+        ...(drawingStyle && typeof drawingStyle === "object" ? drawingStyle : {}),
         points: [point]
       };
       redrawDrawingCanvas(canvas, drawingStrokesRef.current, drawingDraftRef.current);
@@ -164,6 +167,7 @@ export function useViewerDrawingOverlay({
         drawingDraftRef.current = {
           id: "__draft__",
           tool: drawingTool,
+          ...(drawingStyle && typeof drawingStyle === "object" ? drawingStyle : {}),
           points: [anchor.screenPoint, anchor.screenPoint],
           surfaceLine: anchor.surfaceLine
         };
@@ -250,6 +254,7 @@ export function useViewerDrawingOverlay({
     drawingMinPointDistancePx,
     drawingMinStrokeLengthPx,
     drawingStrokesRef,
+    drawingStyle,
     drawingTool,
     drawingToolNeedsTwoPoints,
     meshData,

--- a/viewer/src/client/components/workbench/FloatingToolBar.js
+++ b/viewer/src/client/components/workbench/FloatingToolBar.js
@@ -4,6 +4,7 @@ import {
   Focus,
   MousePointer2,
   Orbit,
+  PanelsTopLeft,
   Pause,
   Play,
   PenTool
@@ -57,6 +58,8 @@ function DesktopFloatingToolBar({
   canUndoDrawing,
   canRedoDrawing,
   drawingStrokes,
+  threeViewMarkupAvailable = false,
+  handleOpenThreeViewMarkup,
   handleEnterPreviewMode,
   handleScreenshotCopy
 }) {
@@ -109,6 +112,14 @@ function DesktopFloatingToolBar({
                 aria-pressed={drawToolActive}
               >
                 <PenTool className="size-3" strokeWidth={2} aria-hidden="true" />
+              </ToolbarButton>
+
+              <ToolbarButton
+                label="Orthographic markup"
+                onClick={handleOpenThreeViewMarkup}
+                disabled={!threeViewMarkupAvailable}
+              >
+                <PanelsTopLeft className="size-3" strokeWidth={2} aria-hidden="true" />
               </ToolbarButton>
 
               {displayControlAvailable ? (

--- a/viewer/src/client/components/workbench/ThreeViewMarkupWorkspace.js
+++ b/viewer/src/client/components/workbench/ThreeViewMarkupWorkspace.js
@@ -1,0 +1,563 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowLeftRight,
+  ArrowRight,
+  Circle,
+  ClipboardCopy,
+  Download,
+  Eraser,
+  Images,
+  Minus,
+  PaintBucket,
+  PenTool,
+  RotateCcw,
+  Square,
+  Upload
+} from "lucide-react";
+import CadViewer from "../CadViewer";
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from "../ui/dialog";
+import { Textarea } from "../ui/textarea";
+import { triggerBlobDownload } from "@/ui/download";
+import { copyTextToClipboard } from "@/ui/clipboard";
+import { DRAWING_TOOL } from "@/workbench/constants";
+import DrawingToolbar from "./DrawingToolbar";
+import {
+  buildThreeViewMarkupDocument,
+  emptyThreeViewMarkupState,
+  markupFilenameStem,
+  parseThreeViewMarkupDocument,
+  THREE_VIEW_MARKUP_INTENTS,
+  THREE_VIEW_MARKUP_VIEWS,
+  viewStateFromThreeViewMarkupDocument
+} from "@/workbench/threeViewMarkup";
+import { cn } from "@/ui/utils";
+
+const DRAWING_TOOL_OPTIONS = [
+  { id: DRAWING_TOOL.FREEHAND, label: "Freehand", Icon: PenTool },
+  { id: DRAWING_TOOL.LINE, label: "Line", Icon: Minus },
+  { id: DRAWING_TOOL.ARROW, label: "Arrow", Icon: ArrowRight },
+  { id: DRAWING_TOOL.DOUBLE_ARROW, label: "Expand / rotate", Icon: ArrowLeftRight },
+  { id: DRAWING_TOOL.RECTANGLE, label: "Rectangle", Icon: Square },
+  { id: DRAWING_TOOL.CIRCLE, label: "Circle", Icon: Circle },
+  { id: DRAWING_TOOL.FILL, label: "Fill", Icon: PaintBucket },
+  { id: DRAWING_TOOL.ERASE, label: "Erase", Icon: Eraser }
+];
+
+function emptyHistory() {
+  return Object.fromEntries(
+    THREE_VIEW_MARKUP_VIEWS.map((view) => [
+      view.id,
+      {
+        undo: [],
+        redo: []
+      }
+    ])
+  );
+}
+
+function cloneStrokes(strokes) {
+  return Array.isArray(strokes)
+    ? strokes.map((stroke) => ({
+      ...stroke,
+      points: Array.isArray(stroke?.points)
+        ? stroke.points.map((point) => ({ ...point }))
+        : [],
+      ...(Array.isArray(stroke?.fillPoints)
+        ? { fillPoints: stroke.fillPoints.map((point) => ({ ...point })) }
+        : {})
+    }))
+    : [];
+}
+
+function ThreeViewPanel({
+  definition,
+  meshData,
+  modelKey,
+  renderFormat,
+  themeSettings,
+  displaySettings,
+  drawingTool,
+  drawingStyle,
+  strokes,
+  onStrokesChange,
+  registerViewer
+}) {
+  const viewerRef = useRef(null);
+
+  const setViewerRef = useCallback((instance) => {
+    viewerRef.current = instance;
+    registerViewer(definition.id, instance);
+  }, [definition.id, registerViewer]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const timers = [];
+
+    const orientAndFit = () => {
+      if (cancelled) {
+        return;
+      }
+      const focused = viewerRef.current?.focusViewPreset?.(definition.cameraPreset, {
+        animate: false
+      });
+      if (!focused) {
+        return;
+      }
+      viewerRef.current?.zoomToFit?.({ animate: false });
+    };
+
+    for (const delay of [0, 650, 1500]) {
+      timers.push(globalThis.setTimeout(orientAndFit, delay));
+    }
+    return () => {
+      cancelled = true;
+      timers.forEach((timer) => globalThis.clearTimeout(timer));
+    };
+  }, [definition.cameraPreset, meshData, modelKey]);
+
+  return (
+    <section
+      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border border-primary bg-background/70 shadow-sm ring-2 ring-primary/20"
+    >
+      <div className="flex items-center justify-between border-b bg-muted/55 px-3 py-1.5">
+        <div>
+          <h3 className="text-sm font-semibold">{definition.label}</h3>
+          <p className="text-[11px] text-muted-foreground">
+            {definition.plane} plane · right {definition.screenAxes.right} · up {definition.screenAxes.up}
+          </p>
+        </div>
+        <span className="rounded bg-background/80 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          {strokes.length} mark{strokes.length === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      <div className="relative min-h-[180px] flex-1 bg-background">
+        <CadViewer
+          ref={setViewerRef}
+          meshData={meshData}
+          modelKey={`${modelKey || "cad-part"}:three-view-markup`}
+          renderFormat={renderFormat}
+          projection="orthographic"
+          showViewPlane={false}
+          previewMode={false}
+          themeSettings={themeSettings}
+          displaySettings={displaySettings ? {
+            ...displaySettings,
+            projection: "orthographic"
+          } : null}
+          drawingEnabled
+          drawingTool={drawingTool}
+          drawingStyle={drawingStyle}
+          drawingStrokes={strokes}
+          onDrawingStrokesChange={onStrokesChange}
+        />
+      </div>
+    </section>
+  );
+}
+
+export default function ThreeViewMarkupWorkspace({
+  open,
+  onOpenChange,
+  meshData,
+  modelKey = "",
+  sourceFile = "",
+  renderFormat = "step",
+  themeSettings = null,
+  displaySettings = null
+}) {
+  const [drawingTool, setDrawingTool] = useState(DRAWING_TOOL.FREEHAND);
+  const [activeIntentId, setActiveIntentId] = useState("remove");
+  const [activeViewId, setActiveViewId] = useState("front");
+  const [viewState, setViewState] = useState(emptyThreeViewMarkupState);
+  const [history, setHistory] = useState(emptyHistory);
+  const [overallNote, setOverallNote] = useState("");
+  const [status, setStatus] = useState("");
+  const importInputRef = useRef(null);
+  const activeViewerRef = useRef(null);
+
+  const activeIntent = useMemo(
+    () => THREE_VIEW_MARKUP_INTENTS.find((intent) => intent.id === activeIntentId) ||
+      THREE_VIEW_MARKUP_INTENTS[0],
+    [activeIntentId]
+  );
+  const drawingStyle = useMemo(() => ({
+    intent: activeIntent.id,
+    color: activeIntent.color,
+    fillColor: activeIntent.fillColor,
+    haloColor: "rgba(255, 255, 255, 0.94)"
+  }), [activeIntent]);
+  const activeStrokes = viewState[activeViewId]?.strokes || [];
+  const activeHistory = history[activeViewId] || { undo: [], redo: [] };
+  const activeViewDefinition = THREE_VIEW_MARKUP_VIEWS.find((view) => view.id === activeViewId) ||
+    THREE_VIEW_MARKUP_VIEWS[0];
+  const filenameStem = markupFilenameStem(sourceFile);
+
+  const registerViewer = useCallback((_viewId, instance) => {
+    activeViewerRef.current = instance;
+  }, []);
+
+  const updateViewStrokes = useCallback((viewId, nextStrokes) => {
+    const previous = cloneStrokes(viewState[viewId]?.strokes);
+    setHistory((currentHistory) => ({
+      ...currentHistory,
+      [viewId]: {
+        undo: [...(currentHistory[viewId]?.undo || []), previous],
+        redo: []
+      }
+    }));
+    setViewState((current) => {
+      return {
+        ...current,
+        [viewId]: {
+          ...current[viewId],
+          strokes: cloneStrokes(nextStrokes)
+        }
+      };
+    });
+    setStatus("");
+  }, [viewState]);
+
+  const updateViewNote = useCallback((viewId, note) => {
+    setViewState((current) => ({
+      ...current,
+      [viewId]: {
+        ...current[viewId],
+        note
+      }
+    }));
+  }, []);
+
+  const handleUndo = useCallback(() => {
+    const viewId = activeViewId;
+    const undo = history[viewId]?.undo || [];
+    if (!undo.length) {
+      return;
+    }
+    const previous = undo[undo.length - 1];
+    setViewState((currentState) => ({
+      ...currentState,
+      [viewId]: {
+        ...currentState[viewId],
+        strokes: cloneStrokes(previous)
+      }
+    }));
+    setHistory((currentHistory) => ({
+      ...currentHistory,
+      [viewId]: {
+        undo: undo.slice(0, -1),
+        redo: [
+          ...(currentHistory[viewId]?.redo || []),
+          cloneStrokes(viewState[viewId]?.strokes)
+        ]
+      }
+    }));
+  }, [activeViewId, history, viewState]);
+
+  const handleRedo = useCallback(() => {
+    const viewId = activeViewId;
+    const redo = history[viewId]?.redo || [];
+    if (!redo.length) {
+      return;
+    }
+    const next = redo[redo.length - 1];
+    setViewState((currentState) => ({
+      ...currentState,
+      [viewId]: {
+        ...currentState[viewId],
+        strokes: cloneStrokes(next)
+      }
+    }));
+    setHistory((currentHistory) => ({
+      ...currentHistory,
+      [viewId]: {
+        undo: [
+          ...(currentHistory[viewId]?.undo || []),
+          cloneStrokes(viewState[viewId]?.strokes)
+        ],
+        redo: redo.slice(0, -1)
+      }
+    }));
+  }, [activeViewId, history, viewState]);
+
+  const handleClear = useCallback(() => {
+    if (!activeStrokes.length) {
+      return;
+    }
+    updateViewStrokes(activeViewId, []);
+  }, [activeStrokes.length, activeViewId, updateViewStrokes]);
+
+  const handleResetView = useCallback(() => {
+    const viewer = activeViewerRef.current;
+    viewer?.focusViewPreset?.(activeViewDefinition.cameraPreset, { animate: false });
+    viewer?.zoomToFit?.({ animate: false });
+    setStatus(`Reset the ${activeViewDefinition.label.toLowerCase()} view.`);
+  }, [activeViewDefinition]);
+
+  const handleExportMarkup = useCallback(() => {
+    const document = buildThreeViewMarkupDocument({
+      sourceFile,
+      modelKey,
+      renderFormat,
+      overallNote,
+      viewState
+    });
+    const blob = new Blob([`${JSON.stringify(document, null, 2)}\n`], {
+      type: "application/json"
+    });
+    triggerBlobDownload(blob, {
+      filename: `${filenameStem}-three-view-markup.json`
+    });
+    setStatus("Markup JSON downloaded.");
+  }, [filenameStem, modelKey, overallNote, renderFormat, sourceFile, viewState]);
+
+  const handleCopyForCodex = useCallback(async () => {
+    const document = buildThreeViewMarkupDocument({
+      sourceFile,
+      modelKey,
+      renderFormat,
+      overallNote,
+      viewState,
+      includeEmptyViews: false
+    });
+    try {
+      await copyTextToClipboard(JSON.stringify(document, null, 2));
+      const viewCount = document.views.length;
+      setStatus(
+        `Copied for Codex with ${viewCount} changed view${viewCount === 1 ? "" : "s"}. Paste it into your Codex task to submit.`
+      );
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : "Could not copy the markup.");
+    }
+  }, [modelKey, overallNote, renderFormat, sourceFile, viewState]);
+
+  const handleExportCurrentImage = useCallback(async () => {
+    setStatus(`Preparing the ${activeViewDefinition.label.toLowerCase()} PNG…`);
+    try {
+      const viewer = activeViewerRef.current;
+      if (!viewer?.captureScreenshot) {
+        throw new Error(`${activeViewDefinition.label} view is not ready yet.`);
+      }
+      await viewer.captureScreenshot({
+        filename: `${filenameStem}-${activeViewDefinition.id}-markup.png`,
+        mode: "download"
+      });
+      setStatus(`${activeViewDefinition.label} PNG downloaded.`);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : "Could not export the image.");
+    }
+  }, [activeViewDefinition, filenameStem]);
+
+  const handleImportMarkup = useCallback(async (event) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) {
+      return;
+    }
+    try {
+      const document = parseThreeViewMarkupDocument(await file.text());
+      setViewState(viewStateFromThreeViewMarkupDocument(document));
+      setOverallNote(document.overallNote);
+      setHistory(emptyHistory());
+      setStatus(`Loaded ${file.name}.`);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : "Could not import markup.");
+    }
+  }, []);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="h-[calc(100svh-1rem)] max-h-[calc(100svh-1rem)] w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] grid-rows-[auto_auto_minmax(0,1fr)_auto] gap-3 overflow-hidden p-3 sm:!max-w-[calc(100vw-1rem)]"
+      >
+        <DialogHeader className="pr-10">
+          <DialogTitle>Orthographic Markup</DialogTitle>
+          <DialogDescription>
+            Switch between all six fixed orthographic views. Each view keeps its own marks and typed note; the JSON preserves all six.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex min-w-0 flex-col gap-2 rounded-md border bg-muted/35 p-2 xl:flex-row xl:items-center">
+          <DrawingToolbar
+            className="min-w-0 flex-1"
+            layout="scroll"
+            drawingToolOptions={DRAWING_TOOL_OPTIONS}
+            drawingTool={drawingTool}
+            handleSelectDrawingTool={setDrawingTool}
+            handleUndoDrawing={handleUndo}
+            handleRedoDrawing={handleRedo}
+            handleClearDrawings={handleClear}
+            canUndoDrawing={activeHistory.undo.length > 0}
+            canRedoDrawing={activeHistory.redo.length > 0}
+            drawingStrokes={activeStrokes}
+          />
+
+          <div className="flex flex-wrap items-center gap-1.5" aria-label="Markup intent">
+            {THREE_VIEW_MARKUP_INTENTS.map((intent) => {
+              const active = intent.id === activeIntent.id;
+              return (
+                <button
+                  key={intent.id}
+                  type="button"
+                  className={cn(
+                    "inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition",
+                    active
+                      ? "border-foreground/30 bg-background text-foreground shadow-sm"
+                      : "border-transparent text-muted-foreground hover:bg-background/70 hover:text-foreground"
+                  )}
+                  aria-pressed={active}
+                  onClick={() => setActiveIntentId(intent.id)}
+                >
+                  <span
+                    className="size-2.5 rounded-full border border-black/10"
+                    style={{ backgroundColor: intent.color }}
+                    aria-hidden="true"
+                  />
+                  {intent.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <Button variant="outline" size="sm" onClick={handleResetView}>
+            <RotateCcw aria-hidden="true" />
+            Reset view
+          </Button>
+        </div>
+
+        <div className="flex min-h-0 flex-col gap-3">
+          <div className="grid grid-cols-3 gap-1 rounded-md border bg-muted/35 p-1 sm:grid-cols-6">
+            {THREE_VIEW_MARKUP_VIEWS.map((definition) => {
+              const active = definition.id === activeViewId;
+              const markCount = viewState[definition.id]?.strokes?.length || 0;
+              return (
+                <button
+                  key={definition.id}
+                  type="button"
+                  className={cn(
+                    "rounded-md px-3 py-2 text-sm font-medium transition",
+                    active
+                      ? "bg-background text-foreground shadow-sm ring-1 ring-border"
+                      : "text-muted-foreground hover:bg-background/65 hover:text-foreground"
+                  )}
+                  aria-pressed={active}
+                  onClick={() => {
+                    setActiveViewId(definition.id);
+                    setStatus("");
+                  }}
+                >
+                  {definition.label}
+                  <span className="ml-2 text-[11px] font-normal text-muted-foreground">
+                    {markCount} mark{markCount === 1 ? "" : "s"}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="grid min-h-0 flex-1 gap-3 md:grid-cols-[minmax(0,3fr)_minmax(260px,1fr)]">
+            <ThreeViewPanel
+              definition={activeViewDefinition}
+              meshData={meshData}
+              modelKey={modelKey}
+              renderFormat={renderFormat}
+              themeSettings={themeSettings}
+              displaySettings={displaySettings}
+              drawingTool={drawingTool}
+              drawingStyle={drawingStyle}
+              strokes={activeStrokes}
+              onStrokesChange={(strokes) => updateViewStrokes(activeViewId, strokes)}
+              registerViewer={registerViewer}
+            />
+
+            <section className="flex min-h-0 flex-col gap-3 overflow-auto rounded-md border bg-muted/25 p-3">
+              <div>
+                <label
+                  className="text-sm font-semibold"
+                  htmlFor={`three-view-note-${activeViewId}`}
+                >
+                  {activeViewDefinition.label} view note
+                </label>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Type the exact change, dimension, angle, pivot, or clearance for this view.
+                </p>
+                <Textarea
+                  id={`three-view-note-${activeViewId}`}
+                  value={viewState[activeViewId]?.note || ""}
+                  onChange={(event) => updateViewNote(activeViewId, event.target.value)}
+                  placeholder={`What should change in the ${activeViewDefinition.label.toLowerCase()} view?`}
+                  className="mt-2 min-h-32 resize-y bg-background/75"
+                />
+              </div>
+
+              <div className="border-t pt-3">
+                <label className="text-sm font-semibold" htmlFor="three-view-overall-note">
+                  Overall instructions
+                </label>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Include details that apply across all six views.
+                </p>
+                <Textarea
+                  id="three-view-overall-note"
+                  value={overallNote}
+                  onChange={(event) => setOverallNote(event.target.value)}
+                  placeholder="Example: cut the red region, rotate the blue end 35° clockwise, and preserve the STS3215 mounting holes."
+                  className="mt-2 min-h-40 resize-y bg-background/75"
+                />
+              </div>
+
+              <div className="mt-auto rounded-md border bg-background/60 p-2 text-xs text-muted-foreground">
+                Active view: <span className="font-medium text-foreground">{activeViewDefinition.label}</span>. Marks use normalized image coordinates and CAD Z-up axes.
+                <span className="mt-1 block">Copy for Codex includes only views with marks or typed notes.</span>
+              </div>
+            </section>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2 border-t pt-3">
+          <p className="min-h-5 text-xs text-muted-foreground" role="status">
+            {status || "Tip: use arrows for movement, rectangles/circles for regions, and notes for exact dimensions."}
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              ref={importInputRef}
+              type="file"
+              accept="application/json,.json"
+              className="hidden"
+              onChange={handleImportMarkup}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => importInputRef.current?.click()}
+            >
+              <Upload aria-hidden="true" />
+              Import JSON
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleExportCurrentImage}>
+              <Images aria-hidden="true" />
+              Download current PNG
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleExportMarkup}>
+              <Download aria-hidden="true" />
+              Export markup JSON
+            </Button>
+            <Button size="sm" onClick={handleCopyForCodex}>
+              <ClipboardCopy aria-hidden="true" />
+              Copy for Codex
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/viewer/src/client/workbench/threeViewMarkup.js
+++ b/viewer/src/client/workbench/threeViewMarkup.js
@@ -1,0 +1,257 @@
+export const THREE_VIEW_MARKUP_SCHEMA = "cad-viewer-three-view-markup";
+export const THREE_VIEW_MARKUP_VERSION = 1;
+
+export const THREE_VIEW_MARKUP_VIEWS = Object.freeze([
+  Object.freeze({
+    id: "front",
+    label: "Front",
+    plane: "XZ",
+    cameraPreset: "yNeg",
+    lookingAlong: "+Y",
+    screenAxes: Object.freeze({ right: "+X", up: "+Z" })
+  }),
+  Object.freeze({
+    id: "back",
+    label: "Back",
+    plane: "XZ",
+    cameraPreset: "y",
+    lookingAlong: "-Y",
+    screenAxes: Object.freeze({ right: "-X", up: "+Z" })
+  }),
+  Object.freeze({
+    id: "top",
+    label: "Top",
+    plane: "XY",
+    cameraPreset: "z",
+    lookingAlong: "-Z",
+    screenAxes: Object.freeze({ right: "+X", up: "+Y" })
+  }),
+  Object.freeze({
+    id: "bottom",
+    label: "Bottom",
+    plane: "XY",
+    cameraPreset: "zNeg",
+    lookingAlong: "+Z",
+    screenAxes: Object.freeze({ right: "-X", up: "+Y" })
+  }),
+  Object.freeze({
+    id: "right",
+    label: "Right",
+    plane: "YZ",
+    cameraPreset: "x",
+    lookingAlong: "-X",
+    screenAxes: Object.freeze({ right: "+Y", up: "+Z" })
+  }),
+  Object.freeze({
+    id: "left",
+    label: "Left",
+    plane: "YZ",
+    cameraPreset: "xNeg",
+    lookingAlong: "+X",
+    screenAxes: Object.freeze({ right: "-Y", up: "+Z" })
+  })
+]);
+
+export const THREE_VIEW_MARKUP_INTENTS = Object.freeze([
+  Object.freeze({
+    id: "remove",
+    label: "Remove / cut",
+    color: "#ef4444",
+    fillColor: "rgba(239, 68, 68, 0.22)"
+  }),
+  Object.freeze({
+    id: "add",
+    label: "Add material",
+    color: "#22c55e",
+    fillColor: "rgba(34, 197, 94, 0.22)"
+  }),
+  Object.freeze({
+    id: "move",
+    label: "Move / rotate",
+    color: "#3b82f6",
+    fillColor: "rgba(59, 130, 246, 0.22)"
+  }),
+  Object.freeze({
+    id: "hardware",
+    label: "Servo / hardware",
+    color: "#a855f7",
+    fillColor: "rgba(168, 85, 247, 0.22)"
+  }),
+  Object.freeze({
+    id: "note",
+    label: "General note",
+    color: "#f59e0b",
+    fillColor: "rgba(245, 158, 11, 0.22)"
+  })
+]);
+
+const INTENT_IDS = new Set(THREE_VIEW_MARKUP_INTENTS.map((intent) => intent.id));
+const VIEW_BY_ID = new Map(THREE_VIEW_MARKUP_VIEWS.map((view) => [view.id, view]));
+
+function cleanText(value) {
+  return String(value || "").trim();
+}
+
+function finiteUnitCoordinate(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+  return Math.min(Math.max(number, 0), 1);
+}
+
+function sanitizePoint(point) {
+  const x = finiteUnitCoordinate(point?.x);
+  const y = finiteUnitCoordinate(point?.y);
+  return x === null || y === null ? null : { x, y };
+}
+
+function sanitizePoints(points) {
+  return (Array.isArray(points) ? points : [])
+    .map(sanitizePoint)
+    .filter(Boolean);
+}
+
+function sanitizeStroke(stroke, index) {
+  const points = sanitizePoints(stroke?.points);
+  const fillPoints = sanitizePoints(stroke?.fillPoints);
+  if (!points.length && !fillPoints.length) {
+    return null;
+  }
+  const intent = INTENT_IDS.has(stroke?.intent) ? stroke.intent : "note";
+  const intentStyle = THREE_VIEW_MARKUP_INTENTS.find((candidate) => candidate.id === intent);
+  return {
+    id: cleanText(stroke?.id) || `stroke-${index + 1}`,
+    tool: cleanText(stroke?.tool) || "freehand",
+    intent,
+    color: cleanText(stroke?.color) || intentStyle.color,
+    fillColor: cleanText(stroke?.fillColor) || intentStyle.fillColor,
+    haloColor: cleanText(stroke?.haloColor) || "rgba(255, 255, 255, 0.94)",
+    points,
+    ...(fillPoints.length ? { fillPoints } : {}),
+    ...(stroke?.guessed === true ? { guessed: true } : {})
+  };
+}
+
+function sanitizeView(view, definition) {
+  return {
+    id: definition.id,
+    label: definition.label,
+    plane: definition.plane,
+    cameraPreset: definition.cameraPreset,
+    lookingAlong: definition.lookingAlong,
+    screenAxes: definition.screenAxes,
+    note: cleanText(view?.note),
+    strokes: (Array.isArray(view?.strokes) ? view.strokes : [])
+      .map(sanitizeStroke)
+      .filter(Boolean)
+  };
+}
+
+export function emptyThreeViewMarkupState() {
+  return Object.fromEntries(
+    THREE_VIEW_MARKUP_VIEWS.map((view) => [
+      view.id,
+      {
+        note: "",
+        strokes: []
+      }
+    ])
+  );
+}
+
+export function normalizeThreeViewMarkupDocument(value) {
+  if (!value || typeof value !== "object") {
+    throw new Error("Markup file must contain a JSON object.");
+  }
+  if (value.schema !== THREE_VIEW_MARKUP_SCHEMA) {
+    throw new Error(`Unsupported markup schema: ${cleanText(value.schema) || "missing"}.`);
+  }
+  if (Number(value.version) !== THREE_VIEW_MARKUP_VERSION) {
+    throw new Error(`Unsupported markup version: ${value.version ?? "missing"}.`);
+  }
+
+  const incomingViews = new Map(
+    (Array.isArray(value.views) ? value.views : [])
+      .filter((view) => VIEW_BY_ID.has(view?.id))
+      .map((view) => [view.id, view])
+  );
+
+  return {
+    schema: THREE_VIEW_MARKUP_SCHEMA,
+    version: THREE_VIEW_MARKUP_VERSION,
+    createdAt: cleanText(value.createdAt) || new Date().toISOString(),
+    coordinateSystem: "cad-z-up-v1",
+    source: {
+      file: cleanText(value.source?.file),
+      modelKey: cleanText(value.source?.modelKey),
+      renderFormat: cleanText(value.source?.renderFormat)
+    },
+    overallNote: cleanText(value.overallNote),
+    views: THREE_VIEW_MARKUP_VIEWS.map((definition) => (
+      sanitizeView(incomingViews.get(definition.id), definition)
+    ))
+  };
+}
+
+export function buildThreeViewMarkupDocument({
+  sourceFile = "",
+  modelKey = "",
+  renderFormat = "step",
+  overallNote = "",
+  viewState = {},
+  includeEmptyViews = true
+} = {}) {
+  const document = normalizeThreeViewMarkupDocument({
+    schema: THREE_VIEW_MARKUP_SCHEMA,
+    version: THREE_VIEW_MARKUP_VERSION,
+    createdAt: new Date().toISOString(),
+    coordinateSystem: "cad-z-up-v1",
+    source: {
+      file: sourceFile,
+      modelKey,
+      renderFormat
+    },
+    overallNote,
+    views: THREE_VIEW_MARKUP_VIEWS.map((view) => ({
+      ...view,
+      note: viewState?.[view.id]?.note || "",
+      strokes: viewState?.[view.id]?.strokes || []
+    }))
+  });
+  if (!includeEmptyViews) {
+    document.views = document.views.filter((view) => (
+      Boolean(view.note) || view.strokes.length > 0
+    ));
+  }
+  return document;
+}
+
+export function parseThreeViewMarkupDocument(text) {
+  let parsed;
+  try {
+    parsed = JSON.parse(String(text || ""));
+  } catch {
+    throw new Error("The selected file is not valid JSON.");
+  }
+  return normalizeThreeViewMarkupDocument(parsed);
+}
+
+export function viewStateFromThreeViewMarkupDocument(document) {
+  const normalized = normalizeThreeViewMarkupDocument(document);
+  return Object.fromEntries(
+    normalized.views.map((view) => [
+      view.id,
+      {
+        note: view.note,
+        strokes: view.strokes
+      }
+    ])
+  );
+}
+
+export function markupFilenameStem(sourceFile) {
+  const filename = cleanText(sourceFile).split(/[\\/]/u).pop() || "cad-part";
+  const stem = filename.replace(/\.[^.]+$/u, "") || "cad-part";
+  return stem.replace(/[^a-z0-9_-]+/giu, "_").replace(/^_+|_+$/gu, "") || "cad-part";
+}

--- a/viewer/src/client/workbench/threeViewMarkup.test.js
+++ b/viewer/src/client/workbench/threeViewMarkup.test.js
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildThreeViewMarkupDocument,
+  markupFilenameStem,
+  parseThreeViewMarkupDocument,
+  viewStateFromThreeViewMarkupDocument
+} from "./threeViewMarkup.js";
+
+test("builds a stable three-view markup document", () => {
+  const document = buildThreeViewMarkupDocument({
+    sourceFile: "robot/Upper arm.step",
+    modelKey: "upper-arm",
+    viewState: {
+      front: {
+        note: "Cut here",
+        strokes: [{
+          id: "stroke-7",
+          tool: "arrow",
+          intent: "remove",
+          color: "#ef4444",
+          points: [{ x: 0.25, y: 0.75 }, { x: 1.4, y: -1 }]
+        }]
+      }
+    }
+  });
+
+  assert.equal(document.schema, "cad-viewer-three-view-markup");
+  assert.deepEqual(document.views.map((view) => view.id), [
+    "front",
+    "back",
+    "top",
+    "bottom",
+    "right",
+    "left"
+  ]);
+  assert.equal(document.views[0].note, "Cut here");
+  assert.deepEqual(document.views[0].strokes[0].points, [
+    { x: 0.25, y: 0.75 },
+    { x: 1, y: 0 }
+  ]);
+});
+
+test("parses markup and restores editable view state", () => {
+  const source = buildThreeViewMarkupDocument({
+    overallNote: "Rotate the servo end",
+    viewState: {
+      right: {
+        note: "About Z",
+        strokes: [{
+          tool: "circle",
+          intent: "hardware",
+          points: [{ x: 0.4, y: 0.4 }, { x: 0.6, y: 0.4 }]
+        }]
+      }
+    }
+  });
+
+  const parsed = parseThreeViewMarkupDocument(JSON.stringify(source));
+  const state = viewStateFromThreeViewMarkupDocument(parsed);
+  assert.equal(parsed.overallNote, "Rotate the servo end");
+  assert.equal(state.right.note, "About Z");
+  assert.equal(state.right.strokes[0].intent, "hardware");
+});
+
+test("builds compact submissions with only changed views", () => {
+  const document = buildThreeViewMarkupDocument({
+    includeEmptyViews: false,
+    viewState: {
+      left: {
+        note: "Move this face 4 mm",
+        strokes: []
+      }
+    }
+  });
+
+  assert.deepEqual(document.views.map((view) => view.id), ["left"]);
+  const restored = viewStateFromThreeViewMarkupDocument(document);
+  assert.equal(restored.left.note, "Move this face 4 mm");
+  assert.equal(restored.front.note, "");
+});
+
+test("rejects unrelated JSON and creates safe file stems", () => {
+  assert.throws(
+    () => parseThreeViewMarkupDocument('{"schema":"other","version":1}'),
+    /Unsupported markup schema/u
+  );
+  assert.equal(markupFilenameStem("parts/Upper arm (editable).step"), "Upper_arm_editable");
+});


### PR DESCRIPTION
## What changed

- adds an orthographic markup workspace for STEP models with front/back/left/right/top/bottom projections
- allows one projection at a time, typed notes, drawing tools, and compact submissions containing only changed views
- adds a persistent toolbar entry and `?markup=three-view` launch support
- prevents the dev launcher from reusing an incompatible packaged viewer

## Why

This provides a simple visual feedback loop for CAD iteration: users can mark up only the views they changed and send a small machine-readable payload back to an agent.

## Validation

- `npm --prefix viewer run build`
- `node --test viewer/src/client/workbench/threeViewMarkup.test.js viewer/scripts/start-agent-viewer.test.mjs`
  - all markup tests and the new launcher-mode test pass
  - five pre-existing launcher tests fail on Windows because they assume POSIX paths or symlink privileges
- manual review in the fork viewer with a STEP model and `?markup=three-view`