### PR TITLE
Viewer: reduce load under software WebGL

### DIFF
--- a/packages/cadjs/src/lib/viewer/webglSupport.js
+++ b/packages/cadjs/src/lib/viewer/webglSupport.js
@@ -1,4 +1,5 @@
 const WEBGL_CONTEXT_ERROR_PATTERN = /(?:error creating webgl context|webgl context could not be created|failed to create webgl|webgl is not supported)/i;
+const SOFTWARE_WEBGL_RENDERER_PATTERN = /(?:swiftshader|llvmpipe|softpipe|software rasterizer|lavapipe)/i;
 
 export function runtimeErrorMessage(error) {
   return error instanceof Error ? error.message : String(error || "");
@@ -6,6 +7,23 @@ export function runtimeErrorMessage(error) {
 
 export function isWebGlContextCreationError(error) {
   return WEBGL_CONTEXT_ERROR_PATTERN.test(runtimeErrorMessage(error));
+}
+
+export function isSoftwareWebGlRenderer(renderer) {
+  const context = renderer?.getContext?.();
+  if (!context) {
+    return false;
+  }
+
+  let rendererName = "";
+  try {
+    const debugInfo = context.getExtension?.("WEBGL_debug_renderer_info");
+    const rendererParameter = debugInfo?.UNMASKED_RENDERER_WEBGL ?? context.RENDERER;
+    rendererName = String(context.getParameter?.(rendererParameter) || "");
+  } catch {
+    return false;
+  }
+  return SOFTWARE_WEBGL_RENDERER_PATTERN.test(rendererName);
 }
 
 export function buildRuntimeInitializationAlert(error) {

--- a/packages/cadjs/src/lib/viewer/webglSupport.test.js
+++ b/packages/cadjs/src/lib/viewer/webglSupport.test.js
@@ -3,9 +3,27 @@ import test from "node:test";
 
 import {
   buildRuntimeInitializationAlert,
+  isSoftwareWebGlRenderer,
   isWebGlContextCreationError,
   runtimeErrorMessage
 } from "./webglSupport.js";
+
+function rendererWithName(name, exposeDebugInfo = true) {
+  const debugInfo = exposeDebugInfo ? { UNMASKED_RENDERER_WEBGL: 1 } : null;
+  return {
+    getContext() {
+      return {
+        RENDERER: 2,
+        getExtension() {
+          return debugInfo;
+        },
+        getParameter() {
+          return name;
+        }
+      };
+    }
+  };
+}
 
 test("isWebGlContextCreationError recognizes Three.js context creation failures", () => {
   assert.equal(isWebGlContextCreationError(new Error("Error creating WebGL context.")), true);
@@ -14,6 +32,13 @@ test("isWebGlContextCreationError recognizes Three.js context creation failures"
     true
   );
   assert.equal(isWebGlContextCreationError(new Error("Failed to load render mesh")), false);
+});
+
+test("isSoftwareWebGlRenderer recognizes common software rasterizers", () => {
+  assert.equal(isSoftwareWebGlRenderer(rendererWithName("ANGLE (Google, SwiftShader Device)")), true);
+  assert.equal(isSoftwareWebGlRenderer(rendererWithName("llvmpipe (LLVM 18.1.3)", false)), true);
+  assert.equal(isSoftwareWebGlRenderer(rendererWithName("AMD Radeon Graphics (radeonsi)")), false);
+  assert.equal(isSoftwareWebGlRenderer(null), false);
 });
 
 test("buildRuntimeInitializationAlert reports WebGL as a blocking browser capability issue", () => {

--- a/viewer/src/client/components/CadViewer.js
+++ b/viewer/src/client/components/CadViewer.js
@@ -3174,7 +3174,7 @@ const CadViewer = forwardRef(function CadViewer({
     updateSpotLightTarget(runtime);
 
     // Keep a single primary shadow; the spot light drives the floor glow/fill.
-    runtime.keyLight.castShadow = runtime.keyLight.visible;
+    runtime.keyLight.castShadow = runtime.keyLight.visible && runtime.softwareRendering !== true;
     runtime.spotLight.castShadow = false;
 
     const materialSettings = {

--- a/viewer/src/client/components/viewer/hooks/useViewerRuntime.js
+++ b/viewer/src/client/components/viewer/hooks/useViewerRuntime.js
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { isEditableTarget } from "../../../ui/dom";
 import {
   isWebGlContextCreationError,
+  isSoftwareWebGlRenderer,
   runtimeErrorMessage
 } from "cadjs/lib/viewer/webglSupport";
 import {
@@ -155,13 +156,16 @@ export function useViewerRuntime({
       syncCameraViewport(orthographicCamera, width, height);
 
       const renderer = createWebGlRenderer(THREE);
+      const softwareRendering = isSoftwareWebGlRenderer(renderer);
+      const idlePixelRatioCap = softwareRendering ? 1 : IDLE_PIXEL_RATIO_CAP;
+      const interactionPixelRatioCap = softwareRendering ? 1 : INTERACTION_PIXEL_RATIO_CAP;
       renderer.outputColorSpace = THREE.SRGBColorSpace;
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = getViewerThemeValue(viewerTheme, "toneMappingExposure", DEFAULT_LIGHTING.toneMappingExposure);
       renderer.localClippingEnabled = true;
-      renderer.shadowMap.enabled = true;
+      renderer.shadowMap.enabled = !softwareRendering;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-      renderer.setPixelRatio(getPixelRatioCap(IDLE_PIXEL_RATIO_CAP));
+      renderer.setPixelRatio(getPixelRatioCap(idlePixelRatioCap));
       renderer.setSize(width, height);
       container.innerHTML = "";
       container.appendChild(renderer.domElement);
@@ -189,7 +193,7 @@ export function useViewerRuntime({
         getViewerThemeValue(viewerTheme, "keyLightIntensity", DEFAULT_LIGHTING.keyLightIntensity)
       );
       keyLight.position.set(240, -150, 340);
-      keyLight.castShadow = true;
+      keyLight.castShadow = !softwareRendering;
       keyLight.shadow.mapSize.set(2048, 2048);
       keyLight.shadow.bias = -0.00025;
       keyLight.shadow.normalBias = 0.024;
@@ -239,8 +243,8 @@ export function useViewerRuntime({
       const pointer = new THREE.Vector2();
       const interactionState = {
         active: false,
-        pixelRatioCap: IDLE_PIXEL_RATIO_CAP,
-        pixelRatio: getPixelRatioCap(IDLE_PIXEL_RATIO_CAP),
+        pixelRatioCap: idlePixelRatioCap,
+        pixelRatio: getPixelRatioCap(idlePixelRatioCap),
         renderQueued: false,
         renderQueuedAt: 0,
         renderFallbackTimerId: 0,
@@ -392,8 +396,8 @@ export function useViewerRuntime({
         }
         interactionState.active = true;
         applyRenderQuality(resolveInteractionPixelRatioCap({
-          idlePixelRatioCap: IDLE_PIXEL_RATIO_CAP,
-          interactionPixelRatioCap: INTERACTION_PIXEL_RATIO_CAP,
+          idlePixelRatioCap,
+          interactionPixelRatioCap,
           preservePixelRatio: runtimeRef.current?.preserveInteractionPixelRatio === true,
           screenSpaceLineMaterialCount: getScreenSpaceLineMaterialCount()
         }));
@@ -410,7 +414,7 @@ export function useViewerRuntime({
           controls.enableDamping = true;
           controls.dampingFactor = DEFAULT_DAMPING_FACTOR;
           controls.zoomSpeed = getDefaultZoomSpeed();
-          applyRenderQuality(IDLE_PIXEL_RATIO_CAP);
+          applyRenderQuality(idlePixelRatioCap);
           requestRender();
         }, INTERACTION_IDLE_DELAY_MS);
       };
@@ -563,6 +567,7 @@ export function useViewerRuntime({
         projection: "perspective",
         syncCameraViewport,
         renderer,
+        softwareRendering,
         Line2,
         LineGeometry,
         LineSegments2,


### PR DESCRIPTION
## Summary

- detect common software WebGL renderers through the renderer context
- cap software-rendered sessions at 1x pixel ratio
- disable shadow maps and key-light shadows only for software rendering
- preserve existing hardware-rendered behavior

## Validation

- packages/cadjs: 383 tests passed
- viewer: 386 tests passed, 4 skipped
- production Viewer build passed under Node 22
- development symlink layout check passed

Independent Forage review task 7836 was dispatched but had not completed within the bounded wait when this PR was opened.