### PR TITLE
snapshot: key render-asset URLs per file identity to fix stale cross-job mesh reuse

### DIFF
--- a/skills/cad/scripts/snapshot/__main__.py
+++ b/skills/cad/scripts/snapshot/__main__.py
@@ -12,6 +12,7 @@ import time
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from hashlib import sha256
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote, unquote, urlparse
@@ -572,7 +573,25 @@ def encode_path_param(value: str) -> str:
 def asset_url_for_path(file_path: Path, root_path: Path) -> str:
     if not path_is_inside_or_equal(file_path, root_path):
         raise SnapshotError(f"Render asset must be inside the snapshot render root: {file_path}")
-    return f"/__render_asset/{encode_path_param(file_path.resolve().relative_to(root_path.resolve()).as_posix())}"
+    resolved_path = file_path.resolve()
+    relative_path = resolved_path.relative_to(root_path.resolve()).as_posix()
+    base_url = f"/__render_asset/{encode_path_param(relative_path)}"
+    try:
+        file_stat = resolved_path.stat()
+    except OSError:
+        # Same-stem generator inputs resolve to a STEP path that is never written
+        # (the generator runs with skip_step_write=True), so there is nothing to
+        # version; keep the unversioned URL for those.
+        return base_url
+    cache_identity = "\0".join(
+        (
+            str(resolved_path),
+            str(file_stat.st_size),
+            str(file_stat.st_mtime_ns),
+        )
+    )
+    cache_key = sha256(cache_identity.encode("utf-8")).hexdigest()[:16]
+    return f"{base_url}?v={cache_key}"
 
 
 def step_parameter_path_for_step_source(source_path: Path) -> Path:

--- a/skills/cad/scripts/snapshot/__main__.py
+++ b/skills/cad/scripts/snapshot/__main__.py
@@ -578,10 +578,12 @@ def asset_url_for_path(file_path: Path, root_path: Path) -> str:
     base_url = f"/__render_asset/{encode_path_param(relative_path)}"
     try:
         file_stat = resolved_path.stat()
-    except OSError:
+    except FileNotFoundError:
         # Same-stem generator inputs resolve to a STEP path that is never written
         # (the generator runs with skip_step_write=True), so there is nothing to
-        # version; keep the unversioned URL for those.
+        # version; keep the unversioned URL for those. Any other stat failure is
+        # left to propagate: silently falling back to an unversioned URL would
+        # re-enable the very collision this key exists to prevent.
         return base_url
     cache_identity = "\0".join(
         (

--- a/tests/python/skills/cad/snapshot/test_cli.py
+++ b/tests/python/skills/cad/snapshot/test_cli.py
@@ -362,6 +362,26 @@ class SnapshotCliTests(unittest.TestCase):
             url = snapshot_main.asset_url_for_path(missing_step, root)
         self.assertEqual(url, "/__render_asset/model.step")
 
+    def test_asset_url_does_not_swallow_unexpected_stat_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            asset = root / "model.step"
+            asset.write_text("ISO-10303-21;\nEND-ISO-10303-21;\n", encoding="utf-8")
+
+            original_stat = Path.stat
+
+            def denying_stat(self, *args, **kwargs):
+                if self == asset.resolve():
+                    raise PermissionError(13, "stat denied", str(self))
+                return original_stat(self, *args, **kwargs)
+
+            try:
+                Path.stat = denying_stat
+                with self.assertRaises(PermissionError):
+                    snapshot_main.asset_url_for_path(asset, root)
+            finally:
+                Path.stat = original_stat
+
     def test_render_job_ensures_step_artifact_for_step_input(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory).resolve()

--- a/tests/python/skills/cad/snapshot/test_cli.py
+++ b/tests/python/skills/cad/snapshot/test_cli.py
@@ -368,11 +368,14 @@ class SnapshotCliTests(unittest.TestCase):
             asset = root / "model.step"
             asset.write_text("ISO-10303-21;\nEND-ISO-10303-21;\n", encoding="utf-8")
 
+            denied = str(asset.resolve())
             original_stat = Path.stat
 
             def denying_stat(self, *args, **kwargs):
-                if self == asset.resolve():
-                    raise PermissionError(13, "stat denied", str(self))
+                # No Path operations in here: Path.resolve() calls stat() on some
+                # platforms, which would re-enter this patch recursively.
+                if str(self) == denied:
+                    raise PermissionError(13, "stat denied", denied)
                 return original_stat(self, *args, **kwargs)
 
             try:

--- a/tests/python/skills/cad/snapshot/test_cli.py
+++ b/tests/python/skills/cad/snapshot/test_cli.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
 from tests.python.support.paths import add_repo_path, repo_path
@@ -368,22 +369,19 @@ class SnapshotCliTests(unittest.TestCase):
             asset = root / "model.step"
             asset.write_text("ISO-10303-21;\nEND-ISO-10303-21;\n", encoding="utf-8")
 
-            denied = str(asset.resolve())
+            # Resolve up front: on Python 3.12 Path.resolve() calls Path.stat()
+            # internally, so resolving inside the patch would recurse forever.
+            resolved_asset = asset.resolve()
             original_stat = Path.stat
 
             def denying_stat(self, *args, **kwargs):
-                # No Path operations in here: Path.resolve() calls stat() on some
-                # platforms, which would re-enter this patch recursively.
-                if str(self) == denied:
-                    raise PermissionError(13, "stat denied", denied)
+                if self == resolved_asset:
+                    raise PermissionError(13, "stat denied", str(self))
                 return original_stat(self, *args, **kwargs)
 
-            try:
-                Path.stat = denying_stat
+            with mock.patch.object(Path, "stat", denying_stat):
                 with self.assertRaises(PermissionError):
                     snapshot_main.asset_url_for_path(asset, root)
-            finally:
-                Path.stat = original_stat
 
     def test_render_job_ensures_step_artifact_for_step_input(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tests/python/skills/cad/snapshot/test_cli.py
+++ b/tests/python/skills/cad/snapshot/test_cli.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from urllib.parse import parse_qs, urlparse
 
 from tests.python.support.paths import add_repo_path, repo_path
 
@@ -302,8 +303,64 @@ class SnapshotCliTests(unittest.TestCase):
         self.assertNotIn("workspaceRoot", job)
         self.assertNotIn("rootDir", job)
         self.assertEqual(job["resolved"]["rootPath"], str(models))
-        self.assertEqual(job["resolved"]["inputUrl"], "/__render_asset/part.step")
-        self.assertEqual(job["resolved"]["glbUrl"], "/__render_asset/.part.step.glb")
+        input_url = urlparse(job["resolved"]["inputUrl"])
+        glb_url = urlparse(job["resolved"]["glbUrl"])
+        self.assertEqual(input_url.path, "/__render_asset/part.step")
+        self.assertEqual(glb_url.path, "/__render_asset/.part.step.glb")
+        self.assertRegex(parse_qs(input_url.query)["v"][0], r"^[0-9a-f]{16}$")
+        self.assertRegex(parse_qs(glb_url.query)["v"][0], r"^[0-9a-f]{16}$")
+
+    def test_multijob_asset_urls_do_not_collide_across_render_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            for folder_name in ("first", "second"):
+                folder = root / folder_name
+                folder.mkdir()
+                (folder / "model.step").write_text(
+                    "ISO-10303-21;\nEND-ISO-10303-21;\n",
+                    encoding="utf-8",
+                )
+                (folder / ".model.step.glb").write_bytes(b"glb")
+
+            original_ensure = snapshot_main.ensure_step_topology_artifact
+            try:
+                snapshot_main.ensure_step_topology_artifact = lambda *args, **kwargs: None
+                packet = resolve_render_job_packet(
+                    {
+                        "jobs": [
+                            {
+                                "input": "first/model.step",
+                                "outputs": [{"path": "first.png"}],
+                            },
+                            {
+                                "input": "second/model.step",
+                                "outputs": [{"path": "second.png"}],
+                            },
+                        ]
+                    },
+                    cwd=root,
+                )
+            finally:
+                snapshot_main.ensure_step_topology_artifact = original_ensure
+
+        first_resolved = packet["jobs"][0]["resolved"]
+        second_resolved = packet["jobs"][1]["resolved"]
+        self.assertEqual(
+            urlparse(first_resolved["glbUrl"]).path,
+            urlparse(second_resolved["glbUrl"]).path,
+        )
+        self.assertNotEqual(
+            first_resolved["glbUrl"],
+            second_resolved["glbUrl"],
+        )
+
+    def test_asset_url_unversioned_for_generator_input_without_step_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            missing_step = root / "model.step"
+            self.assertFalse(missing_step.exists())
+            url = snapshot_main.asset_url_for_path(missing_step, root)
+        self.assertEqual(url, "/__render_asset/model.step")
 
     def test_render_job_ensures_step_artifact_for_step_input(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary

When `scripts/snapshot` batches multiple jobs into one Chromium page, jobs whose inputs **resolve to the same asset URL** silently render the **first** job's geometry. Exit code 0, no warning. (Same-basename inputs in different directories are the common case, but the trigger is URL identity, not filename identity — see the sidecar case below.)

## Mechanism

- Asset URLs are built relative to the per-job render root (`asset_url_for_path`, `skills/cad/scripts/snapshot/__main__.py:572`), and the root defaults to the input's parent directory (`:849`) — so `first/model.step` and `second/model.step` both become `/__render_asset/model.step` (and both GLBs `/__render_asset/.model.step.glb`).
- **This is not the HTTP cache.** The runtime memoises assets in *page-lifetime JS Maps keyed by the raw URL string* (`packages/cadjs/src/lib/renderAssetClient.js:28`, `loadCached(glbCache, url, ...)` at `:239-240`), and the batch renderer keeps one page across all jobs. On a collision **no request is issued at all** — instrumenting the route handler to log requests per job shows **job 1 making 0 asset requests** where the control batch makes 1 each. The per-job `active_root_path` swap is correct but unreachable, and `cache-control: no-store` never gets a chance to matter.
- The stale layers are application-level: the byte cache and its in-flight map gating the sole fetch site, the parsed-GLB/topology/selector/display-edge memos above it, **and the ES-module `import()` of `.step.js` sidecars** — the last one being unevictable from JS at all, so only a URL change can fix it. Isolated demonstration: two jobs with *different* mesh URLs but a colliding sidecar URL produce a correct mesh wearing the **first job's pose** — a failure that looks like a plausible render of the right part.

## Repro

For fixed inputs and settings the pipeline rendered byte-identically across repeated invocations in this repro, so hashes serve as a clean instrument here. Two genuinely different models, both named `model.step` in sibling directories, one `--job` batch, same camera:

| | output A | output B |
|---|---|---|
| unpatched | `43ec94fcc5c4ea14` | `43ec94fcc5c4ea14` — **byte-identical to A** |
| patched | `43ec94fcc5c4ea14` — unchanged | `85b955e256c6fc9a` — renders as itself |

Patched output A is byte-identical to unpatched output A: the healthy path is untouched; only the poisoned path changes.

## Fix

Append a file-identity version key to render-asset URLs: `?v=sha256(abs_path, size, mtime_ns)[:16]`. Unchanged files keep a stable key, so legitimate cache reuse within a job still hits; distinct resolved paths, and ordinary changes that alter size or `mtime_ns`, get different keys. Same-stem **generator** inputs resolve to a STEP path that is deliberately never written (`skip_step_write=True`) — those keep the unversioned URL (nothing to version), verified against a live generator-input render. That fallback is narrowed to `FileNotFoundError` on purpose: any other stat failure propagates rather than silently degrading to an unversioned, collision-capable URL.

Server routing is unaffected: request routing is on `urlparse(request.url).path`, and the runtime strips `[?#]` before extension sniffing. Verified after patching that a colliding pair now issues its own request per job (the sidecar case above goes from 1 request to 2, distinct `?v=` keys), and that legitimate reuse still hits — the four runtimes that request the same GLB within one job still share a single fetch.

One thing this does **not** add, if you want it: nothing in the pipeline would notice a *future* re-collision. A cheap assertion — the runtime rejecting a cache hit whose recorded source path differs from the job's — would convert a silent wrong image into an error. Happy to send that separately if it appeals.

**Consistency note:** `packages/implicitjs/scripts/snapshot.mjs` already versions its asset URLs by file identity (`path:mtimeMs:size`, base64url). This PR brings the cadjs/STEP path in line with that existing convention. I used `sha256[:16]` (opaque, fixed length, no absolute-path leak into URLs) — happy to switch to the mjs encoding if you'd rather have one form.

## Tests

- Existing URL assertions updated to parse the URL and verify path + `v` key format.
- New: `test_multijob_asset_urls_do_not_collide_across_render_roots` — red on unpatched code (URLs byte-equal), green with the fix.
- New: `test_asset_url_unversioned_for_generator_input_without_step_file` — guards the generator flow.
- New: `test_asset_url_does_not_swallow_unexpected_stat_failures` — an existing file whose `stat` raises `PermissionError` must raise, not degrade to an unversioned URL.
- Suite: 27 tests, 26 pass on Windows. The one failure (`test_timestamp_output_path_preserves_extension`) pre-exists on base `184cfbb` and is Windows-only (`Path.with_name` yields backslashes; Linux CI never sees it) — deliberately not mixed into this PR; happy to send it separately.

## Also affects `release/0.4.0`

The same mechanism is present there (`asset_url_for_path` at `__main__.py:701`, same `renderAssetClient.js` caches), with a wider input surface (direct GLB/STL inputs, `__cadgen__` component namespace) that needs the same treatment in more URL builders. The concept ports one-to-one but a literal diff won't apply — I can follow up with the 0.4.0 pass after this lands, if useful.

## Context

Found while batch-rendering parametric scroll sequences on Windows — our own runs escaped the bug only because every state file happened to have a unique name. Two smaller follow-ups are ready separately (a `--camera` file-path form matching `--display`/`--appearance`, and BOM-tolerant reads for the three user-authored JSON inputs, which PowerShell writes by default).
