### PR TITLE
fix(gcode): name the conversion skill and command when rejecting non-mesh inputs

### DIFF
--- a/skills/gcode/SKILL.md
+++ b/skills/gcode/SKILL.md
@@ -122,7 +122,11 @@ Preferred slicer backend order is `orcaslicer`, `prusa-slicer`, then `curaengine
 
 Pass `.stl`, `.obj`, and unsliced `.3mf` directly to the slicer. Convert `.ply`, `.glb`, and `.gltf` to temporary STL at execution time with optional `trimesh`; if `trimesh` is unavailable, ask the user to install it or provide `.stl`, `.obj`, or unsliced `.3mf`.
 
-Reject `.step`, `.stp`, `.dxf`, `.svg`, `.urdf`, and `.sdf` in v1. Use the existing CAD/render workflows to convert those to a supported mesh format before using this skill.
+Reject `.step`, `.stp`, `.dxf`, `.svg`, `.urdf`, and `.sdf` in v1. `inspect` and `slice` fail with a structured `remediation` object naming the skill and command that produce a sliceable mesh; use it instead of inferring a conversion workflow:
+
+- `.step`, `.stp`: boundary-representation CAD, not a mesh. Export an STL sidecar with `$cad` (`python scripts/step --kind part <input> --stl <output>.stl`, or target the generator with `python scripts/step <model>.step.py --stl <output>.stl`), then slice the exported `.stl` here.
+- `.dxf`, `.svg`: 2D drawings with no 2D-to-mesh conversion in this toolchain. Model the 3D solid in `$cad` with `gen_step()` and export an STL sidecar, then slice that. If the part is a flat cut rather than a print, use `$sendcutsend` instead of this skill.
+- `.urdf`, `.sdf`: robot descriptions that reference per-link mesh files. Slice the referenced `.stl`/`.obj` meshes one at a time; regenerate stale or missing ones from the owning CAD source with `$cad` first. Use `$urdf` or `$sdf` for the robot description itself.
 
 Read `references/slicer-backends.md` when backend behavior, profile expectations, or source links matter.
 

--- a/skills/gcode/references/slicer-backends.md
+++ b/skills/gcode/references/slicer-backends.md
@@ -71,7 +71,10 @@ Always run a dry-run first and inspect the emitted command before `--execute`.
 - `.stl`, `.obj`, and unsliced `.3mf` are passed directly to the selected slicer.
 - `.ply`, `.glb`, and `.gltf` are converted to temporary STL with `trimesh` during `--execute`.
 - Sliced Bambu 3MF files containing `Metadata/plate_N.gcode` are already print jobs; do not re-slice them.
-- `.step`, `.stp`, `.dxf`, `.svg`, `.urdf`, and `.sdf` are out of scope for this skill. Convert them to a supported mesh first.
+- `.step`, `.stp`, `.dxf`, `.svg`, `.urdf`, and `.sdf` are out of scope for this skill. `inspect_input` rejects them with a `remediation` object (`skill`, `reason`, `next_step`) that names the owning skill and the exact conversion command; both `inspect` and `slice` surface it in their JSON error payload.
+  - `.step`, `.stp`: export an STL sidecar with `$cad` (`python scripts/step --kind part <input> --stl <output>.stl`).
+  - `.dxf`, `.svg`: no 2D-to-mesh path exists; model the solid in `$cad`, or use `$sendcutsend` when the part is a flat cut rather than a print.
+  - `.urdf`, `.sdf`: slice the per-link meshes the description references, regenerating them from CAD with `$cad` when stale.
 
 ## Source Links
 

--- a/skills/gcode/scripts/gcode_tool.py
+++ b/skills/gcode/scripts/gcode_tool.py
@@ -19,7 +19,49 @@ from typing import Any
 
 DIRECT_MESH_EXTENSIONS = {".stl", ".obj", ".3mf"}
 CONVERT_TO_STL_EXTENSIONS = {".ply", ".glb", ".gltf"}
-UNSUPPORTED_EXTENSIONS = {".step", ".stp", ".dxf", ".svg", ".urdf", ".sdf"}
+
+_STEP_REMEDIATION = {
+    "skill": "cad",
+    "reason": "STEP/STP is boundary-representation CAD, not a mesh.",
+    "next_step": (
+        "Export an STL sidecar with $cad: `python scripts/step --kind part <input> --stl <output>.stl`. "
+        "When a Python generator exists, target it instead: `python scripts/step <model>.step.py --stl <output>.stl`. "
+        "Then slice the exported .stl with this skill."
+    ),
+}
+_FLAT_2D_REMEDIATION = {
+    "skill": "cad",
+    "reason": "This is a 2D drawing, not a printable solid, and this toolchain has no 2D-to-mesh conversion.",
+    "next_step": (
+        "For an FDM print, model the 3D solid in $cad with `gen_step()` and export an STL sidecar "
+        "(`python scripts/step <model>.step.py --stl <output>.stl`), then slice that .stl here. "
+        "If the part is a flat cut rather than a print, use $sendcutsend instead of this skill."
+    ),
+}
+
+
+def _robot_description_remediation(skill: str, label: str) -> dict[str, str]:
+    return {
+        "skill": skill,
+        "reason": f"{label} is a robot description that references per-link mesh files; it is not itself a mesh.",
+        "next_step": (
+            f"Slice the per-link .stl/.obj meshes the {label} references, one mesh at a time. "
+            f"If those meshes are missing or stale, regenerate them from the owning CAD source with $cad "
+            "(`python scripts/step <model>.step.py --stl <output>.stl`), then slice the exported mesh here. "
+            f"Use ${skill} for the robot description itself."
+        ),
+    }
+
+
+UNSUPPORTED_INPUT_REMEDIATION = {
+    ".step": _STEP_REMEDIATION,
+    ".stp": _STEP_REMEDIATION,
+    ".dxf": _FLAT_2D_REMEDIATION,
+    ".svg": _FLAT_2D_REMEDIATION,
+    ".urdf": _robot_description_remediation("urdf", "URDF"),
+    ".sdf": _robot_description_remediation("sdf", "SDF"),
+}
+UNSUPPORTED_EXTENSIONS = set(UNSUPPORTED_INPUT_REMEDIATION)
 SLICED_BAMBU_PLATE_RE = re.compile(r"^Metadata/plate_(\d+)\.gcode$")
 
 PREFERRED_BACKEND_ORDER = ["orcaslicer", "prusa-slicer", "curaengine"]
@@ -78,6 +120,10 @@ SUPPORTED_GCODE_COMMANDS = {
 
 class GCodeToolError(RuntimeError):
     """Raised for expected user-facing workflow errors."""
+
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details = details or {}
 
 
 @dataclass(frozen=True)
@@ -351,9 +397,14 @@ def inspect_input(path: Path) -> InputInspection:
         raise GCodeToolError(f"Input file does not exist: {resolved}")
 
     extension = resolved.suffix.lower()
-    if extension in UNSUPPORTED_EXTENSIONS:
+    remediation = UNSUPPORTED_INPUT_REMEDIATION.get(extension)
+    if remediation is not None:
         supported = ", ".join(sorted(DIRECT_MESH_EXTENSIONS | CONVERT_TO_STL_EXTENSIONS))
-        raise GCodeToolError(f"{extension} is out of scope for this skill. Supported v1 mesh inputs: {supported}.")
+        raise GCodeToolError(
+            f"{extension} is out of scope for this skill. Supported v1 mesh inputs: {supported}. "
+            f"{remediation['reason']} {remediation['next_step']}",
+            details={"remediation": {"extension": extension, **remediation}},
+        )
     if extension not in DIRECT_MESH_EXTENSIONS | CONVERT_TO_STL_EXTENSIONS:
         supported = ", ".join(sorted(DIRECT_MESH_EXTENSIONS | CONVERT_TO_STL_EXTENSIONS))
         raise GCodeToolError(f"Unsupported input extension {extension or '<none>'}. Supported v1 mesh inputs: {supported}.")
@@ -733,7 +784,9 @@ def main(argv: list[str] | None = None) -> int:
     try:
         return args.func(args)
     except GCodeToolError as exc:
-        print_json({"ok": False, "error": str(exc)})
+        payload: dict[str, Any] = {"ok": False, "error": str(exc)}
+        payload.update(exc.details)
+        print_json(payload)
         return 2
 
 

--- a/tests/python/skills/gcode/test_gcode_tool.py
+++ b/tests/python/skills/gcode/test_gcode_tool.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import os
 import tempfile
@@ -159,6 +161,59 @@ class GCodeToolTests(unittest.TestCase):
             step.write_text("ISO-10303-21;", encoding="utf-8")
             with self.assertRaisesRegex(gcode.GCodeToolError, "out of scope"):
                 gcode.inspect_input(step)
+
+    def test_rejected_inputs_name_the_conversion_skill_and_command(self) -> None:
+        expected_skills = {
+            ".step": "cad",
+            ".stp": "cad",
+            ".dxf": "cad",
+            ".svg": "cad",
+            ".urdf": "urdf",
+            ".sdf": "sdf",
+        }
+        self.assertEqual(gcode.UNSUPPORTED_EXTENSIONS, set(expected_skills))
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for extension, skill in expected_skills.items():
+                with self.subTest(extension=extension):
+                    rejected = root / f"part{extension}"
+                    rejected.write_text("placeholder\n", encoding="utf-8")
+
+                    with self.assertRaises(gcode.GCodeToolError) as caught:
+                        gcode.inspect_input(rejected)
+                    remediation = caught.exception.details["remediation"]
+                    self.assertEqual(remediation["extension"], extension)
+                    self.assertEqual(remediation["skill"], skill)
+                    self.assertTrue(remediation["reason"])
+                    self.assertIn(f"${skill}", remediation["next_step"])
+                    self.assertIn(".stl", remediation["next_step"])
+
+                    stdout = io.StringIO()
+                    with contextlib.redirect_stdout(stdout):
+                        code = gcode.main(["inspect", "--input", str(rejected), "--json"])
+                    payload = json.loads(stdout.getvalue())
+                    self.assertEqual(code, 2)
+                    self.assertFalse(payload["ok"])
+                    self.assertIn("out of scope", payload["error"])
+                    self.assertEqual(payload["remediation"], remediation)
+
+            profile = write_profile(root)
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                code = gcode.main(
+                    [
+                        "slice",
+                        "--input",
+                        str(root / "part.step"),
+                        "--output",
+                        str(root / "part.gcode"),
+                        "--profile",
+                        str(profile),
+                        "--dry-run",
+                    ]
+                )
+            self.assertEqual(code, 2)
+            self.assertEqual(json.loads(stdout.getvalue())["remediation"]["skill"], "cad")
 
     def test_dry_run_command_construction_for_each_backend(self) -> None:
         cases = [


### PR DESCRIPTION
Closes #164.

## Problem

`gcode` rejects `.step`, `.stp`, `.dxf`, `.svg`, `.urdf`, and `.sdf` with a generic message pointing at unnamed "existing CAD/render workflows":

```
.step is out of scope for this skill. Supported v1 mesh inputs: .3mf, .glb, .gltf, .obj, .ply, .stl.
```

An agent orchestrating skills has to infer the conversion step itself, which invites a hallucinated workflow. The issue's suggested `gen_stl` is an example of exactly that — no such entry point exists; the source contract is `gen_step()` and STL is a sidecar flag on `$cad`'s `scripts/step`.

## Change

This implements option 2 from the issue — a structured error naming the exact skill and command. Option 1 (dispatching the conversion from the gcode entry point) is not available: `AGENTS.md` requires skills to be self-contained at runtime, so `gcode_tool.py` cannot import or invoke `$cad`. Naming the handoff in prose is the established convention here (`$cad-viewer`, `$bambu-labs`, `$step-parts`).

- `UNSUPPORTED_EXTENSIONS` is now derived from `UNSUPPORTED_INPUT_REMEDIATION`, an extension to `{skill, reason, next_step}` map.
- `GCodeToolError` carries an optional `details` dict; `main()` merges it into the JSON payload instead of flattening to a bare string.
- `build_slice_plan` already routes through `inspect_input`, so `inspect`, `slice --dry-run`, and `slice --execute` all surface the same `remediation`.

```json
{
  "error": ".step is out of scope for this skill. Supported v1 mesh inputs: ... STEP/STP is boundary-representation CAD, not a mesh. Export an STL sidecar with $cad: ...",
  "ok": false,
  "remediation": {
    "extension": ".step",
    "next_step": "Export an STL sidecar with $cad: `python scripts/step --kind part <input> --stl <output>.stl`. When a Python generator exists, target it instead: `python scripts/step <model>.step.py --stl <output>.stl`. Then slice the exported .stl with this skill.",
    "reason": "STEP/STP is boundary-representation CAD, not a mesh.",
    "skill": "cad"
  }
}
```

## Mapping

| Input | Owner | Path |
| --- | --- | --- |
| `.step`, `.stp` | `$cad` | `python scripts/step --kind part <input> --stl <output>.stl`, then slice the `.stl` |
| `.dxf`, `.svg` | `$cad` / `$sendcutsend` | No 2D-to-mesh path exists; model the solid in `$cad`, or use `$sendcutsend` when the part is a flat cut rather than a print |
| `.urdf`, `.sdf` | `$urdf` / `$sdf` | Not convertible — they reference per-link meshes; slice those, regenerating stale ones from CAD |

`SKILL.md` and `references/slicer-backends.md` carry the same mapping so the agent-facing docs and the tool output agree.

## Tests

`test_rejected_inputs_name_the_conversion_skill_and_command` pins the expected skill per extension and asserts the mapping's key set equals `UNSUPPORTED_EXTENSIONS`, so a newly rejected type cannot be added without remediation. It checks the CLI JSON payload on both the `inspect` and `slice` paths.

Run locally:

- `scripts/test/test-python.sh` — all suites OK (gcode 10/10)
- `scripts/test/test-global.sh` — 7/7 OK, including skill self-containment
- `scripts/bundle/bundle.sh --check` — all bundle outputs up to date

🤖 Generated with [Claude Code](https://claude.com/claude-code)
