### PR TITLE
fix(cad-viewer): document the startup command the bundled runtime ships

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,16 +160,24 @@ When reviewing repo fixtures in CAD Viewer, point the Viewer at the repo
 generated CAD/robot-description files in `models/` so the viewer catalog and
 artifacts stay in one place.
 
-Start or reuse the Viewer through the `cad-viewer` skill launcher and use the
-base URL it prints. The launcher owns port selection, reuses a compatible live
-Viewer for the same worktree/branch, and uses the source app in Vite dev mode
-when the skill viewer path is a development symlink.
+Start or reuse the Viewer through the `serve` entrypoint documented in
+`skills/cad-viewer/SKILL.md` and use the base URL it prints. `serve` is the only
+startup command the bundled skill runtime ships, so document and use it in both
+layouts; it owns port selection, binding `4178` when free and scanning forward
+when it is not.
 
 Run from `skills/cad-viewer`:
 
 ```bash
-npm --prefix scripts/viewer run agent:start -- --host 127.0.0.1 --shutdown-after 12h
+npm --prefix scripts/viewer run serve -- --host 127.0.0.1 --dir <absolute-model-root> --shutdown-after 12h --json
 ```
+
+`--dir` is required for a useful catalog and must be absolute. Read the bound
+port from the `--json` startup line rather than assuming `4178`.
+
+`viewer/scripts/start-agent-viewer.mjs` (`npm run agent:start`) is a
+source-checkout-only launcher that adds Vite dev mode and cross-worktree reuse.
+It is not bundled into the skill runtime, so never document it in `skills/`.
 
 Every returned Viewer URL must include `?dir=<absolute-model-root>`, commonly
 `<repo>/models`, and `file=<path>` values must be relative to `?dir=`. Do not

--- a/skills/cad-viewer/SKILL.md
+++ b/skills/cad-viewer/SKILL.md
@@ -15,38 +15,45 @@ live review links. The expected input is one or more explicit file paths.
 
 ## Start Viewer
 
-Start or reuse one local CAD Viewer with `npm run agent:start`, passing the
-absolute artifact directory as `--dir`. The `agent:start` launcher owns port
-selection, compatible-server reuse, directory activation, and the `?dir=` query
-parameter. Dev-mode viewers are reused only for matching git identities; dist
-bundle viewers can be reused across git branches when their viewer versions
-match. It activates reused servers through the Viewer's lightweight directory
-activation API, without requiring agents to probe ports or trigger catalog
-scans manually. Use the Viewer URL printed by `agent:start` as-is, then add only
-a `file=` query value for the artifact you want to review.
+Use one local CAD Viewer per machine and serve every directory through `?dir=`.
+The Viewer advertises `dynamic-root`, so a single server answers for any
+absolute directory; you never need a second server just to change directories.
 
-Choose `--dir` as the absolute directory that contains the model
-artifacts and sidecars, commonly `<repo>/models` or the consuming project's
-equivalent model directory. The `file=` value must be relative to that `--dir`.
-Do not manually choose ports, probe servers, rewrite `?dir=`, or start a
-separate Viewer just to change directories.
-
-Run from this skill directory:
+First check whether a reusable Viewer is already running on the default port:
 
 ```bash
-npm --prefix scripts/viewer run agent:start -- --host 127.0.0.1 --dir <absolute-model-root>
+curl -sS -m 2 http://127.0.0.1:4178/__cad/server
 ```
 
-Use the printed Viewer URL and append `file=`:
+Reuse that server when the response is JSON with `"app": "cad-viewer"` and
+`"dynamicRoot": true`. Take its `url` and `port` from the response and skip
+straight to Links. Start your own server instead when the probe fails, or when
+the response's `viewerVersion` differs from the `version` in
+`scripts/viewer/package.json` — a different version is another checkout's
+Viewer, not this skill's runtime.
+
+To start one, run from this skill directory:
 
 ```bash
-http://127.0.0.1:<printed-port>/?dir=/absolute/project/models&file=path/to/model.step
+npm --prefix scripts/viewer run serve -- --host 127.0.0.1 --dir <absolute-model-root> --shutdown-after 12h --json
 ```
 
-If a non-Viewer process or another worktree's Viewer occupies the candidate
-port, the launcher will continue automatically. In sandboxed agent environments,
-local binding or probe failures such as `EPERM` or `EACCES` can be expected;
-rerun the same command with the needed permission/escalation.
+Choose `--dir` as the absolute directory that contains the model artifacts and
+sidecars, commonly `<repo>/models` or the consuming project's equivalent model
+directory. The `file=` value must be relative to that `--dir`.
+
+The server binds `4178` when it is free and scans forward when it is not, so do
+not pick ports by hand or probe for a free one. Read the bound port from the
+`--json` startup line described under Claude Preview rather than assuming
+`4178`, then append `file=`:
+
+```bash
+http://127.0.0.1:<bound-port>/?dir=/absolute/project/models&file=path/to/model.step
+```
+
+In sandboxed agent environments, local binding or probe failures such as `EPERM`
+or `EACCES` can be expected; rerun the same command with the needed
+permission/escalation.
 
 ## Links
 
@@ -59,33 +66,32 @@ rerun the same command with the needed permission/escalation.
 - Start/reuse the Viewer once per absolute directory `--dir`, then append
   `file=<path>` for each requested file. The file path must be relative to
   `--dir`.
-- For directory-only review links, return the URL printed by `agent:start`
+- For directory-only review links, return the started or reused Viewer URL
   without adding `file=`.
 - Do not stop an existing Viewer server unless the user asks.
 - If Viewer startup fails, report the failure and continue with the owning skill's non-GUI validation or artifacts.
 
 ## Claude Preview
 
-The viewer port is dynamic — it is chosen at startup and may differ across
-worktrees. To integrate with the Claude Preview tool, add `--json` to the
-`agent:start` command:
+The viewer port is dynamic — `4178` is only the first candidate, and the server
+scans forward when it is taken. To integrate with the Claude Preview tool, pass
+`--json` when starting the server:
 
 ```bash
-npm --prefix scripts/viewer run agent:start -- --host 127.0.0.1 --dir <absolute-model-root> --json
+npm --prefix scripts/viewer run serve -- --host 127.0.0.1 --dir <absolute-model-root> --shutdown-after 12h --json
 ```
 
-The launcher writes a JSON result line to stdout after the human-readable lines.
+The server writes a JSON result line to stdout after the human-readable lines.
 Parse it by taking the last line of stdout that begins with `{`:
 
 ```json
-{"url":"http://127.0.0.1:<port>/?dir=<absolute-model-root>","port":<port>,"action":"reuse"}
+{"url":"http://127.0.0.1:<port>/?dir=<absolute-model-root>","host":"127.0.0.1","port":<port>,"action":"start"}
 ```
 
-`action` is `"reuse"` when an existing server was reused and is immediately
-ready, or `"start"` when a new server process was spawned and may still be
-initializing. For a `"start"` result, probe `GET /__cad/server` on the base
-URL (e.g. `http://127.0.0.1:<port>/__cad/server`) until it returns HTTP 200
-before passing the `url` value to the Claude Preview tool.
+The line is written once the listener is bound, so `url` is ready to hand to
+the Claude Preview tool without further probing. When you reused an existing
+Viewer from the `/__cad/server` probe instead of starting one, use that
+response's `url` and append `?dir=<absolute-model-root>` yourself.
 
 ## References
 

--- a/tests/python/global/test_documented_viewer_commands.py
+++ b/tests/python/global/test_documented_viewer_commands.py
@@ -1,0 +1,167 @@
+"""Guard the skill-docs-to-bundled-runtime contract for CAD Viewer startup.
+
+`skills/**` is published to consumers who only ever get the *generated* runtime,
+so an npm script or CLI flag that exists in `viewer/` but never reaches the
+bundle makes the documented startup command fail on every install. These tests
+compare what the Markdown tells agents to run against what the bundler actually
+generates.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SKILLS_ROOT = REPO_ROOT / "skills"
+AGENTS_DOC = REPO_ROOT / "AGENTS.md"
+VIEWER_RUNTIME_DIR = REPO_ROOT / "skills" / "cad-viewer" / "scripts" / "viewer"
+VIEWER_BUNDLER = REPO_ROOT / "scripts" / "bundle" / "skills" / "bundle-cad-viewer.sh"
+SERVER_ARGS_SOURCE = REPO_ROOT / "viewer" / "src" / "server" / "serverArgs.mjs"
+
+# `npm --prefix <dir> run <script>`, the form every skill doc uses.
+NPM_PREFIX_RUN_RE = re.compile(
+    r"npm\s+--prefix\s+(?P<prefix>[^\s]+)\s+run\s+(?P<script>[A-Za-z0-9:_-]+)"
+)
+RUNTIME_PACKAGE_HEREDOC_RE = re.compile(
+    r'cat > "\$target_dir/package\.json" <<EOF\n(?P<body>.*?)\nEOF\n',
+    re.DOTALL,
+)
+SERVER_FLAG_RE = re.compile(r'arg(?:\s*===\s*|\.startsWith\()\s*"(?P<flag>--[a-z0-9-]+)=?"')
+DOCUMENTED_FLAG_RE = re.compile(r"(?<![A-Za-z0-9-])(--[a-z0-9-]+)")
+
+
+def markdown_files() -> list[Path]:
+    files = sorted(
+        path
+        for path in SKILLS_ROOT.rglob("*.md")
+        if "node_modules" not in path.parts
+    )
+    files.append(AGENTS_DOC)
+    return files
+
+
+def shell_command_lines(text: str) -> list[str]:
+    """Every line inside a ```bash / ```console fenced block."""
+    lines: list[str] = []
+    in_shell_block = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            language = stripped[3:].strip().lower()
+            in_shell_block = not in_shell_block and language in {"bash", "sh", "shell", "console"}
+            continue
+        if in_shell_block:
+            lines.append(line)
+    return lines
+
+
+def generated_runtime_scripts() -> set[str]:
+    """Script names the installed CAD Viewer runtime actually defines.
+
+    On a publish branch the generated `package.json` is a real file. In the
+    `develop` symlink layout it points back at `viewer/`, which defines scripts
+    that are never bundled, so fall back to the bundler's own heredoc.
+    """
+    runtime_package = VIEWER_RUNTIME_DIR / "package.json"
+    if runtime_package.is_file() and not VIEWER_RUNTIME_DIR.is_symlink():
+        return set(json.loads(runtime_package.read_text(encoding="utf-8")).get("scripts", {}))
+
+    match = RUNTIME_PACKAGE_HEREDOC_RE.search(VIEWER_BUNDLER.read_text(encoding="utf-8"))
+    if match is None:
+        raise AssertionError(
+            f"Could not find the generated package.json heredoc in {VIEWER_BUNDLER}"
+        )
+    body = match.group("body").replace("$RELEASE_VERSION", "0.0.0")
+    return set(json.loads(body).get("scripts", {}))
+
+
+def server_accepted_flags() -> set[str]:
+    return set(SERVER_FLAG_RE.findall(SERVER_ARGS_SOURCE.read_text(encoding="utf-8")))
+
+
+def targets_viewer_runtime(doc: Path, prefix: str) -> bool:
+    """Does `--prefix <prefix>` in `doc` point at the bundled CAD Viewer runtime?
+
+    Skill docs are run from their own skill directory, and `AGENTS.md` says to
+    run from `skills/cad-viewer`, so try both bases.
+    """
+    runtime = VIEWER_RUNTIME_DIR.resolve()
+    bases = (doc.parent, SKILLS_ROOT / "cad-viewer")
+    return any((base / prefix).resolve() == runtime for base in bases)
+
+
+class DocumentedViewerCommandTests(unittest.TestCase):
+    def test_documented_npm_scripts_exist_in_the_bundled_runtime(self) -> None:
+        available = generated_runtime_scripts()
+        self.assertIn("serve", available, "the bundled runtime must define a startup script")
+
+        failures: list[str] = []
+        for doc in markdown_files():
+            for line in shell_command_lines(doc.read_text(encoding="utf-8")):
+                for match in NPM_PREFIX_RUN_RE.finditer(line):
+                    prefix = match.group("prefix")
+                    script = match.group("script")
+                    if not targets_viewer_runtime(doc, prefix):
+                        continue
+                    if script not in available:
+                        failures.append(
+                            f"{doc.relative_to(REPO_ROOT)}: `npm --prefix {prefix} run {script}` "
+                            f"is not defined by the generated CAD Viewer runtime "
+                            f"(defined: {', '.join(sorted(available))})"
+                        )
+
+        self.assertEqual(
+            failures,
+            [],
+            "Documented npm scripts must exist in the runtime the bundler generates:\n"
+            + "\n".join(failures),
+        )
+
+    def test_documented_serve_flags_are_accepted_by_the_server(self) -> None:
+        accepted = server_accepted_flags()
+        self.assertIn("--dir", accepted, "sanity check on the serverArgs.mjs flag scrape")
+
+        failures: list[str] = []
+        for doc in markdown_files():
+            for line in shell_command_lines(doc.read_text(encoding="utf-8")):
+                match = NPM_PREFIX_RUN_RE.search(line)
+                if match is None or match.group("script") != "serve":
+                    continue
+                if not targets_viewer_runtime(doc, match.group("prefix")):
+                    continue
+                for flag in DOCUMENTED_FLAG_RE.findall(line[match.end():]):
+                    if flag not in accepted:
+                        failures.append(
+                            f"{doc.relative_to(REPO_ROOT)}: `{flag}` is documented for "
+                            f"`run serve` but the server rejects it "
+                            f"(accepted: {', '.join(sorted(accepted))})"
+                        )
+
+        self.assertEqual(
+            failures,
+            [],
+            "Documented CAD Viewer server flags must be accepted by viewer/src/server/serverArgs.mjs:\n"
+            + "\n".join(failures),
+        )
+
+    def test_skill_docs_do_not_reference_source_only_launchers(self) -> None:
+        """`agent:start` lives in viewer/scripts/, which the bundler never syncs."""
+        offenders = [
+            str(doc.relative_to(REPO_ROOT))
+            for doc in sorted(SKILLS_ROOT.rglob("*.md"))
+            if "node_modules" not in doc.parts and "agent:start" in doc.read_text(encoding="utf-8")
+        ]
+        self.assertEqual(
+            offenders,
+            [],
+            "skills/ docs must not reference agent:start; it is a source-checkout-only launcher "
+            f"that is not bundled into {VIEWER_RUNTIME_DIR.relative_to(REPO_ROOT)}: {offenders}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/README.md
+++ b/viewer/README.md
@@ -41,13 +41,23 @@ npm run dev -- --host 127.0.0.1
 Open the URL printed by Vite and add paths, for example
 `?dir=/path/to/root&file=assemblies/robot-arm/robot-arm.step`.
 Local tools should not assume a fixed port. Use
-`npm run agent:start -- --dir /path/to/root` for agent-driven review. It starts
-at port `4178`, reuses a compatible existing Viewer, skips viewers with a
-different launcher-provided `git` value or a different requested default
-`--dir`, and starts on the first free candidate port. Use Vite's standard
-`--port` argument only when a specific dev port is needed. Local dev and
-production servers stay running unless `VIEWER_SERVER_LIFETIME_MS` is set or
-production `serve` is started with `--shutdown-after <duration>`.
+`npm run serve -- --dir /path/to/root --json` for agent-driven review. It starts
+at port `4178`, scans forward to the first free port when that one is taken, and
+prints a machine-readable `{"url":...,"port":...}` line as its last stdout line.
+`serve` is the entrypoint the bundled `cad-viewer` skill runtime ships, so it is
+what `skills/cad-viewer/SKILL.md` documents.
+
+`npm run agent:start -- --dir /path/to/root` is a source-checkout-only launcher
+on top of the same server. It additionally picks Vite dev mode when the skill
+viewer path is a development symlink and reuses a compatible existing Viewer,
+skipping viewers with a different launcher-provided `git` value or a different
+requested default `--dir`. It is deliberately **not** bundled into
+`skills/cad-viewer/scripts/viewer`, so skill-facing docs must not reference it.
+Note it requires `--dir` and rejects `--shutdown-after`.
+
+Use Vite's standard `--port` argument only when a specific dev port is needed.
+Local dev and production servers stay running unless `VIEWER_SERVER_LIFETIME_MS`
+is set or production `serve` is started with `--shutdown-after <duration>`.
 
 The local filesystem backend accepts absolute or startup-directory-relative
 `?dir=` values directly in the Viewer URL. Once seen, the active directory is
@@ -97,9 +107,9 @@ snapshot, and export logic in the source packages.
 
 ```bash
 npm run dev          # Vite dev server with local CAD API middleware
-npm run agent:start  # Launcher that chooses mode and reuses/selects a local port
+npm run agent:start  # Source-only launcher: chooses dev/serve mode, reuses viewers
 npm run build        # Production frontend build
-npm run serve        # Serve dist/ with the local or hosted backend
+npm run serve        # Serve dist/ with the local or hosted backend (bundled entrypoint)
 npm run test         # Discover and run all JS tests
 npm run upload:blob  # Upload a hosted catalog and supported viewer assets
 ```

--- a/viewer/docs/backend.md
+++ b/viewer/docs/backend.md
@@ -92,8 +92,12 @@ npm run serve
 ```
 
 Then open the printed server URL with
-`?dir=/absolute/root&file=model.step`. Pass `--port <number>` to
-`npm run serve --` only when the default production port is already in use.
+`?dir=/absolute/root&file=model.step`. The server binds `4178` by default and
+scans forward when that port is taken, printing the port it actually bound. Pass
+`--port <number>` only to pin a different starting port, `--port-scan-limit 0`
+to fail instead of scanning, and `--json` to emit a machine-readable
+`{"url":...,"host":...,"port":...,"action":"start"}` line as the last stdout
+line once the listener is bound.
 
 ## Vercel Blob
 

--- a/viewer/src/server/server.mjs
+++ b/viewer/src/server/server.mjs
@@ -39,6 +39,10 @@ import {
   applyServerArgsToEnv,
   serverHelpText,
 } from "./serverArgs.mjs";
+import {
+  buildViewerStartupJson,
+  listenWithPortFallback,
+} from "./serverListen.mjs";
 
 const serverModuleDir = path.dirname(fileURLToPath(import.meta.url));
 const viewerAppRoot = path.basename(path.dirname(serverModuleDir)) === "src"
@@ -89,8 +93,10 @@ const directoryRoot = resolveDirectoryRoot({
   defaultDirectoryRoot,
 });
 const backendKind = normalizeViewerAssetBackend(runtimeEnv.VIEWER_ASSET_BACKEND);
-const port = normalizeViewerPort(runtime.args.port, DEFAULT_VIEWER_PORT);
+const requestedPort = normalizeViewerPort(runtime.args.port, DEFAULT_VIEWER_PORT);
 const host = runtime.args.host || "127.0.0.1";
+// Reassigned once the listener binds; the requested port may be taken.
+let port = requestedPort;
 const serverLifetimeMs = runtime.args.shutdownAfterMs ?? normalizeServerLifetimeMs(runtimeEnv.VIEWER_SERVER_LIFETIME_MS);
 const distRoot = path.resolve(viewerAppRoot, "dist");
 const backend = backendKind === VIEWER_ASSET_BACKENDS.VERCEL_BLOB
@@ -186,13 +192,37 @@ function runMiddleware(index, req, res) {
 
 const server = http.createServer((req, res) => runMiddleware(0, req, res));
 
-server.listen(port, host, () => {
-  console.log(`CAD Viewer backend listening on http://${host}:${port}/ (${backend.kind})`);
-  if (serverLifetimeMs !== null) {
-    scheduleProcessShutdown({
-      lifetimeMs: serverLifetimeMs,
-      label: "CAD Viewer backend",
-      close: () => closeHttpServer(server),
-    });
-  }
+try {
+  port = await listenWithPortFallback({
+    server,
+    host,
+    port: requestedPort,
+    scanLimit: runtime.args.portScanLimit,
+  });
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+}
+server.on("error", (error) => {
+  process.stderr.write(`CAD Viewer backend error: ${error instanceof Error ? error.message : String(error)}\n`);
 });
+
+console.log(`CAD Viewer backend listening on http://${host}:${port}/ (${backend.kind})`);
+if (port !== requestedPort) {
+  console.log(`Requested port ${requestedPort} was in use; bound ${port} instead.`);
+}
+if (runtime.args.json) {
+  console.log(JSON.stringify(buildViewerStartupJson({
+    host,
+    port,
+    rootDir: runtime.args.rootDir || "",
+    cwd: process.cwd(),
+  })));
+}
+if (serverLifetimeMs !== null) {
+  scheduleProcessShutdown({
+    lifetimeMs: serverLifetimeMs,
+    label: "CAD Viewer backend",
+    close: () => closeHttpServer(server),
+  });
+}

--- a/viewer/src/server/serverArgs.mjs
+++ b/viewer/src/server/serverArgs.mjs
@@ -1,3 +1,4 @@
+import { DEFAULT_PORT_SCAN_LIMIT } from "./serverListen.mjs";
 import { parseServerLifetimeMs } from "./serverLifetime.mjs";
 
 function requiredValue(argv, index, flag) {
@@ -16,12 +17,22 @@ function parsePort(value, flag) {
   return parsed;
 }
 
+function parseNonNegativeInteger(value, flag) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${flag} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
 export function parseServerArgs(argv = []) {
   const options = {
     port: null,
     host: "",
     rootDir: "",
     shutdownAfterMs: null,
+    portScanLimit: DEFAULT_PORT_SCAN_LIMIT,
+    json: false,
     help: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -72,6 +83,19 @@ export function parseServerArgs(argv = []) {
       index += 1;
       continue;
     }
+    if (arg.startsWith("--port-scan-limit=")) {
+      options.portScanLimit = parseNonNegativeInteger(arg.slice("--port-scan-limit=".length), "--port-scan-limit");
+      continue;
+    }
+    if (arg === "--port-scan-limit") {
+      options.portScanLimit = parseNonNegativeInteger(requiredValue(argv, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
     throw new Error(`Unknown argument: ${arg}`);
   }
   return options;
@@ -81,11 +105,16 @@ export function serverHelpText() {
   return `Usage: node backend/server.mjs [options]
 
 Options:
-  --port <number>    Port to bind. Defaults to 4178.
+  --port <number>    First port to try. Defaults to 4178.
   --host <host>      Host to bind. Defaults to 127.0.0.1.
   --dir <path>       Default local directory root. Defaults to startup directory.
   --shutdown-after <time>
                      Shut down after a duration such as 12h, 30m, or 60000.
+  --port-scan-limit <number>
+                     How many additional ports to try when the requested port
+                     is in use. Defaults to ${DEFAULT_PORT_SCAN_LIMIT}. Pass 0 to fail instead.
+  --json             Print a machine-readable startup line as the last stdout
+                     line, for example {"url":...,"port":...,"action":"start"}.
   -h, --help         Show this help.
 `;
 }

--- a/viewer/src/server/serverArgs.test.mjs
+++ b/viewer/src/server/serverArgs.test.mjs
@@ -4,7 +4,9 @@ import test from "node:test";
 import {
   applyServerArgsToEnv,
   parseServerArgs,
+  serverHelpText,
 } from "./serverArgs.mjs";
+import { DEFAULT_PORT_SCAN_LIMIT } from "./serverListen.mjs";
 
 test("parseServerArgs accepts direct backend port and host flags", () => {
   assert.deepEqual(
@@ -14,6 +16,8 @@ test("parseServerArgs accepts direct backend port and host flags", () => {
       host: "0.0.0.0",
       rootDir: "",
       shutdownAfterMs: null,
+      portScanLimit: DEFAULT_PORT_SCAN_LIMIT,
+      json: false,
       help: false,
     }
   );
@@ -27,6 +31,8 @@ test("parseServerArgs accepts a default directory", () => {
       host: "",
       rootDir: "/tmp/models",
       shutdownAfterMs: null,
+      portScanLimit: DEFAULT_PORT_SCAN_LIMIT,
+      json: false,
       help: false,
     }
   );
@@ -37,6 +43,8 @@ test("parseServerArgs accepts a default directory", () => {
       host: "",
       rootDir: "models",
       shutdownAfterMs: null,
+      portScanLimit: DEFAULT_PORT_SCAN_LIMIT,
+      json: false,
       help: false,
     }
   );
@@ -50,6 +58,8 @@ test("parseServerArgs accepts an explicit shutdown duration", () => {
       host: "",
       rootDir: "",
       shutdownAfterMs: 12 * 60 * 60 * 1000,
+      portScanLimit: DEFAULT_PORT_SCAN_LIMIT,
+      json: false,
       help: false,
     }
   );
@@ -79,4 +89,23 @@ test("applyServerArgsToEnv preserves env while keeping CLI port in parsed args",
 
 test("parseServerArgs rejects invalid ports", () => {
   assert.throws(() => parseServerArgs(["--port", "99999"]), /TCP port/);
+});
+
+test("parseServerArgs accepts the machine-readable startup flag", () => {
+  assert.equal(parseServerArgs(["--json"]).json, true);
+  assert.equal(parseServerArgs([]).json, false);
+});
+
+test("parseServerArgs accepts a port scan limit", () => {
+  assert.equal(parseServerArgs(["--port-scan-limit", "8"]).portScanLimit, 8);
+  assert.equal(parseServerArgs(["--port-scan-limit=0"]).portScanLimit, 0);
+  assert.equal(parseServerArgs([]).portScanLimit, DEFAULT_PORT_SCAN_LIMIT);
+  assert.throws(() => parseServerArgs(["--port-scan-limit", "-1"]), /non-negative integer/);
+});
+
+test("serverHelpText documents the flags the cad-viewer skill relies on", () => {
+  const help = serverHelpText();
+  for (const flag of ["--dir", "--port", "--host", "--shutdown-after", "--port-scan-limit", "--json"]) {
+    assert.ok(help.includes(flag), `expected help text to document ${flag}`);
+  }
 });

--- a/viewer/src/server/serverListen.mjs
+++ b/viewer/src/server/serverListen.mjs
@@ -1,0 +1,109 @@
+import path from "node:path";
+
+export const DEFAULT_PORT_SCAN_LIMIT = 64;
+const MAX_TCP_PORT = 65535;
+
+function permissionErrorMessage(host, port, code) {
+  return `CAD Viewer could not bind ${host}:${port} (${code}). `
+    + "Rerun with permission to bind local ports, or pass --host/--port values the sandbox allows.";
+}
+
+function exhaustedErrorMessage(host, firstPort, lastPort) {
+  if (firstPort === lastPort) {
+    return `CAD Viewer could not bind ${host}:${firstPort} because the port is already in use. `
+      + "Pass --port <number> to choose another port, or raise --port-scan-limit.";
+  }
+  return `CAD Viewer could not bind ${host}: ports ${firstPort}-${lastPort} are all in use. `
+    + "Pass --port <number> to choose another port, or raise --port-scan-limit.";
+}
+
+/**
+ * Bind `server`, scanning forward from `port` while the candidate is taken.
+ *
+ * The bundled runtime is started directly rather than through a launcher, so
+ * port selection has to live here: an unhandled EADDRINUSE would otherwise
+ * surface as a crash. Resolves with the port that was actually bound.
+ */
+export function listenWithPortFallback({
+  server,
+  host = "127.0.0.1",
+  port,
+  scanLimit = DEFAULT_PORT_SCAN_LIMIT,
+} = {}) {
+  if (!server || typeof server.listen !== "function") {
+    throw new Error("listenWithPortFallback requires an http server");
+  }
+  const firstPort = Number(port);
+  if (!Number.isInteger(firstPort) || firstPort <= 0 || firstPort > MAX_TCP_PORT) {
+    throw new Error("listenWithPortFallback requires a TCP port from 1 to 65535");
+  }
+  const requestedScanLimit = Number(scanLimit);
+  const attemptLimit = Number.isInteger(requestedScanLimit) && requestedScanLimit >= 0
+    ? requestedScanLimit
+    : DEFAULT_PORT_SCAN_LIMIT;
+
+  return new Promise((resolve, reject) => {
+    let candidate = firstPort;
+    let attemptsUsed = 0;
+
+    const cleanup = () => {
+      server.removeListener("error", onError);
+      server.removeListener("listening", onListening);
+    };
+
+    const onError = (error) => {
+      const code = String(error?.code || "");
+      if (code === "EADDRINUSE" && attemptsUsed < attemptLimit && candidate < MAX_TCP_PORT) {
+        attemptsUsed += 1;
+        candidate += 1;
+        server.listen(candidate, host);
+        return;
+      }
+      cleanup();
+      if (code === "EACCES" || code === "EPERM") {
+        reject(new Error(permissionErrorMessage(host, candidate, code), { cause: error }));
+        return;
+      }
+      if (code === "EADDRINUSE") {
+        reject(new Error(exhaustedErrorMessage(host, firstPort, candidate), { cause: error }));
+        return;
+      }
+      reject(error instanceof Error ? error : new Error(String(error)));
+    };
+
+    const onListening = () => {
+      cleanup();
+      resolve(candidate);
+    };
+
+    server.on("error", onError);
+    server.on("listening", onListening);
+    server.listen(candidate, host);
+  });
+}
+
+export function buildViewerStartupUrl({ host = "127.0.0.1", port, rootDir = "", cwd = "" } = {}) {
+  const baseUrl = `http://${host}:${port}/`;
+  const requestedDir = String(rootDir || "").trim();
+  if (!requestedDir) {
+    return baseUrl;
+  }
+  const absoluteDir = path.isAbsolute(requestedDir)
+    ? path.resolve(requestedDir)
+    : path.resolve(String(cwd || ""), requestedDir);
+  return `${baseUrl}?dir=${encodeURIComponent(absoluteDir)}`;
+}
+
+/**
+ * Machine-readable startup line for agents and the Claude Preview tool.
+ * Callers print this as the last stdout line so it can be parsed by taking the
+ * last line that begins with `{`.
+ */
+export function buildViewerStartupJson({ host = "127.0.0.1", port, rootDir = "", cwd = "" } = {}) {
+  return {
+    url: buildViewerStartupUrl({ host, port, rootDir, cwd }),
+    host,
+    port: Number(port),
+    action: "start",
+  };
+}

--- a/viewer/src/server/serverListen.test.mjs
+++ b/viewer/src/server/serverListen.test.mjs
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  DEFAULT_PORT_SCAN_LIMIT,
+  buildViewerStartupJson,
+  buildViewerStartupUrl,
+  listenWithPortFallback,
+} from "./serverListen.mjs";
+
+const host = "127.0.0.1";
+
+function createServer() {
+  return http.createServer((req, res) => {
+    res.statusCode = 204;
+    res.end();
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close(() => resolve());
+  });
+}
+
+async function occupyPort() {
+  const server = createServer();
+  const port = await new Promise((resolve) => {
+    server.listen(0, host, () => resolve(server.address().port));
+  });
+  return { server, port };
+}
+
+test("listenWithPortFallback binds the requested port when it is free", async (t) => {
+  const blocker = createServer();
+  const blockerPort = (await new Promise((resolve) => {
+    blocker.listen(0, host, () => resolve(blocker.address().port));
+  }));
+  await closeServer(blocker);
+
+  const server = createServer();
+  t.after(() => closeServer(server));
+  const bound = await listenWithPortFallback({ server, host, port: blockerPort });
+  assert.equal(bound, blockerPort);
+  assert.equal(server.address().port, blockerPort);
+});
+
+test("listenWithPortFallback scans forward when the requested port is in use", async (t) => {
+  const occupied = await occupyPort();
+  t.after(() => closeServer(occupied.server));
+
+  const server = createServer();
+  t.after(() => closeServer(server));
+  const bound = await listenWithPortFallback({
+    server,
+    host,
+    port: occupied.port,
+    scanLimit: 8,
+  });
+
+  assert.ok(bound > occupied.port, `expected a port above ${occupied.port}, got ${bound}`);
+  assert.ok(bound <= occupied.port + 8, `expected a port within the scan window, got ${bound}`);
+  assert.equal(server.address().port, bound);
+});
+
+test("listenWithPortFallback fails with a clear message when scanning is disabled", async (t) => {
+  const occupied = await occupyPort();
+  t.after(() => closeServer(occupied.server));
+
+  const server = createServer();
+  t.after(() => closeServer(server));
+  await assert.rejects(
+    listenWithPortFallback({ server, host, port: occupied.port, scanLimit: 0 }),
+    /already in use.*--port/su,
+  );
+});
+
+test("listenWithPortFallback reports the exhausted range", async (t) => {
+  const occupied = await occupyPort();
+  t.after(() => closeServer(occupied.server));
+
+  const neighbour = createServer();
+  t.after(() => closeServer(neighbour));
+  let neighbourBound = false;
+  try {
+    await listenWithPortFallback({ server: neighbour, host, port: occupied.port + 1, scanLimit: 0 });
+    neighbourBound = true;
+  } catch {
+    // The neighbouring port is already taken by something else, which is fine.
+  }
+  if (!neighbourBound) {
+    return;
+  }
+
+  const server = createServer();
+  t.after(() => closeServer(server));
+  await assert.rejects(
+    listenWithPortFallback({ server, host, port: occupied.port, scanLimit: 1 }),
+    new RegExp(`ports ${occupied.port}-${occupied.port + 1} are all in use`, "u"),
+  );
+});
+
+test("listenWithPortFallback rejects an invalid port", () => {
+  assert.throws(
+    () => listenWithPortFallback({ server: createServer(), host, port: 99999 }),
+    /TCP port from 1 to 65535/u,
+  );
+});
+
+test("buildViewerStartupUrl omits ?dir= when no directory was requested", () => {
+  assert.equal(
+    buildViewerStartupUrl({ host, port: 4178 }),
+    "http://127.0.0.1:4178/",
+  );
+});
+
+test("buildViewerStartupUrl resolves relative directories against the startup directory", () => {
+  assert.equal(
+    buildViewerStartupUrl({ host, port: 4178, rootDir: "/absolute/models" }),
+    `http://127.0.0.1:4178/?dir=${encodeURIComponent("/absolute/models")}`,
+  );
+  assert.equal(
+    buildViewerStartupUrl({ host, port: 4178, rootDir: "models", cwd: "/repo" }),
+    `http://127.0.0.1:4178/?dir=${encodeURIComponent(path.resolve("/repo", "models"))}`,
+  );
+});
+
+test("buildViewerStartupJson matches the documented handshake shape", () => {
+  assert.deepEqual(
+    buildViewerStartupJson({ host, port: 4180, rootDir: "/absolute/models" }),
+    {
+      url: `http://127.0.0.1:4180/?dir=${encodeURIComponent("/absolute/models")}`,
+      host: "127.0.0.1",
+      port: 4180,
+      action: "start",
+    },
+  );
+});
+
+test("the default port scan limit leaves room for parallel viewers", () => {
+  assert.ok(DEFAULT_PORT_SCAN_LIMIT >= 8);
+});


### PR DESCRIPTION
Fixes #173.

## The bug

`skills/cad-viewer/SKILL.md` told agents to start the Viewer with
`npm --prefix scripts/viewer run agent:start`. The bundled runtime has never
defined that script, so the documented command failed on **every** install:

```console
$ npm --prefix scripts/viewer run agent:start -- --host 127.0.0.1 --dir /some/model/dir
npm error Missing script: "agent:start"
```

Two causes, both in `scripts/bundle/skills/bundle-cad-viewer.sh`:

1. `write_runtime_package_json()` generates `package.json` from a fixed heredoc
   listing only `serve`, `start`, and the `moveit2:*` scripts.
2. `build_runtime()` syncs `dist/`, `moveit2_server/`, and `packages/`, and
   esbuilds the server — but never `viewer/scripts/`, where the launcher lives.

Confirmed present in every release `0.2.9` through `0.3.9`.

## Approach

This takes the reporter's option 2 — document the `serve` entrypoint the runtime
actually ships. Option 1 (bundle the launcher) turned out to need more than the
issue assumed: `start-agent-viewer.mjs` imports two unbundled `src/server/`
modules, **and** its serve-mode spawn target is `<packageRoot>/src/server/server.mjs`,
which does not exist in a bundle — the server there is `backend/server.mjs`.

`serve` is defined in both `viewer/package.json` and the generated runtime, so
one documented command now works in the dev symlink layout and in an install.

## Moving the launcher's responsibilities into the shipped server

`SKILL.md` depended on three things only the launcher did:

- **Port selection** — new `viewer/src/server/serverListen.mjs` scans forward
  from 4178 on `EADDRINUSE`. Previously `server.listen()` had no `error`
  handler at all, so a taken port crashed the process. `EACCES`/`EPERM` fail
  immediately with a message naming the fix, and `--port-scan-limit 0` opts out.
- **The `--json` handshake** — the server now prints
  `{"url","host","port","action"}` as its last stdout line once bound, so the
  Claude Preview flow works without the launcher.
- **Reuse** — `SKILL.md` now probes `GET /__cad/server`, which already returns
  `url`, `port`, `pid`, and `viewerVersion`. Since the server advertises
  `dynamic-root`, one server covers any `?dir=`.

`agent:start` is unchanged and stays a source-checkout-only launcher, now
labelled as such in `viewer/README.md`.

## Second drift, found while fixing this

`AGENTS.md:171` documented an `agent:start` command that failed **in a source
checkout too**: the launcher requires `--dir` (absent) and explicitly throws on
`--shutdown-after` (present). Fixed to the `serve` form.

## Regression guard

`tests/python/global/test_documented_viewer_commands.py` fails when skill or repo
docs name an npm script the bundler does not generate, or a `serve` flag the
server does not accept. Verified it fails on the pre-fix docs with exactly the
right message, and passes after.

This is the doc-vs-runtime check #165 does not cover: the bundler is
self-consistent here, so a regenerate-and-diff check sees nothing wrong.

## Verification

- Built a real bundled runtime, installed it as a fake skill, and ran the exact
  new `SKILL.md` command: server starts, `--json` line parses, `GET /` returns
  200, `/__cad/server` reports the bound port, and a second instance on a taken
  port falls back instead of crashing.
- Confirmed the esbuilt `backend/server.mjs` (top-level `await`) bundles and runs.
- `npm --prefix viewer run test` — 400/400 pass.
- `scripts/test/test-global.sh` — 10/10 pass.
- `scripts/dev/setup-symlinks.sh --check` and the pre-commit bundle check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)