### PR TITLE
ci: check generated outputs against sources and add a build badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Set up dependencies
         uses: ./.github/actions/setup-deps
 
+      - name: Check generated outputs against sources
+        run: scripts/bundle/bundle.sh --check
+
       - name: Bundle production outputs
         run: scripts/bundle/bundle.sh --clean
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,12 +131,13 @@ Run the smallest path-targeted check that covers the change. Use broad wrappers
 when touching shared surfaces or before handoff:
 
 - Code tests: `scripts/test/test.sh`
-  - In GitHub Actions, `test.yml` checks the canonical release version as a
-    separate non-blocking job; its test job verifies the `develop` symlink
-    layout, bundles temporary production outputs, and runs docs and code tests
-    against that bundle. `main` writes are validated by the `Release`
-    workflow's publish job; GitHub branch settings should block PRs and direct
-    pushes to `main`.
+  - In GitHub Actions, `test.yml` checks the canonical release version in a
+    separate job so code tests still run when version metadata is wrong; its
+    test job verifies the `develop` symlink layout, checks generated outputs
+    against their sources, bundles temporary production outputs, and runs docs
+    and code tests against that bundle. `main` writes are validated by the
+    `Release` workflow's publish job; GitHub branch settings should block PRs
+    and direct pushes to `main`.
 - Focused test runners: `scripts/test/test-js.sh`,
   `scripts/test/test-docs.sh`, `scripts/test/test-python.sh`,
   `scripts/test/test-global.sh`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,9 +169,16 @@ The `main` production branch must be installable from a plain checkout, so it
 contains generated production outputs instead of symlinks. `main` is
 publish-only: do not open PRs to `main` or push it directly. The `Test`
 workflow runs on `develop` and PRs to `develop`: it starts from the symlink
-layout, runs `scripts/bundle/bundle.sh --clean`, checks the production layout
-without rebuilding it, runs documentation checks, and runs the code tests
-against that generated output.
+layout, verifies that layout, checks generated outputs against their sources
+with `scripts/bundle/bundle.sh --check`, runs `scripts/bundle/bundle.sh
+--clean`, checks the production layout without rebuilding it, runs
+documentation checks, and runs the code tests against that generated output.
+
+Most generated paths cannot drift on `develop` because they are symlinks to
+their canonical sources, and the freshness check skips those. It covers the
+generated outputs that `develop` does commit as real files, such as the CAD
+snapshot runtime built from `packages/cadjs` and `packages/implicitjs`, and
+version metadata derived from `plugins/cad/VERSION`.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A skills library for CAD, robotics, and hardware design agents
 
 [Docs](https://www.cadskills.xyz) | [Demo](https://demo.cadskills.xyz)
 
+[![Tests](https://img.shields.io/github/actions/workflow/status/earthtojake/text-to-cad/test.yml?branch=develop&style=for-the-badge&logo=githubactions&logoColor=white&label=Tests)](https://github.com/earthtojake/text-to-cad/actions/workflows/test.yml?query=branch%3Adevelop)
 [![Join Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/5FGB9DwJYU)
 [![GitHub stars](https://img.shields.io/github/stars/earthtojake/text-to-cad?style=for-the-badge&logo=github&label=Stars)](https://github.com/earthtojake/text-to-cad/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue?style=for-the-badge)](LICENSE)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,11 +50,19 @@ scripts/bundle/bundle.sh --check
 scripts/bundle/bundle-skill.sh <skill-id> --check
 ```
 
-`scripts/github-workflows/check-builds.sh` is the release-layout gate. It verifies
-there are no symlinks under production runtime paths, then runs
-`scripts/bundle/bundle.sh --check` by default. Use `--skip-bundle-check` only in
-workflows that already ran `scripts/bundle/bundle.sh --clean` in the same
-checkout. Plugin skill-copy
+Every bundle script also reports the paths it generates, so checks can discover
+production runtime paths instead of repeating them:
+
+```bash
+scripts/bundle/bundle-skill.sh --all --print-outputs
+scripts/bundle/bundle-plugin.sh --print-outputs
+```
+
+`scripts/github-workflows/check-builds.sh` is the release-layout gate. It asks the
+bundle scripts for their generated paths, verifies each one exists and contains no
+symlinks, then runs `scripts/bundle/bundle.sh --check` by default. Use
+`--skip-bundle-check` only in workflows that already ran
+`scripts/bundle/bundle.sh --clean` in the same checkout. Plugin skill-copy
 freshness and plugin metadata validation are part of
 `scripts/bundle/bundle-plugin.sh --check`, which runs through the master bundle
 check.

--- a/scripts/bundle/bundle-plugin.sh
+++ b/scripts/bundle/bundle-plugin.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 MODE="write"
 CLEAN=0
+PRINT_OUTPUTS=0
 
 SOURCE_SKILLS_ROOT="$REPO_ROOT/skills"
 PLUGIN_ROOT="$REPO_ROOT/plugins/cad"
@@ -26,6 +27,8 @@ because provider installers cache plugin roots independently of this checkout.
 Options:
   --check  Bundle into tmp/ and fail if plugin outputs or metadata are stale.
   --clean  Remove temporary bundle/check directories first.
+  --print-outputs
+           Print the repo-relative generated output paths, then exit.
   -h, --help
            Show this help.
 EOF
@@ -39,6 +42,9 @@ while [ "$#" -gt 0 ]; do
     --clean)
       CLEAN=1
       ;;
+    --print-outputs)
+      PRINT_OUTPUTS=1
+      ;;
     -h|--help)
       usage
       exit 0
@@ -51,6 +57,11 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+
+if [ "$PRINT_OUTPUTS" -eq 1 ]; then
+  printf '%s\n' "${TARGET_SKILLS_ROOT#"$REPO_ROOT"/}"
+  exit 0
+fi
 
 ensure_deps() {
   if ! command -v rsync >/dev/null 2>&1; then

--- a/scripts/bundle/skills/bundle-cad-viewer.sh
+++ b/scripts/bundle/skills/bundle-cad-viewer.sh
@@ -7,6 +7,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 MODE="write"
 BUILD=1
 CLEAN=0
+PRINT_OUTPUTS=0
 
 CADJS_PACKAGE_DIR="$REPO_ROOT/packages/cadjs"
 CADPY_PACKAGE_DIR="$REPO_ROOT/packages/cadpy"
@@ -36,6 +37,8 @@ Options:
   --clean     Remove generated package copies and temporary check directories first.
   --no-build  Reuse the current viewer/dist instead of rebuilding the viewer.
               The existing dist must already include client sourcemaps.
+  --print-outputs
+              Print the repo-relative generated output paths, then exit.
   -h, --help  Show this help.
 EOF
 }
@@ -51,6 +54,9 @@ while [ "$#" -gt 0 ]; do
     --no-build)
       BUILD=0
       ;;
+    --print-outputs)
+      PRINT_OUTPUTS=1
+      ;;
     -h|--help)
       usage
       exit 0
@@ -63,6 +69,15 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+
+if [ "$PRINT_OUTPUTS" -eq 1 ]; then
+  printf '%s\n' \
+    "${VIEWER_CADJS_DIR#"$REPO_ROOT"/}" \
+    "${VIEWER_CADPY_DIR#"$REPO_ROOT"/}" \
+    "${VIEWER_IMPLICITJS_DIR#"$REPO_ROOT"/}" \
+    "${RUNTIME_DIR#"$REPO_ROOT"/}"
+  exit 0
+fi
 
 require_path() {
   local path_to_check="$1"

--- a/scripts/bundle/skills/bundle-cad.sh
+++ b/scripts/bundle/skills/bundle-cad.sh
@@ -7,6 +7,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 MODE="write"
 CLEAN=0
 INSTALL_DEPS=1
+PRINT_OUTPUTS=0
 
 ESBUILD_VERSION="${CAD_SNAPSHOT_ESBUILD_VERSION:-0.27.7}"
 THREE_VERSION="${CAD_SNAPSHOT_THREE_VERSION:-0.160.0}"
@@ -31,6 +32,8 @@ Options:
   --check       Bundle into tmp/ and fail if snapshot/runtime is stale.
   --clean       Remove the temporary dependency/build directories first.
   --no-install  Require existing build dependencies in tmp/cad-snapshot-build.
+  --print-outputs
+                Print the repo-relative generated output paths, then exit.
   -h, --help    Show this help.
 EOF
 }
@@ -46,6 +49,9 @@ while [ "$#" -gt 0 ]; do
     --no-install)
       INSTALL_DEPS=0
       ;;
+    --print-outputs)
+      PRINT_OUTPUTS=1
+      ;;
     -h|--help)
       usage
       exit 0
@@ -58,6 +64,13 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+
+if [ "$PRINT_OUTPUTS" -eq 1 ]; then
+  printf '%s\n' \
+    "${RUNTIME_DIR#"$REPO_ROOT"/}" \
+    "${CADPY_RUNTIME_DIR#"$REPO_ROOT"/}"
+  exit 0
+fi
 
 if [ ! -f "$ENTRYPOINT" ]; then
   echo "Missing snapshot render entrypoint: $ENTRYPOINT" >&2

--- a/scripts/bundle/skills/bundle-dxf.sh
+++ b/scripts/bundle/skills/bundle-dxf.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 MODE="write"
 CLEAN=0
+PRINT_OUTPUTS=0
 
 CHECK_DIR="${DXF_SKILL_CHECK_DIR:-$REPO_ROOT/tmp/dxf-skill-runtime-check}"
 CADPY_PACKAGE_DIR="$REPO_ROOT/packages/cadpy"
@@ -21,6 +22,8 @@ Vendors packages/cadpy into skills/dxf/scripts/packages/cadpy.
 Options:
   --check  Fail if the generated DXF skill runtime copy is stale.
   --clean  Remove the temporary check directory first.
+  --print-outputs
+           Print the repo-relative generated output paths, then exit.
   -h, --help
            Show this help.
 EOF
@@ -34,6 +37,9 @@ while [ "$#" -gt 0 ]; do
     --clean)
       CLEAN=1
       ;;
+    --print-outputs)
+      PRINT_OUTPUTS=1
+      ;;
     -h|--help)
       usage
       exit 0
@@ -46,6 +52,11 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+
+if [ "$PRINT_OUTPUTS" -eq 1 ]; then
+  printf '%s\n' "${CADPY_RUNTIME_DIR#"$REPO_ROOT"/}"
+  exit 0
+fi
 
 if [ ! -f "$CADPY_PACKAGE_DIR/pyproject.toml" ] || [ ! -d "$CADPY_PACKAGE_DIR/src/cadpy" ]; then
   echo "Missing cadpy package source: $CADPY_PACKAGE_DIR" >&2

--- a/scripts/bundle/skills/bundle-implicit-cad.sh
+++ b/scripts/bundle/skills/bundle-implicit-cad.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 MODE="write"
 CLEAN=0
+PRINT_OUTPUTS=0
 
 IMPLICITJS_PACKAGE_DIR="$REPO_ROOT/packages/implicitjs"
 IMPLICITJS_RUNTIME_DIR="$REPO_ROOT/skills/implicit-cad/scripts/packages/implicitjs"
@@ -22,6 +23,8 @@ layouts.
 Options:
   --check  Bundle into tmp/ and fail if checked-in production outputs are stale.
   --clean  Remove temporary check directories first.
+  --print-outputs
+           Print the repo-relative generated output paths, then exit.
   -h, --help
            Show this help.
 EOF
@@ -35,6 +38,9 @@ while [ "$#" -gt 0 ]; do
     --clean)
       CLEAN=1
       ;;
+    --print-outputs)
+      PRINT_OUTPUTS=1
+      ;;
     -h|--help)
       usage
       exit 0
@@ -47,6 +53,11 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+
+if [ "$PRINT_OUTPUTS" -eq 1 ]; then
+  printf '%s\n' "${IMPLICITJS_RUNTIME_DIR#"$REPO_ROOT"/}"
+  exit 0
+fi
 
 require_file() {
   local path_to_check="$1"

--- a/scripts/bundle/skills/bundle-sdf.sh
+++ b/scripts/bundle/skills/bundle-sdf.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 MODE="write"
 CLEAN=0
+PRINT_OUTPUTS=0
 PACKAGE_DIR="$REPO_ROOT/packages/cadpy_metadata"
 RUNTIME_DIR="$REPO_ROOT/skills/sdf/scripts/packages/cadpy_metadata"
 
@@ -19,6 +20,8 @@ Vendors packages/cadpy_metadata into skills/sdf/scripts/packages/cadpy_metadata.
 Options:
   --check  Fail if the generated SDF skill runtime copy is stale.
   --clean  Remove the generated runtime copy before writing it.
+  --print-outputs
+           Print the repo-relative generated output paths, then exit.
   -h, --help
            Show this help.
 EOF
@@ -32,6 +35,9 @@ while [ "$#" -gt 0 ]; do
     --clean)
       CLEAN=1
       ;;
+    --print-outputs)
+      PRINT_OUTPUTS=1
+      ;;
     -h|--help)
       usage
       exit 0
@@ -44,6 +50,11 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+
+if [ "$PRINT_OUTPUTS" -eq 1 ]; then
+  printf '%s\n' "${RUNTIME_DIR#"$REPO_ROOT"/}"
+  exit 0
+fi
 
 if [ ! -f "$PACKAGE_DIR/pyproject.toml" ] || [ ! -d "$PACKAGE_DIR/src/cadpy_metadata" ]; then
   echo "Missing cadpy_metadata package source: $PACKAGE_DIR" >&2

--- a/scripts/bundle/skills/bundle-srdf.sh
+++ b/scripts/bundle/skills/bundle-srdf.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 MODE="write"
 CLEAN=0
+PRINT_OUTPUTS=0
 PACKAGE_DIR="$REPO_ROOT/packages/cadpy_metadata"
 RUNTIME_DIR="$REPO_ROOT/skills/srdf/scripts/packages/cadpy_metadata"
 
@@ -19,6 +20,8 @@ Vendors packages/cadpy_metadata into skills/srdf/scripts/packages/cadpy_metadata
 Options:
   --check  Fail if the generated SRDF skill runtime copy is stale.
   --clean  Remove the generated runtime copy before writing it.
+  --print-outputs
+           Print the repo-relative generated output paths, then exit.
   -h, --help
            Show this help.
 EOF
@@ -32,6 +35,9 @@ while [ "$#" -gt 0 ]; do
     --clean)
       CLEAN=1
       ;;
+    --print-outputs)
+      PRINT_OUTPUTS=1
+      ;;
     -h|--help)
       usage
       exit 0
@@ -44,6 +50,11 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+
+if [ "$PRINT_OUTPUTS" -eq 1 ]; then
+  printf '%s\n' "${RUNTIME_DIR#"$REPO_ROOT"/}"
+  exit 0
+fi
 
 if [ ! -f "$PACKAGE_DIR/pyproject.toml" ] || [ ! -d "$PACKAGE_DIR/src/cadpy_metadata" ]; then
   echo "Missing cadpy_metadata package source: $PACKAGE_DIR" >&2

--- a/scripts/bundle/skills/bundle-urdf.sh
+++ b/scripts/bundle/skills/bundle-urdf.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 MODE="write"
 CLEAN=0
+PRINT_OUTPUTS=0
 PACKAGE_DIR="$REPO_ROOT/packages/cadpy_metadata"
 RUNTIME_DIR="$REPO_ROOT/skills/urdf/scripts/packages/cadpy_metadata"
 
@@ -19,6 +20,8 @@ Vendors packages/cadpy_metadata into skills/urdf/scripts/packages/cadpy_metadata
 Options:
   --check  Fail if the generated URDF skill runtime copy is stale.
   --clean  Remove the generated runtime copy before writing it.
+  --print-outputs
+           Print the repo-relative generated output paths, then exit.
   -h, --help
            Show this help.
 EOF
@@ -32,6 +35,9 @@ while [ "$#" -gt 0 ]; do
     --clean)
       CLEAN=1
       ;;
+    --print-outputs)
+      PRINT_OUTPUTS=1
+      ;;
     -h|--help)
       usage
       exit 0
@@ -44,6 +50,11 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
+
+if [ "$PRINT_OUTPUTS" -eq 1 ]; then
+  printf '%s\n' "${RUNTIME_DIR#"$REPO_ROOT"/}"
+  exit 0
+fi
 
 if [ ! -f "$PACKAGE_DIR/pyproject.toml" ] || [ ! -d "$PACKAGE_DIR/src/cadpy_metadata" ]; then
   echo "Missing cadpy_metadata package source: $PACKAGE_DIR" >&2

--- a/scripts/github-workflows/check-builds.sh
+++ b/scripts/github-workflows/check-builds.sh
@@ -41,16 +41,54 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
+# Generated output paths production layout must materialize. A stale entry here
+# only weakens a redundant guard, because bundling already fails when it cannot
+# write an output.
+required_paths() {
+  cat <<'EOF'
+viewer/packages
+skills/cad/scripts/packages
+skills/cad/scripts/snapshot/runtime
+skills/cad-viewer/scripts/viewer
+skills/dxf/scripts/packages
+skills/implicit-cad/scripts/packages
+skills/sdf/scripts/packages
+skills/srdf/scripts/packages
+skills/urdf/scripts/packages
+plugins/cad/skills
+EOF
+}
+
+# Roots scanned for leftover development symlinks. This list must not drift
+# behind the bundle scripts, so derive it from them: every skill with bundle
+# logic ships generated copies, and a new bundle-<skill>.sh is covered without
+# editing anything here.
+symlink_scan_roots() {
+  find scripts/bundle/skills -maxdepth 1 -type f -name 'bundle-*.sh' -print |
+    sed -e 's|.*/bundle-|skills/|' -e 's|\.sh$||' |
+    LC_ALL=C sort
+  echo "viewer/packages"
+  echo "plugins/cad/skills"
+}
+
+check_exists() {
+  local path="$1"
+
+  if [ ! -e "$path" ]; then
+    echo "Missing production bundle path: $path" >&2
+    echo "Run scripts/bundle/bundle.sh --clean and commit the generated outputs." >&2
+    exit 1
+  fi
+}
+
 check_no_symlinks() {
   local root="$1"
   local first_link
 
-  if [ ! -e "$root" ]; then
-    echo "Missing production bundle path: $root" >&2
-    exit 1
-  fi
+  check_exists "$root"
 
-  first_link="$(find "$root" -type l -print -quit)"
+  # Bundling installs dependencies under some roots; only committed paths matter.
+  first_link="$(find "$root" -name node_modules -prune -o -type l -print -quit)"
   if [ -n "$first_link" ]; then
     echo "Production bundle paths must not contain symlinks." >&2
     echo "First symlink: $first_link" >&2
@@ -59,13 +97,13 @@ check_no_symlinks() {
   fi
 }
 
-check_no_symlinks "viewer/packages"
-check_no_symlinks "skills/cad/scripts/packages"
-check_no_symlinks "skills/cad-viewer/scripts/viewer"
-check_no_symlinks "skills/urdf/scripts/packages"
-check_no_symlinks "skills/srdf/scripts/packages"
-check_no_symlinks "skills/sdf/scripts/packages"
-check_no_symlinks "plugins/cad/skills"
+while IFS= read -r required_path; do
+  check_exists "$required_path"
+done < <(required_paths)
+
+while IFS= read -r scan_root; do
+  check_no_symlinks "$scan_root"
+done < <(symlink_scan_roots)
 
 if [ "$RUN_BUNDLE_CHECK" -eq 1 ]; then
   "$REPO_ROOT/scripts/bundle/bundle.sh" --check

--- a/scripts/github-workflows/check-builds.sh
+++ b/scripts/github-workflows/check-builds.sh
@@ -41,51 +41,22 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
-# Generated output paths production layout must materialize. A stale entry here
-# only weakens a redundant guard, because bundling already fails when it cannot
-# write an output.
-required_paths() {
-  cat <<'EOF'
-viewer/packages
-skills/cad/scripts/packages
-skills/cad/scripts/snapshot/runtime
-skills/cad-viewer/scripts/viewer
-skills/dxf/scripts/packages
-skills/implicit-cad/scripts/packages
-skills/sdf/scripts/packages
-skills/srdf/scripts/packages
-skills/urdf/scripts/packages
-plugins/cad/skills
-EOF
+# Ask the bundle scripts which paths they generate rather than repeating them
+# here, so this check cannot fall behind a new or renamed bundle output.
+generated_paths() {
+  "$REPO_ROOT/scripts/bundle/bundle-skill.sh" --all --print-outputs
+  "$REPO_ROOT/scripts/bundle/bundle-plugin.sh" --print-outputs
 }
 
-# Roots scanned for leftover development symlinks. This list must not drift
-# behind the bundle scripts, so derive it from them: every skill with bundle
-# logic ships generated copies, and a new bundle-<skill>.sh is covered without
-# editing anything here.
-symlink_scan_roots() {
-  find scripts/bundle/skills -maxdepth 1 -type f -name 'bundle-*.sh' -print |
-    sed -e 's|.*/bundle-|skills/|' -e 's|\.sh$||' |
-    LC_ALL=C sort
-  echo "viewer/packages"
-  echo "plugins/cad/skills"
-}
-
-check_exists() {
-  local path="$1"
-
-  if [ ! -e "$path" ]; then
-    echo "Missing production bundle path: $path" >&2
-    echo "Run scripts/bundle/bundle.sh --clean and commit the generated outputs." >&2
-    exit 1
-  fi
-}
-
-check_no_symlinks() {
+check_generated_path() {
   local root="$1"
   local first_link
 
-  check_exists "$root"
+  if [ ! -e "$root" ]; then
+    echo "Missing production bundle path: $root" >&2
+    echo "Run scripts/bundle/bundle.sh --clean and commit the generated outputs." >&2
+    exit 1
+  fi
 
   # Bundling installs dependencies under some roots; only committed paths matter.
   first_link="$(find "$root" -name node_modules -prune -o -type l -print -quit)"
@@ -97,13 +68,9 @@ check_no_symlinks() {
   fi
 }
 
-while IFS= read -r required_path; do
-  check_exists "$required_path"
-done < <(required_paths)
-
-while IFS= read -r scan_root; do
-  check_no_symlinks "$scan_root"
-done < <(symlink_scan_roots)
+while IFS= read -r generated_path; do
+  check_generated_path "$generated_path"
+done < <(generated_paths)
 
 if [ "$RUN_BUNDLE_CHECK" -eq 1 ]; then
   "$REPO_ROOT/scripts/bundle/bundle.sh" --check


### PR DESCRIPTION
Closes #165.

## Context

The issue flagged that a PR could edit a source file without regenerating its generated copy, silently reintroducing the drift `AGENTS.md` is trying to prevent, and that there is no CI badge.

Investigating: most of that drift is already structurally impossible. On `develop`, 21 generated paths are committed as **directory symlinks** to their canonical sources (`plugins/cad/skills/*`, `skills/*/scripts/packages/*`, `skills/cad-viewer/scripts/viewer`, `viewer/packages/*`), so editing the source *is* editing the copy — and `setup-symlinks.sh --check` runs first in CI as a required check.

The real gap is narrower: the only non-symlink files under any bundle output root on `develop` are `skills/cad/scripts/snapshot/runtime/{render.html,snapshot-render.js}` — a 901 KB esbuild bundle of `packages/cadjs` + `packages/implicitjs`. Those *can* go stale, and nothing verified them.

## Changes

**Run the drift check that already existed.** `scripts/bundle/bundle.sh --check` rebuilds into `tmp/` and `cmp`s against the checked-in outputs, and is symlink-aware ([`bundle-cad-viewer.sh:456`](https://github.com/earthtojake/text-to-cad/blob/develop/scripts/bundle/skills/bundle-cad-viewer.sh#L456) skips the runtime diff under the dev layout). `test.yml` never ran it — it ran `bundle.sh --clean`, which rewrites the outputs in place, then `check-builds.sh --skip-bundle-check`, which only asserts "no symlinks". Now the freshness check runs before bundling.

**Stop `check-builds.sh` naming skills at all.** Its hand-maintained no-symlink list had drifted behind the bundle scripts, missing `skills/dxf/scripts/packages` and `skills/implicit-cad/scripts/packages` — both bundle outputs and both symlinks on `develop` — so a development symlink under either could have been published to `main` undetected (`main` is clean today, so this was latent). Every bundle script now takes `--print-outputs` and reports the repo-relative paths it writes; `check-builds.sh` asks for that list rather than carrying its own, and verifies each path exists and contains no symlinks. A new, renamed, or removed bundle output cannot leave the check stale.

Derived coverage is also more precise than the old list: `skills/cad/scripts/packages/cadpy` rather than `skills/cad/scripts/packages`, plus `skills/cad/scripts/snapshot/runtime`, which the old list never mentioned.

```
$ scripts/bundle/bundle-skill.sh --all --print-outputs
skills/cad/scripts/snapshot/runtime
skills/cad/scripts/packages/cadpy
viewer/packages/cadjs
viewer/packages/cadpy
viewer/packages/implicitjs
skills/cad-viewer/scripts/viewer
skills/dxf/scripts/packages/cadpy
skills/implicit-cad/scripts/packages/implicitjs
skills/sdf/scripts/packages/cadpy_metadata
skills/srdf/scripts/packages/cadpy_metadata
skills/urdf/scripts/packages/cadpy_metadata
```

**Add the badge**, pointing at `develop` — that is where `test.yml` runs, and a `main` badge would render no status.

Docs in `CONTRIBUTING.md`, `AGENTS.md`, and `scripts/README.md` updated to match. `AGENTS.md` also called `Version Check` a "non-blocking job"; branch protection lists both `Version Check` and `Test` as required contexts, so that wording is corrected.

## Verification

- `scripts/bundle/bundle.sh --check` passes end-to-end on the develop tip, correctly skipping symlinked paths and diffing the CAD snapshot runtime. In CI it takes 15s, against 14s for the bundle step it precedes and 46s for the test step.
- `check-builds.sh` verified in both directions on a real production layout: passes after `bundle.sh --clean`, fails with `Missing production bundle path: skills/implicit-cad/scripts/packages/implicitjs` when a generated output is removed (a path the old list did not cover), and fails on the dev symlink layout with `First symlink: skills/cad/scripts/packages/cadpy`.
- Symlink layout restored afterward; `setup-symlinks.sh --check` and `bundle.sh --check` both clean. `bash -n` clean on all edited scripts; `scripts/test/test-global.sh` passes (7 tests). Badge endpoint renders `TESTS: PASSING`.

## Not addressed

Two things surfaced while investigating that are your call, not code changes:

- Fork PRs sit at `action_required` until approved (2 of the last 15 runs), so outside contributors see no checks at all — likely part of what prompted this issue.
- `CONTRIBUTING.md` asks for a `[0-9]*.[0-9]*.[0-9]*` tag ruleset and immutable releases; only the `main publish only` branch ruleset exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)