### PR TITLE
Define and enforce which file types models/ accepts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,22 @@ coverage
 *.stp.glb.lock
 tmp/
 
+# Review media rendered next to a fixture. models/ holds CAD/robot sources,
+# generated 3D and fabrication outputs, and docs only; see models/README.md.
+models/**/*.png
+models/**/*.jpg
+models/**/*.jpeg
+models/**/*.gif
+models/**/*.webp
+models/**/*.avif
+models/**/*.bmp
+models/**/*.tif
+models/**/*.tiff
+models/**/*.svg
+models/**/*.mp4
+models/**/*.mov
+models/**/*.webm
+models/**/*.mkv
+
 # Local printer credentials
 /bambu-printers.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,16 @@ flow, CI/CD-testing and resume options, and local/manual fallbacks.
 - Edit the source reached by the `develop` symlink layout first, then regenerate
   explicit derived outputs when a production-output task requires it.
 - Write all test, sample, permanent, and generated CAD/robot-description
-  artifacts under `models/`, including STEP/STP, STL, GLB, DXF, URDF, SRDF,
-  SDF, and G-code outputs. Do not create ad hoc artifact directories elsewhere.
+  artifacts under `models/`, including STEP/STP, STL, 3MF, GLB, DXF, URDF,
+  SRDF, SDF, and G-code outputs. Do not create ad hoc artifact directories
+  elsewhere.
+- `models/` takes CAD/robot sources, the 3D and fabrication outputs generated
+  from them, and their docs — nothing else. Do not commit review media
+  (snapshot PNGs, orbit GIFs, screen recordings), data or metadata dumps,
+  archives, foreign CAD sources, or runtime debris there; render review images
+  under `/tmp` and attach them to the conversation or PR. The File Policy
+  section of `models/README.md` is the authoritative list, enforced by
+  `tests/python/global/test_models_directory_policy.py`.
 - Reserve `scripts/` for durable repo commands. Do not write temporary,
   one-off, or local-only helper scripts there; use `tmp/` or `/tmp` instead.
 - Development symlinks mark generated or copied paths. If a file is under a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,14 @@ ask it to write files under that scratch path. This keeps skill scripts,
 fixtures, generated sidecars, and Viewer links using the same repo-relative
 paths that CI and local checks expect.
 
+Only commit what belongs there. The File Policy section of
+[models/README.md](models/README.md) lists the file types `models/` accepts —
+CAD/robot sources, the 3D and fabrication outputs generated from them, and
+docs — and `tests/python/global/test_models_directory_policy.py` enforces that
+list against tracked files. Review media such as snapshot PNGs and orbit GIFs
+are not model artifacts: render them under `/tmp` and attach them to the pull
+request instead.
+
 ## Source Boundaries
 
 Each skill must be self-contained and independent when it is installed from a

--- a/models/README.md
+++ b/models/README.md
@@ -34,15 +34,60 @@ model artifacts explicitly when you need local bytes:
 git lfs pull --include="models/**" --exclude=""
 ```
 
-## Cleanup Policy
+## File Policy
 
-- Keep canonical sources (`*.py`, `*.implicit.js`, `*.urdf`, `*.srdf`, and docs)
-  readable in normal Git.
-- Keep durable generated fixtures (`*.step`, `*.stl`, `*.3mf`, `*.glb`,
-  `*.gcode`, and `*.dxf`) in Git LFS.
-- Do not commit supplementary media or sidecar metadata such as `*.png`,
-  `*.mp4`, `*.gif`, or `*.json` unless a future workflow defines them as a
-  required model artifact.
-- Do not commit local runtime debris such as `.DS_Store`, `__pycache__/`,
-  `.cache/`, logs, or one-off timestamped review snapshots.
-- Put temporary scratch artifacts under ignored local paths, not in this tree.
+This tree accepts three things: CAD and robot-description **sources**, the 3D
+and fabrication **outputs** generated from them, and the **docs** that describe
+both. Nothing else belongs here — a file that is neither runnable model source
+nor a durable generated artifact is review material or scratch, and lives
+outside `models/`.
+
+`tests/python/global/test_models_directory_policy.py` enforces the list below
+against every tracked file. Adding a new artifact type is a deliberate change:
+update this section and that test together.
+
+### Allowed File Types
+
+| Kind | Files | Storage |
+| --- | --- | --- |
+| Generator and helper source | `*.py` | normal Git |
+| Implicit CAD source | `*.implicit.js`, `*.implicit.mjs` | normal Git |
+| Robot description source | `*.urdf`, `*.srdf`, `*.sdf` | normal Git |
+| Documentation | `*.md` | normal Git |
+| CAD Viewer interaction sidecar | `.<stem>.step.js` | normal Git |
+| CAD exchange output | `*.step`, `*.stp` | Git LFS |
+| Mesh output | `*.stl`, `*.3mf`, `*.glb` | Git LFS |
+| CAD Viewer render/selector sidecar | `.<stem>.step.glb` | Git LFS |
+| 2D output | `*.dxf` | Git LFS |
+| Fabrication output | `*.gcode` | Git LFS |
+
+The output rows are exactly the model formats CAD Viewer catalogs
+(`SOURCE_EXTENSIONS` in `viewer/src/server/catalog/cadDirectoryScanner.mjs`),
+plus the two hidden sidecars paired with a STEP file. Hidden files are only
+ever those sidecars; `.<stem>.step.glb` and `.<stem>.step.js` must sit beside
+the `.step`/`.stp` file they belong to.
+
+Commit a generated output only when it is durable — something a workflow, test,
+catalog entry, or print job depends on. Regenerable one-offs stay local.
+
+### Not Allowed
+
+Anything outside the table above, and in particular:
+
+- **Review media** — `*.png`, `*.jpg`, `*.jpeg`, `*.gif`, `*.webp`, `*.avif`,
+  `*.bmp`, `*.tif`, `*.tiff`, `*.svg`, `*.mp4`, `*.mov`, `*.webm`, `*.mkv`.
+  Snapshots, orbit GIFs, and screen captures are review output, not model
+  artifacts. Render them under `/tmp` and attach them to the conversation or
+  pull request. Repository `.gitignore` rules keep a stray render from showing
+  up as untracked under `models/`; the policy test is the gate that a forced
+  `git add` still has to pass.
+- **Data and metadata dumps** — `*.json`, `*.yaml`, `*.yml`, `*.csv`, `*.tsv`,
+  `*.txt`, `*.toml`, `*.ini`, `*.xml`. Keep model parameters and metadata in the
+  generator source, or regenerate the sidecar locally as a transient artifact.
+- **Archives and foreign CAD sources** — `*.zip`, `*.7z`, `*.tar`, `*.tgz`,
+  `*.gz`, `*.rar`, `*.f3d`, `*.ipt`, `*.iam`, `*.sldprt`, `*.sldasm`, `*.prt`,
+  `*.blend`, `*.scad`. Commit the generator and its exported STEP instead of the
+  upstream bundle it came from.
+- **Runtime debris** — `.DS_Store`, `__pycache__/`, `.cache/`, `*.log`,
+  `*.lock`, `*.tmp`, and one-off timestamped review captures. Put temporary
+  scratch artifacts under ignored local paths, not in this tree.

--- a/models/fun/.thick_mobius_strip.step.glb
+++ b/models/fun/.thick_mobius_strip.step.glb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3303ff6c5d0786670cb7da8f8a29c50420ff0c6adef873e7a63628f6aa421cea
-size 30854804

--- a/tests/python/global/test_models_directory_policy.py
+++ b/tests/python/global/test_models_directory_policy.py
@@ -1,0 +1,314 @@
+"""Policy checks for what may be committed under `models/`.
+
+`models/README.md` states the policy for humans; this module is the enforced
+version of the same list. The two are kept in step by
+`test_readme_documents_every_allowed_file_type`, so widening the policy means
+editing both.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODELS_DIR = "models"
+README_PATH = REPO_ROOT / MODELS_DIR / "README.md"
+
+# Sources and docs that stay readable in normal Git.
+TEXT_SUFFIXES = (
+    ".py",
+    ".md",
+    ".implicit.js",
+    ".implicit.mjs",
+    ".step.js",
+    ".urdf",
+    ".srdf",
+    ".sdf",
+)
+
+# Generated CAD, mesh, and fabrication outputs kept in Git LFS. These are the
+# model formats CAD Viewer catalogs plus the hidden `.<stem>.step.glb` sidecar.
+BINARY_SUFFIXES = (
+    ".step",
+    ".stp",
+    ".stl",
+    ".3mf",
+    ".glb",
+    ".dxf",
+    ".gcode",
+)
+
+ALLOWED_SUFFIXES = TEXT_SUFFIXES + BINARY_SUFFIXES
+
+# Hidden files under `models/` are CAD Viewer sidecars paired with a STEP file.
+HIDDEN_SIDECAR_SUFFIXES = (".step.glb", ".step.js")
+STEP_SUFFIXES = (".step", ".stp")
+
+DISALLOWED_KINDS = (
+    (
+        "review media",
+        (
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".webp",
+            ".avif",
+            ".bmp",
+            ".tif",
+            ".tiff",
+            ".svg",
+            ".mp4",
+            ".mov",
+            ".webm",
+            ".mkv",
+        ),
+        "render snapshots and orbit animations under /tmp and attach them to the "
+        "conversation or pull request",
+    ),
+    (
+        "data and metadata dumps",
+        (
+            ".json",
+            ".yaml",
+            ".yml",
+            ".csv",
+            ".tsv",
+            ".txt",
+            ".toml",
+            ".ini",
+            ".xml",
+        ),
+        "keep model parameters and metadata in the generator source, or "
+        "regenerate the sidecar locally as a transient artifact",
+    ),
+    (
+        "archives and foreign CAD sources",
+        (
+            ".zip",
+            ".7z",
+            ".tar",
+            ".tgz",
+            ".gz",
+            ".rar",
+            ".f3d",
+            ".ipt",
+            ".iam",
+            ".sldprt",
+            ".sldasm",
+            ".prt",
+            ".blend",
+            ".scad",
+        ),
+        "commit the generator and its exported STEP instead of the upstream bundle",
+    ),
+    (
+        "runtime debris",
+        (".log", ".lock", ".tmp", ".pyc", ".swp"),
+        "keep local runtime output under ignored paths",
+    ),
+)
+
+DISALLOWED_NAMES = (".DS_Store", "Thumbs.db", "desktop.ini")
+DISALLOWED_DIR_NAMES = ("__pycache__", ".cache", ".vite", "node_modules", "dist", "tmp")
+
+README_REFERENCE = (
+    "See the File Policy section of models/README.md for the full list and for "
+    "how to widen it."
+)
+
+
+def _run_git(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _tracked_model_paths() -> list[str]:
+    completed = _run_git("ls-files", "-z", "--", MODELS_DIR)
+    return sorted(entry for entry in completed.stdout.split("\0") if entry)
+
+
+def _matched_suffix(name: str, suffixes: tuple[str, ...]) -> str | None:
+    """Return the longest allowed suffix `name` ends with, if any.
+
+    A file whose whole name is the suffix (``.py``) is not a source file, so the
+    match must leave at least one character of stem behind.
+    """
+    lowered = name.lower()
+    matches = [
+        suffix
+        for suffix in suffixes
+        if lowered.endswith(suffix) and len(lowered) > len(suffix)
+    ]
+    return max(matches, key=len) if matches else None
+
+
+def _format_paths(paths: list[str], limit: int = 20) -> str:
+    shown = "\n".join(f"  {path}" for path in paths[:limit])
+    if len(paths) > limit:
+        shown += f"\n  ... and {len(paths) - limit} more"
+    return shown
+
+
+class ModelsDirectoryPolicyTest(unittest.TestCase):
+    tracked_paths: list[str]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            cls.tracked_paths = _tracked_model_paths()
+        except (OSError, subprocess.CalledProcessError) as error:  # pragma: no cover
+            raise unittest.SkipTest(f"git is unavailable: {error}") from error
+        if not cls.tracked_paths:
+            raise unittest.SkipTest("no tracked files under models/")
+
+    def test_tracked_files_use_allowed_file_types(self) -> None:
+        offenders = [
+            path
+            for path in self.tracked_paths
+            if _matched_suffix(Path(path).name, ALLOWED_SUFFIXES) is None
+        ]
+        self.assertEqual(
+            offenders,
+            [],
+            "models/ accepts CAD/robot sources, generated 3D and fabrication "
+            "outputs, and docs only. These tracked files match no allowed type:\n"
+            f"{_format_paths(offenders)}\n{README_REFERENCE}",
+        )
+
+    def test_tracked_files_exclude_media_and_other_denied_kinds(self) -> None:
+        failures: list[str] = []
+        for kind, suffixes, remedy in DISALLOWED_KINDS:
+            offenders = [
+                path
+                for path in self.tracked_paths
+                if _matched_suffix(Path(path).name, suffixes) is not None
+            ]
+            if offenders:
+                failures.append(
+                    f"{kind} must not be committed under models/ "
+                    f"({remedy}):\n{_format_paths(offenders)}"
+                )
+
+        named_offenders = [
+            path for path in self.tracked_paths if Path(path).name in DISALLOWED_NAMES
+        ]
+        if named_offenders:
+            failures.append(
+                "runtime debris must not be committed under models/:\n"
+                f"{_format_paths(named_offenders)}"
+            )
+
+        dir_offenders = [
+            path
+            for path in self.tracked_paths
+            if set(Path(path).parts[:-1]) & set(DISALLOWED_DIR_NAMES)
+        ]
+        if dir_offenders:
+            failures.append(
+                "generated or cache directories must not be committed under "
+                f"models/:\n{_format_paths(dir_offenders)}"
+            )
+
+        self.assertEqual(
+            failures, [], "\n\n".join([*failures, README_REFERENCE])
+        )
+
+    def test_hidden_files_are_cad_viewer_step_sidecars(self) -> None:
+        offenders: list[str] = []
+        orphans: list[str] = []
+        tracked = set(self.tracked_paths)
+
+        for path in self.tracked_paths:
+            name = Path(path).name
+            if not name.startswith("."):
+                continue
+            suffix = _matched_suffix(name, HIDDEN_SIDECAR_SUFFIXES)
+            if suffix is None:
+                offenders.append(path)
+                continue
+            stem = name[1 : -len(suffix)]
+            parent = Path(path).parent
+            if not any(
+                str(parent / f"{stem}{step_suffix}") in tracked
+                for step_suffix in STEP_SUFFIXES
+            ):
+                orphans.append(path)
+
+        self.assertEqual(
+            offenders,
+            [],
+            "the only hidden files allowed under models/ are the CAD Viewer "
+            "sidecars .<stem>.step.glb and .<stem>.step.js:\n"
+            f"{_format_paths(offenders)}\n{README_REFERENCE}",
+        )
+        self.assertEqual(
+            orphans,
+            [],
+            "these CAD Viewer sidecars have no STEP file beside them; remove "
+            "the sidecar or commit the .step/.stp it belongs to:\n"
+            f"{_format_paths(orphans)}",
+        )
+
+    def test_generated_outputs_are_lfs_tracked(self) -> None:
+        binaries = [
+            path
+            for path in self.tracked_paths
+            if _matched_suffix(Path(path).name, BINARY_SUFFIXES) is not None
+        ]
+        self.assertTrue(binaries, "expected generated model outputs under models/")
+
+        completed = subprocess.run(
+            ["git", "check-attr", "filter", "--stdin"],
+            cwd=REPO_ROOT,
+            input="\n".join(binaries),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        offenders = []
+        for line in completed.stdout.splitlines():
+            path, _, value = line.rpartition(": filter: ")
+            if path and value.strip() != "lfs":
+                offenders.append(f"{path} (filter={value.strip()})")
+
+        self.assertEqual(
+            offenders,
+            [],
+            "generated model outputs must be stored in Git LFS; add the missing "
+            f"filter rule to .gitattributes:\n{_format_paths(offenders)}",
+        )
+
+    def test_readme_documents_every_allowed_file_type(self) -> None:
+        readme = README_PATH.read_text(encoding="utf-8")
+        undocumented = [suffix for suffix in ALLOWED_SUFFIXES if suffix not in readme]
+        self.assertEqual(
+            undocumented,
+            [],
+            "models/README.md must document every file type this policy allows; "
+            f"missing: {undocumented}",
+        )
+
+        lowered = readme.lower()
+        undocumented_kinds = [
+            kind for kind, _, _ in DISALLOWED_KINDS if kind.lower() not in lowered
+        ]
+        self.assertEqual(
+            undocumented_kinds,
+            [],
+            "models/README.md must name every disallowed category this policy "
+            f"rejects; missing: {undocumented_kinds}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

`models/README.md` had a prose-only **Cleanup Policy** with an open-ended escape hatch ("unless a future workflow defines them as a required model artifact"), and nothing checked it. Review media, scratch metadata, or a vendor archive could land in the fixture tree and only get caught by a reviewer noticing.

## What changed

**`models/README.md` — new File Policy section.** `models/` accepts three things: CAD/robot **sources**, the 3D and fabrication **outputs** generated from them, and the **docs** describing both.

| Kind | Files | Storage |
| --- | --- | --- |
| Generator and helper source | `*.py` | normal Git |
| Implicit CAD source | `*.implicit.js`, `*.implicit.mjs` | normal Git |
| Robot description source | `*.urdf`, `*.srdf`, `*.sdf` | normal Git |
| Documentation | `*.md` | normal Git |
| CAD Viewer interaction sidecar | `.<stem>.step.js` | normal Git |
| CAD exchange output | `*.step`, `*.stp` | Git LFS |
| Mesh output | `*.stl`, `*.3mf`, `*.glb` | Git LFS |
| CAD Viewer render/selector sidecar | `.<stem>.step.glb` | Git LFS |
| 2D output | `*.dxf` | Git LFS |
| Fabrication output | `*.gcode` | Git LFS |

The output rows are exactly `SOURCE_EXTENSIONS` from `viewer/src/server/catalog/cadDirectoryScanner.mjs`, so the policy tracks what CAD Viewer can actually catalog rather than a hand-maintained parallel list.

Four denied categories are named explicitly, with the reason and the alternative:

- **Review media** — `png/jpg/jpeg/gif/webp/avif/bmp/tif/tiff/svg/mp4/mov/webm/mkv`. Snapshots and orbit GIFs are review output, not model artifacts; render them under `/tmp` and attach them to the conversation or PR.
- **Data and metadata dumps** — `json/yaml/yml/csv/tsv/txt/toml/ini/xml`.
- **Archives and foreign CAD sources** — `zip/7z/tar/tgz/gz/rar/f3d/ipt/iam/sldprt/sldasm/prt/blend/scad`.
- **Runtime debris** — `.DS_Store`, `__pycache__/`, `.cache/`, `*.log`, `*.lock`, `*.tmp`.

**`tests/python/global/test_models_directory_policy.py` — enforcement.** Runs over `git ls-files -- models` (index only, so it needs no LFS hydration) and checks:

1. every tracked file matches an allowed type;
2. no denied kind, debris filename, or cache directory is tracked;
3. hidden files are only `.<stem>.step.glb` / `.<stem>.step.js`, and each has its `.step`/`.stp` beside it;
4. generated outputs resolve to `filter=lfs` via `git check-attr`;
5. the README documents every allowed suffix and every denied category — so the doc and the enforced list cannot drift.

**`.gitignore`** — media patterns scoped to `models/**` so a snapshot rendered next to a fixture never shows up as untracked. This is convenience, not the gate: a forced `git add` still has to pass the test.

**`AGENTS.md` / `CONTRIBUTING.md`** — point at the README section as the authority, and add 3MF to the artifact list in AGENTS.md (it was already produced by the CAD skill but missing from that sentence).

## One file removed

`models/fun/.thick_mobius_strip.step.glb` — the orphan check found it. No `thick_mobius_strip.step` has ever existed in this repo's history (no deletion record), no generator produces it, and nothing references the name. It was a dead 133-byte LFS pointer from the original bulk model-assets import.

## Verification

- `scripts/test/test-global.sh` — 15/15 pass (needs `PYTHON_BIN=<main-checkout>/.venv/bin/python` in a worktree; the `python3` fallback is 3.9 and the pre-existing `test_skill_self_containment` needs `tomllib` from 3.11+).
- Negative-tested each rule by staging a `review.png`, a `meta.json`, a `.notes.txt`, and an orphaned `.orphan.step.glb` — each failed with the intended message and path list, then cleaned up.
- Confirmed `git check-ignore` catches media under `models/` at any depth.

Docs `npm run check` gets as far as the hero STEP asset check (passes) before `eslint` — `docs/node_modules` isn't installed in this worktree, and nothing in `docs/` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)