### PR TITLE
Read the canonical version from the legacy path at older refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,7 +298,10 @@ jobs:
           current_version="$(tr -d '[:space:]' < VERSION)"
           latest_tag="$(git tag --list '[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname | head -n 1 || true)"
           if ! scripts/release/check-version.sh --incremented-from origin/main >/tmp/publish-main-version-check.log 2>&1; then
-            main_version="$(git show origin/main:VERSION | tr -d '[:space:]')"
+            # main published before the plugin package moved to the repository
+            # root keeps the canonical version at plugins/cad/VERSION.
+            main_version="$(git show origin/main:VERSION 2>/dev/null || git show origin/main:plugins/cad/VERSION)"
+            main_version="$(printf '%s' "$main_version" | tr -d '[:space:]')"
             if [ "$main_version" = "$current_version" ] && ! git rev-parse --verify --quiet "refs/tags/$current_version" >/dev/null; then
               echo "Release version already reached origin/main, but tag $current_version is missing; resuming publish."
             else

--- a/scripts/release/bump-version.sh
+++ b/scripts/release/bump-version.sh
@@ -5,6 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 VERSION_PATH="VERSION"
 VERSION_FILE="$REPO_ROOT/$VERSION_PATH"
+# Refs published before the plugin package moved to the repository root keep the
+# canonical version at plugins/cad/VERSION. Release tags are permanent, so
+# comparisons against older tags always need this fallback; it is not
+# transitional and must not be removed once main carries the new path.
+LEGACY_VERSION_PATH="plugins/cad/VERSION"
 
 PART=""
 SET_VERSION=""
@@ -118,7 +123,14 @@ git_text_at_ref() {
   if [[ "$ref" =~ ^0+$ ]]; then
     die "base ref must be a real commit, not an empty all-zero ref"
   fi
-  git -C "$REPO_ROOT" show "$ref:$VERSION_PATH"
+  local candidate
+  for candidate in "$VERSION_PATH" "$LEGACY_VERSION_PATH"; do
+    if git -C "$REPO_ROOT" cat-file -e "$ref:$candidate" 2>/dev/null; then
+      git -C "$REPO_ROOT" show "$ref:$candidate"
+      return 0
+    fi
+  done
+  die "no canonical version file at $ref ($VERSION_PATH or $LEGACY_VERSION_PATH)"
 }
 
 stage_paths() {

--- a/tests/python/global/test_release_version_paths.py
+++ b/tests/python/global/test_release_version_paths.py
@@ -1,0 +1,133 @@
+"""The canonical version file moved from `plugins/cad/VERSION` to `VERSION`.
+
+`scripts/release/bump-version.sh --check-incremented-from REF` reads the
+canonical version *at a git ref*, and the refs it is pointed at are frequently
+older than the move: `origin/main` until the first new-layout release lands, and
+release tags forever after that, since tags are immutable.
+
+Without a fallback the script fails with git's exit 128 ("path 'VERSION' exists
+on disk, but not in <ref>") rather than a version comparison, which takes the
+whole `Release` workflow down at its first gate. These tests pin the fallback.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BUMP_SCRIPT = REPO_ROOT / "scripts" / "release" / "bump-version.sh"
+
+VERSION_PATH = "VERSION"
+LEGACY_VERSION_PATH = "plugins/cad/VERSION"
+
+
+def git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def init_repo(root: Path) -> None:
+    """Init a repo with the script installed at its real repo-relative path.
+
+    `bump-version.sh` resolves its own repo root from `${BASH_SOURCE[0]}`, not
+    from the working directory, so the fixture only exercises the fixture repo
+    when the script is invoked from inside it.
+    """
+    git("init", "--quiet", cwd=root)
+    git("config", "user.email", "test@example.com", cwd=root)
+    git("config", "user.name", "test", cwd=root)
+
+    script_copy = root / "scripts" / "release" / "bump-version.sh"
+    script_copy.parent.mkdir(parents=True, exist_ok=True)
+    script_copy.write_bytes(BUMP_SCRIPT.read_bytes())
+    script_copy.chmod(0o755)
+
+
+def build_repo(root: Path, base_version_path: str, base_version: str) -> None:
+    """Create a repo whose base commit holds `base_version` at `base_version_path`."""
+    init_repo(root)
+
+    base_file = root / base_version_path
+    base_file.parent.mkdir(parents=True, exist_ok=True)
+    base_file.write_text(f"{base_version}\n", encoding="utf-8")
+    git("add", "-A", cwd=root)
+    git("commit", "--quiet", "-m", "base layout", cwd=root)
+    git("tag", base_version, cwd=root)
+
+
+def run_check(root: Path, ref: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(root / "scripts" / "release" / "bump-version.sh"), "--check-incremented-from", ref],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+
+
+class ReleaseVersionPathTest(unittest.TestCase):
+    def _scenario(self, base_version_path: str, next_version: str) -> subprocess.CompletedProcess[str]:
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        build_repo(root, base_version_path, "0.3.11")
+
+        # Move to the current layout and bump.
+        if base_version_path != VERSION_PATH:
+            git("rm", "--quiet", "-r", "plugins", cwd=root)
+        (root / VERSION_PATH).write_text(f"{next_version}\n", encoding="utf-8")
+        git("add", "-A", cwd=root)
+        git("commit", "--quiet", "-m", "move to repo root", cwd=root)
+
+        return run_check(root, "refs/tags/0.3.11")
+
+    def test_reads_the_legacy_version_path_at_older_refs(self) -> None:
+        result = self._scenario(LEGACY_VERSION_PATH, "0.3.12")
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"expected the legacy fallback to resolve\nstdout: {result.stdout}\nstderr: {result.stderr}",
+        )
+        self.assertIn("0.3.11 -> 0.3.12", result.stdout)
+
+    def test_reads_the_current_version_path_at_newer_refs(self) -> None:
+        result = self._scenario(VERSION_PATH, "0.3.12")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("0.3.11 -> 0.3.12", result.stdout)
+
+    def test_still_rejects_a_version_that_did_not_advance(self) -> None:
+        # The fallback must not turn a real comparison failure into a pass.
+        result = self._scenario(LEGACY_VERSION_PATH, "0.3.11")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be greater than", result.stderr)
+
+    def test_fails_clearly_when_no_version_file_exists_at_the_ref(self) -> None:
+        tmp = TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+
+        init_repo(root)
+        (root / "README.md").write_text("no version here\n", encoding="utf-8")
+        git("add", "-A", cwd=root)
+        git("commit", "--quiet", "-m", "no version", cwd=root)
+        git("tag", "empty-base", cwd=root)
+
+        (root / VERSION_PATH).write_text("0.3.12\n", encoding="utf-8")
+        git("add", "-A", cwd=root)
+        git("commit", "--quiet", "-m", "add version", cwd=root)
+
+        result = run_check(root, "refs/tags/empty-base")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("no canonical version file", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Blocks the next release. Found while preparing a `build-test` release run after #183.

`bump-version.sh --check-incremented-from REF` reads the canonical version **at a git ref**. Moving the canonical file from `plugins/cad/VERSION` to `VERSION` in #183 broke every such read against a ref published before the move:

```
$ scripts/release/check-version.sh --incremented-from origin/main
fatal: path 'VERSION' exists on disk, but not in 'origin/main'
exit=128

$ scripts/release/check-version.sh --incremented-from refs/tags/0.3.11
fatal: path 'VERSION' exists on disk, but not in 'refs/tags/0.3.11'
exit=128
```

Those two calls are the **first gate** in the `Release` workflow's `release-pr` job, so the next release would have failed before building anything — for `build-test` and `main` alike. `main` and every existing tag still carry `plugins/cad/VERSION`.

## Fix

Look up `VERSION` first, fall back to `plugins/cad/VERSION`, in two places:

- `scripts/release/bump-version.sh` — `git_text_at_ref()`
- `.github/workflows/release.yml` — the publish job's `main_version` read, which had the same single-path assumption

**This is permanent, not transitional.** Release tags are immutable, so a comparison against any pre-move tag will always need the legacy path. Both sites carry a comment saying so, to stop a future cleanup from removing it.

## Verification

After the fix, with the canonical version temporarily set to `0.3.12` to simulate the bump:

```
Canonical release version is incremented from origin/main: 0.3.11 -> 0.3.12
Canonical release version is incremented from refs/tags/0.3.11: 0.3.11 -> 0.3.12
```

Both exit 0, resolving `0.3.11` through the legacy path.

## Test

Adds `tests/python/global/test_release_version_paths.py` — builds throwaway git repos in both layouts and asserts:

- the legacy path resolves at older refs
- the current path resolves at newer refs
- a version that did **not** advance is still rejected (the fallback must not mask a real comparison failure)
- a ref with no version file at all fails with a clear message rather than a raw git error

Confirmed the test has teeth: reverting the fallback produces 3 failures, restoring it returns to green. Global suite is 25 tests, all passing.

Note the test installs the script at its real repo-relative path inside each fixture, because `bump-version.sh` resolves its repo root from `${BASH_SOURCE[0]}` rather than the working directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
