### PR TITLE
viewer: let a same-stem generator own its entry, and allow the cadjs real path

### DIFF
--- a/viewer/scripts/serverFsAllow.mjs
+++ b/viewer/scripts/serverFsAllow.mjs
@@ -1,0 +1,38 @@
+// Vite's `server.fs.allow` roots for the dev server.
+//
+// Vite checks a module id AFTER resolving it, so ids arrive as real paths. The
+// develop layout reaches cadjs through the `viewer/packages/cadjs` symlink, so
+// allowing only the symlink path leaves the real path outside the list and Vite
+// refuses to serve anything it resolves through it -- notably
+// `packages/cadjs/src/lib/render/glbMeshWorker.js`, whose loader falls back to
+// main-thread GLB decoding, so the only symptom is a dev-server log line.
+//
+// Listing both the symlink path and its real path keeps the allow list correct
+// in the symlinked develop layout and in a flat checkout, where the two are the
+// same path and dedupe to one entry.
+
+export function resolveServerFsAllow(paths, { realpath } = {}) {
+  const allow = [];
+  const add = (value) => {
+    const entry = String(value || "").trim();
+    if (entry && !allow.includes(entry)) {
+      allow.push(entry);
+    }
+  };
+  for (const candidate of Array.isArray(paths) ? paths : []) {
+    if (!candidate) {
+      continue;
+    }
+    add(candidate);
+    if (typeof realpath !== "function") {
+      continue;
+    }
+    try {
+      add(realpath(candidate));
+    } catch {
+      // A root that does not exist yet is still worth allowing by its literal
+      // path; there is simply no real path to add for it.
+    }
+  }
+  return allow;
+}

--- a/viewer/scripts/serverFsAllow.test.mjs
+++ b/viewer/scripts/serverFsAllow.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveServerFsAllow } from "./serverFsAllow.mjs";
+
+test("server fs allow list includes the real path behind a symlinked package root", () => {
+  // The develop layout: viewer/packages/cadjs is a symlink to packages/cadjs.
+  const realpath = (value) =>
+    value === "/repo/viewer/packages/cadjs/src" ? "/repo/packages/cadjs/src" : value;
+  const allow = resolveServerFsAllow(["/repo/viewer", "/repo/viewer/packages/cadjs/src"], { realpath });
+  assert.deepEqual(allow, [
+    "/repo/viewer",
+    "/repo/viewer/packages/cadjs/src",
+    "/repo/packages/cadjs/src",
+  ]);
+});
+
+test("server fs allow list dedupes when the package root is not a symlink", () => {
+  const allow = resolveServerFsAllow(["/repo/viewer", "/repo/viewer/packages/cadjs/src"], {
+    realpath: (value) => value,
+  });
+  assert.deepEqual(allow, ["/repo/viewer", "/repo/viewer/packages/cadjs/src"]);
+});
+
+test("server fs allow list keeps roots whose real path cannot be read", () => {
+  const allow = resolveServerFsAllow(["/repo/viewer"], {
+    realpath: () => {
+      throw new Error("ENOENT");
+    },
+  });
+  assert.deepEqual(allow, ["/repo/viewer"]);
+});
+
+test("server fs allow list skips empty entries and works without a realpath resolver", () => {
+  assert.deepEqual(resolveServerFsAllow(["/repo/viewer", "", null]), ["/repo/viewer"]);
+  assert.deepEqual(resolveServerFsAllow([]), []);
+});

--- a/viewer/scripts/viewerEnv.mjs
+++ b/viewer/scripts/viewerEnv.mjs
@@ -8,7 +8,7 @@ export function assertNoDeprecatedLocalRootEnv(env = process.env) {
   if (configured.length) {
     throw new Error(
       `${configured.join(", ")} ${configured.length === 1 ? "is" : "are"} no longer supported. ` +
-      "Pass ?dir= in the Viewer URL instead."
+      "A Viewer URL's path is the directory it opens; open the directory in the URL instead."
     );
   }
 }

--- a/viewer/server_py/backend.py
+++ b/viewer/server_py/backend.py
@@ -244,6 +244,17 @@ class LocalAssetBackend:
                 return {"stepPath": os.path.join(os.path.dirname(c), step_base), "sourcePath": c, "skipStepWrite": True}
             if ext not in (".step", ".stp"):
                 raise ValueError("Only STEP/STP sources or same-stem Python generators can generate STEP topology artifacts")
+            # A same-stem `<name>.step.py` generator OWNS the entry even when an
+            # exported `<name>.step` sits beside it. The export is the generator's
+            # output, and only the generator can declare the model's `params`
+            # sidecar -- the documented way to attach one to an imported STEP
+            # (skills/cad/references/parameters.md). Resolving it here keeps the
+            # build, the freshness check and STEP export all keyed on the same
+            # source. cadgen's generator mode writes only the render package, so
+            # the exported `.step` beside it is never rewritten.
+            generator = self._same_stem_python_generator_path(c)
+            if generator:
+                return {"stepPath": c, "sourcePath": generator, "skipStepWrite": True}
             return {"stepPath": c, "sourcePath": "", "skipStepWrite": False}
         raise ValueError(f"STEP file not found: {normalized}")
 
@@ -326,7 +337,9 @@ class LocalAssetBackend:
         step_path = resolved["stepPath"]
         ext = os.path.splitext(step_path)[1].lower()
         has_step = ext in (".step", ".stp") and os.path.isfile(step_path)
-        generator = "" if has_step else self._same_stem_python_generator_path(step_path)
+        # resolve_step_source already prefers a same-stem generator over a sibling
+        # export, so both the freshness check and this build key on one source.
+        generator = resolved.get("sourcePath") or ""
         has_generator = bool(generator) and os.path.isfile(generator)
         if not has_step and not has_generator:
             raise ValueError("CAD Viewer regenerates GLB artifacts only for existing STEP/STP files or their same-stem Python generators.")

--- a/viewer/server_py/tests/test_step_source_resolution.py
+++ b/viewer/server_py/tests/test_step_source_resolution.py
@@ -1,0 +1,85 @@
+"""resolve_step_source precedence: a same-stem generator owns its entry.
+
+A `<name>.step.py` generator beside an exported `<name>.step` is the documented
+way to attach a `params` sidecar to an imported STEP
+(skills/cad/references/parameters.md). The export is the generator's output, so
+the generator -- not the export -- is the source the render package is keyed by.
+"""
+
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from server_py.backend import LocalAssetBackend  # noqa: E402
+
+GENERATOR = """from pathlib import Path
+
+from cadgen.step_scene import import_step
+
+
+def gen_step():
+    return {
+        "shape": import_step(Path(__file__).parent / "widget.step"),
+        "params": "widget.params.js",
+    }
+"""
+
+
+class StepSourceResolutionTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = os.path.realpath(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.backend = LocalAssetBackend()
+
+    def _resolved_root(self):
+        return {"rootPath": self.root}
+
+    def _write(self, name, text=""):
+        path = os.path.join(self.root, name)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        return path
+
+    def test_imported_step_without_a_generator_resolves_to_itself(self):
+        step = self._write("widget.step", "ISO-10303-21;\n")
+        resolved = self.backend.resolve_step_source("widget.step", self._resolved_root())
+        self.assertEqual(resolved["stepPath"], step)
+        self.assertEqual(resolved["sourcePath"], "")
+        self.assertFalse(resolved["skipStepWrite"])
+
+    def test_same_stem_generator_wins_over_a_sibling_export(self):
+        step = self._write("widget.step", "ISO-10303-21;\n")
+        generator = self._write("widget.step.py", GENERATOR)
+        # Reached by the .step ref (how the catalog lists an imported model)...
+        resolved = self.backend.resolve_step_source("widget.step", self._resolved_root())
+        self.assertEqual(resolved["stepPath"], step)
+        self.assertEqual(resolved["sourcePath"], generator)
+        self.assertTrue(resolved["skipStepWrite"])
+        # ...and by the generator ref, which must agree so the freshness check
+        # and the build never key on different sources.
+        via_py = self.backend.resolve_step_source("widget.step.py", self._resolved_root())
+        self.assertEqual(via_py["stepPath"], step)
+        self.assertEqual(via_py["sourcePath"], generator)
+
+    def test_a_sibling_python_file_without_gen_step_is_not_a_generator(self):
+        self._write("widget.step", "ISO-10303-21;\n")
+        self._write("widget.step.py", "value = 1\n")
+        resolved = self.backend.resolve_step_source("widget.step", self._resolved_root())
+        self.assertEqual(resolved["sourcePath"], "")
+        self.assertFalse(resolved["skipStepWrite"])
+
+    def test_generator_with_no_export_on_disk_still_resolves(self):
+        generator = self._write("widget.step.py", GENERATOR)
+        resolved = self.backend.resolve_step_source("widget.step.py", self._resolved_root())
+        self.assertEqual(resolved["stepPath"], os.path.join(self.root, "widget.step"))
+        self.assertEqual(resolved["sourcePath"], generator)
+        self.assertTrue(resolved["skipStepWrite"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/vite.config.mjs
+++ b/viewer/vite.config.mjs
@@ -9,6 +9,7 @@ import react from "@vitejs/plugin-react";
 
 import { cadPythonExecutable, cadPythonEnv } from "./scripts/cad-python.mjs";
 import { resolveDirectoryRoot as resolveViewerDirectoryRoot } from "./scripts/directoryRoot.mjs";
+import { resolveServerFsAllow } from "./scripts/serverFsAllow.mjs";
 import { assertNoDeprecatedLocalRootEnv } from "./scripts/viewerEnv.mjs";
 import {
   normalizeServerLifetimeMs,
@@ -311,10 +312,11 @@ export default defineConfig(({ command }) => ({
     strictPort: true,
     allowedHosts: viewerAllowedHosts,
     fs: {
-      allow: [
-        viewerAppRoot,
-        cadJsPackageRoot,
-      ],
+      // Real paths too: Vite checks ids after resolution, and the develop layout
+      // reaches cadjs through a symlink. See scripts/serverFsAllow.mjs.
+      allow: resolveServerFsAllow([viewerAppRoot, cadJsPackageRoot], {
+        realpath: fs.realpathSync,
+      }),
     },
   },
   preview: {


### PR DESCRIPTION
Three fixes found while loading two large imported-STEP LEGO models into the Viewer.

## A same-stem generator was silently ignored

`generate_step_artifact` only consulted a `<name>.step.py` generator when the exported `<name>.step` was **absent**, so an export always won. That is the documented way to attach a `params` sidecar to an imported STEP (`skills/cad/references/parameters.md`), and three shipped models already use it:

- `models/mechanisms/gear_rack_gripper.step.py`
- `models/mechanisms/adjustable_height_table_2.step.py`
- `models/mechanisms/180_degree_flip_mechanism.step.py`

Each declares a sidecar that exists on disk and could never load. The build recorded `sourceKind=step` with no `paramsPath`, so the Viewer showed no Parameters tab and reported no error.

The preference is resolved in `resolve_step_source`, not at the build, so the freshness check, the build and STEP export all key on one source — keying only the build would leave a model permanently `needs-build`.

Safe to change rather than merely document:

- cadgen already resolves this way (generator first, direct STEP as fallback), so this makes the Viewer consistent rather than inventing a rule.
- cadgen generator mode writes only the render package, so an exported `.step` beside a generator is never rewritten.
- These generators re-import their own sibling export, so this reads identical geometry and additionally records the sidecar.

**Behaviour change:** those three models rebuild once (their packages were keyed on the `.step`), after which their sidecars load.

## Vite refused to serve the GLB mesh worker

`server.fs.allow` listed only `viewer/packages/cadjs/src` — a symlink in the develop layout — but Vite checks module ids *after* resolution, so ids arrive as real paths. It refused `packages/cadjs/src/lib/render/glbMeshWorker.js`, and `loadRenderGlb` quietly fell back to decoding every GLB on the main thread. The only symptom was a dev-server log line, which is why it went unnoticed.

Now allows the real path too, deduped so a flat checkout is unaffected. Verified: the denials are gone after a restart and models still render clean.

## Stale error text

The deprecated-env error still pointed at `?dir=`, removed in b95d1a7d.

## Verification

- 265 viewer JS tests, 79 viewer Python tests — all pass, before and after rebasing onto 480e4555.
- New: 4 resolver precedence tests (`test_step_source_resolution.py`), 4 allow-list tests (`serverFsAllow.test.mjs`).
- Pre-commit hook ran the bundle checks and a full viewer build.

## Note on target branch

Targets `release/0.4.0` rather than `develop` because that is where the affected code lives. Worth knowing: `test.yml` only runs on PRs/pushes to `develop`, so this PR will not get CI — the checks above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
