### PR TITLE
fix(viewer): survive malformed percent-encoding in legacy CAD paths

### DIFF
--- a/viewer/src/server/httpHandlers.mjs
+++ b/viewer/src/server/httpHandlers.mjs
@@ -87,7 +87,12 @@ function legacyCadAssetFileRef(requestUrl, req) {
   if (!requestUrl.pathname.startsWith("/__cad/") || requestUrl.pathname === "/__cad/asset") {
     return "";
   }
-  const relativePath = decodeURIComponent(requestUrl.pathname.slice("/__cad/".length));
+  let relativePath = "";
+  try {
+    relativePath = decodeURIComponent(requestUrl.pathname.slice("/__cad/".length));
+  } catch {
+    return "";
+  }
   if (!relativePath || !path.extname(relativePath)) {
     return "";
   }

--- a/viewer/src/server/httpHandlers.test.mjs
+++ b/viewer/src/server/httpHandlers.test.mjs
@@ -375,6 +375,31 @@ test("local asset middleware resolves legacy URDF mesh URLs from referrer file",
 });
 
 
+test("local asset middleware survives malformed percent-encoding in legacy CAD paths", async () => {
+  const middleware = createLocalAssetMiddleware({
+    backend: {
+      assetPathForFileRef: () => {
+        assert.fail("assetPathForFileRef must not be called for a malformed path");
+      },
+      contentTypeForPath: () => "model/stl",
+    },
+  });
+  const req = {
+    method: "GET",
+    url: "/__cad/foo%zz.step",
+    headers: {},
+  };
+  const res = createResponse();
+  let nextCalled = false;
+
+  middleware(req, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(nextCalled, true, "malformed legacy CAD path should fall through to the next middleware");
+});
+
+
 test("CAD Viewer API middleware reveals file assets with POST reveal route", async () => {
   const calls = [];
   const middleware = createCadViewerApiMiddleware({


### PR DESCRIPTION
Fixes #191.

## Problem

A single request to a `/__cad/` path containing invalid percent-encoding
(e.g. `GET /__cad/foo%zz.step`) crashed the entire CAD Viewer server. In
`viewer/src/server/httpHandlers.mjs:90`, `legacyCadAssetFileRef()` called
`decodeURIComponent()` on the raw pathname outside any try/catch, and the
resulting uncaught `URIError` escaped the request listener and terminated the
Node process.

All other `decodeURIComponent` call sites in the repo are already guarded
(`serveDistAsset` at httpHandlers.mjs:630, `localAssetBackend.mjs:247`,
`viewerConfig.mjs:67-68`); this was the only exposed one.

## Repro

```bash
node --input-type=module -e '
import http from "node:http";
import { createLocalAssetMiddleware } from "./viewer/src/server/httpHandlers.mjs";
const backend = { filePath: "x", assetPathForFileRef: () => "/tmp/a.step", contentTypeForPath: () => "app/octet-stream" };
const mw = createLocalAssetMiddleware({ backend, rootDir: "/tmp" });
const server = http.createServer((req, res) => mw(req, res, () => { res.statusCode = 404; res.end("nf"); }));
server.listen(0, "127.0.0.1", () => {
  const p = server.address().port;
  http.get(`http://127.0.0.1:${p}/__cad/foo%zz.step`, () => process.exit(0));
});
'
```

Before: `URIError: URI malformed` → process exits code 1.
After: malformed paths fall through to `next()`; the server stays up.

## Changes

- `viewer/src/server/httpHandlers.mjs` — guard `decodeURIComponent` in `legacyCadAssetFileRef`; return `""` on malformed input so the middleware falls through gracefully.
- `viewer/src/server/httpHandlers.test.mjs` — regression test asserting a malformed `/__cad/` pathname does not call the asset backend and falls through to the next middleware.

## Verification

- `node --test 'src/**/*.test.*js' 'scripts/**/*.test.*js'` in `viewer/` (Node 24): 401 tests, 0 failures
- `scripts/dev/setup-symlinks.sh --check`: development symlink layout is valid
- `git diff --check`: clean

Note: `npm --prefix viewer run test` fails on Node 24 with
`--experimental-default-type=module` (removed in newer Node); it expects Node 22.