### PR TITLE
fix(viewer): contain handler errors instead of killing the server

### DIFF
--- a/viewer/README.md
+++ b/viewer/README.md
@@ -90,7 +90,9 @@ review links.
 - `src/client/ui/`: viewer-owned browser utilities such as clipboard, color
   scheme, class merging, and DOM helpers.
 - `src/server/`: local and hosted backend adapters, HTTP middleware, and the
-  local production server.
+  local production server. `src/server/requestPipeline.mjs` runs the middleware
+  chain and contains handler failures: an unexpected throw or rejection becomes
+  a 500 instead of killing the server process.
 - `api/cad/`: Vercel serverless shims for `/__cad/*` routes.
 - `scripts/`: developer and runtime launchers, plus the test runner.
 - `docs/`: workflow reference docs for backend storage, browser persistence,

--- a/viewer/src/server/requestPipeline.mjs
+++ b/viewer/src/server/requestPipeline.mjs
@@ -1,0 +1,130 @@
+const DEFAULT_LOG = (message) => process.stderr.write(`${message}\n`);
+
+function describeError(error) {
+  if (error instanceof Error) {
+    return error.stack || `${error.name}: ${error.message}`;
+  }
+  return String(error);
+}
+
+function describeRequest(req) {
+  const method = String(req?.method || "?");
+  const url = String(req?.url || "");
+  return url ? `${method} ${url}` : method;
+}
+
+/**
+ * Turn an unexpected handler failure into a 500 instead of an unhandled throw.
+ * Once headers are on the wire a status code is no longer negotiable, so the
+ * response is destroyed to signal the truncation to the client.
+ */
+export function respondWithInternalError(error, req, res, { log = DEFAULT_LOG } = {}) {
+  log(`CAD Viewer backend request failed (${describeRequest(req)}): ${describeError(error)}`);
+  if (!res || res.writableEnded) {
+    return;
+  }
+  try {
+    if (res.headersSent) {
+      res.destroy();
+      return;
+    }
+    res.statusCode = 500;
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    res.end("Internal Server Error");
+  } catch (responseError) {
+    log(`CAD Viewer backend failed to send 500 (${describeRequest(req)}): ${describeError(responseError)}`);
+    try {
+      res.destroy();
+    } catch {
+      // The socket is already gone; nothing left to clean up.
+    }
+  }
+}
+
+/**
+ * Build the http request listener from an ordered middleware chain. Each
+ * middleware is invoked as `middleware(req, res, next)`; synchronous throws and
+ * rejected promises are both contained so one malformed request cannot take the
+ * whole server process down.
+ */
+export function createRequestPipeline({ middlewares = [], log = DEFAULT_LOG } = {}) {
+  const chain = [...middlewares];
+  const inFlight = new Set();
+
+  function handleRequest(req, res) {
+    inFlight.add(req);
+    const release = () => inFlight.delete(req);
+    res?.once?.("close", release);
+    res?.once?.("finish", release);
+
+    // Only the first failure for a request gets a response; later ones are
+    // logged by respondWithInternalError but cannot rewrite a sent status.
+    let failed = false;
+    const fail = (error) => {
+      if (failed) {
+        return;
+      }
+      failed = true;
+      respondWithInternalError(error, req, res, { log });
+    };
+
+    const runFrom = (index) => {
+      if (failed) {
+        return;
+      }
+      const middleware = chain[index];
+      if (!middleware) {
+        res.statusCode = 404;
+        res.end("Not found");
+        return;
+      }
+      try {
+        const result = middleware(req, res, () => runFrom(index + 1));
+        if (result && typeof result.then === "function") {
+          Promise.resolve(result).catch(fail);
+        }
+      } catch (error) {
+        fail(error);
+      }
+    };
+
+    runFrom(0);
+  }
+
+  return {
+    handleRequest,
+    describeInFlightRequests() {
+      return [...inFlight].map((req) => describeRequest(req));
+    },
+  };
+}
+
+/**
+ * Last-resort guards. An agent session that launched the Viewer should not lose
+ * it to a stray async throw, so both handlers log and keep the process alive
+ * rather than exiting. This can mask real bugs, which is why the log carries the
+ * in-flight request URLs: a crash-shaped log line with the offending request is
+ * more diagnosable than a dead process.
+ */
+export function installProcessErrorGuards({
+  log = DEFAULT_LOG,
+  describeContext = () => [],
+  target = process,
+} = {}) {
+  const contextSuffix = () => {
+    const requests = describeContext() || [];
+    return requests.length ? ` [in-flight: ${requests.join(", ")}]` : "";
+  };
+  const onUnhandledRejection = (reason) => {
+    log(`CAD Viewer backend unhandled rejection: ${describeError(reason)}${contextSuffix()}`);
+  };
+  const onUncaughtException = (error) => {
+    log(`CAD Viewer backend uncaught exception: ${describeError(error)}${contextSuffix()}`);
+  };
+  target.on("unhandledRejection", onUnhandledRejection);
+  target.on("uncaughtException", onUncaughtException);
+  return () => {
+    target.off("unhandledRejection", onUnhandledRejection);
+    target.off("uncaughtException", onUncaughtException);
+  };
+}

--- a/viewer/src/server/requestPipeline.test.mjs
+++ b/viewer/src/server/requestPipeline.test.mjs
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+import { EventEmitter } from "node:events";
+
+import {
+  createRequestPipeline,
+  installProcessErrorGuards,
+} from "./requestPipeline.mjs";
+
+const host = "127.0.0.1";
+
+async function startPipelineServer(t, middlewares) {
+  const logs = [];
+  const pipeline = createRequestPipeline({
+    middlewares,
+    log: (message) => logs.push(message),
+  });
+  const server = http.createServer(pipeline.handleRequest);
+  const port = await new Promise((resolve) => {
+    server.listen(0, host, () => resolve(server.address().port));
+  });
+  t.after(() => new Promise((resolve) => server.close(() => resolve())));
+  return { pipeline, logs, port, server };
+}
+
+function request(port, requestPath) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host, port, path: requestPath, method: "GET" }, (res) => {
+      const chunks = [];
+      res.on("data", (chunk) => chunks.push(chunk));
+      res.on("error", reject);
+      res.on("end", () => resolve({
+        statusCode: res.statusCode,
+        body: Buffer.concat(chunks).toString("utf8"),
+        aborted: res.destroyed && !res.complete,
+      }));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function okMiddleware(req, res) {
+  res.statusCode = 200;
+  res.end("ok");
+}
+
+test("a middleware that throws synchronously yields 500 and leaves the server responsive", async (t) => {
+  const { logs, port } = await startPipelineServer(t, [
+    (req, res, next) => {
+      if (req.url === "/boom") {
+        throw new Error("synchronous handler failure");
+      }
+      next();
+    },
+    okMiddleware,
+  ]);
+
+  const failed = await request(port, "/boom");
+  assert.equal(failed.statusCode, 500);
+  assert.equal(failed.body, "Internal Server Error");
+
+  const followUp = await request(port, "/healthy");
+  assert.equal(followUp.statusCode, 200);
+  assert.equal(followUp.body, "ok");
+
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /GET \/boom/u);
+  assert.match(logs[0], /synchronous handler failure/u);
+});
+
+test("a middleware that rejects asynchronously yields 500 and leaves the server responsive", async (t) => {
+  const { logs, port } = await startPipelineServer(t, [
+    async (req, res, next) => {
+      if (req.url === "/boom") {
+        await Promise.resolve();
+        throw new Error("asynchronous handler failure");
+      }
+      next();
+    },
+    okMiddleware,
+  ]);
+
+  const failed = await request(port, "/boom");
+  assert.equal(failed.statusCode, 500);
+  assert.equal(failed.body, "Internal Server Error");
+
+  const followUp = await request(port, "/healthy");
+  assert.equal(followUp.statusCode, 200);
+  assert.equal(followUp.body, "ok");
+
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /asynchronous handler failure/u);
+});
+
+test("a failure after headers are sent destroys the response instead of throwing", async (t) => {
+  const { logs, port } = await startPipelineServer(t, [
+    (req, res, next) => {
+      if (req.url !== "/late-failure") {
+        next();
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.write("partial");
+      throw new Error("failure after headers");
+    },
+    okMiddleware,
+  ]);
+
+  const truncated = await request(port, "/late-failure").catch((error) => error);
+  // Node surfaces the destroyed socket either as a response error or as a
+  // response that ends without completing; both prove the process survived.
+  if (truncated instanceof Error) {
+    assert.match(String(truncated.code || truncated.message), /ECONNRESET|aborted/u);
+  } else {
+    assert.equal(truncated.statusCode, 200);
+  }
+
+  const followUp = await request(port, "/healthy");
+  assert.equal(followUp.statusCode, 200);
+
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /failure after headers/u);
+});
+
+test("an exhausted middleware chain still returns 404", async (t) => {
+  const { logs, port } = await startPipelineServer(t, [
+    (req, res, next) => next(),
+  ]);
+
+  const missing = await request(port, "/nothing-here");
+  assert.equal(missing.statusCode, 404);
+  assert.equal(missing.body, "Not found");
+  assert.deepEqual(logs, []);
+});
+
+test("only the first failure per request is reported", async (t) => {
+  const { logs, port } = await startPipelineServer(t, [
+    async (req, res, next) => {
+      next();
+      await Promise.resolve();
+      throw new Error("outer late failure");
+    },
+    () => {
+      throw new Error("inner failure");
+    },
+  ]);
+
+  const failed = await request(port, "/double");
+  assert.equal(failed.statusCode, 500);
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /inner failure/u);
+});
+
+test("describeInFlightRequests reports active requests and clears them afterwards", async (t) => {
+  let observed = null;
+  let release = () => {};
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  const { pipeline, port } = await startPipelineServer(t, [
+    async (req, res) => {
+      observed = pipeline.describeInFlightRequests();
+      await gate;
+      res.statusCode = 200;
+      res.end("ok");
+    },
+  ]);
+
+  const pending = request(port, "/slow");
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.deepEqual(observed, ["GET /slow"]);
+  release();
+  await pending;
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.deepEqual(pipeline.describeInFlightRequests(), []);
+});
+
+test("installProcessErrorGuards logs instead of exiting and includes in-flight requests", () => {
+  const logs = [];
+  const target = new EventEmitter();
+  const uninstall = installProcessErrorGuards({
+    log: (message) => logs.push(message),
+    describeContext: () => ["GET /__cad/foo%zz.step"],
+    target,
+  });
+
+  target.emit("unhandledRejection", new Error("stray rejection"));
+  target.emit("uncaughtException", new Error("stray throw"));
+
+  assert.equal(logs.length, 2);
+  assert.match(logs[0], /unhandled rejection: Error: stray rejection/u);
+  assert.match(logs[0], /in-flight: GET \/__cad\/foo%zz\.step/u);
+  assert.match(logs[1], /uncaught exception: Error: stray throw/u);
+
+  uninstall();
+  target.emit("unhandledRejection", new Error("after uninstall"));
+  assert.equal(logs.length, 2);
+});
+
+test("installProcessErrorGuards omits the context suffix when nothing is in flight", () => {
+  const logs = [];
+  const target = new EventEmitter();
+  const uninstall = installProcessErrorGuards({
+    log: (message) => logs.push(message),
+    target,
+  });
+
+  target.emit("unhandledRejection", "plain string reason");
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /unhandled rejection: plain string reason$/u);
+
+  uninstall();
+});

--- a/viewer/src/server/server.mjs
+++ b/viewer/src/server/server.mjs
@@ -43,6 +43,10 @@ import {
   buildViewerStartupJson,
   listenWithPortFallback,
 } from "./serverListen.mjs";
+import {
+  createRequestPipeline,
+  installProcessErrorGuards,
+} from "./requestPipeline.mjs";
 
 const serverModuleDir = path.dirname(fileURLToPath(import.meta.url));
 const viewerAppRoot = path.basename(path.dirname(serverModuleDir)) === "src"
@@ -180,17 +184,12 @@ const middlewares = [
   serveDistAsset({ distRoot }),
 ];
 
-function runMiddleware(index, req, res) {
-  const middleware = middlewares[index];
-  if (!middleware) {
-    res.statusCode = 404;
-    res.end("Not found");
-    return;
-  }
-  middleware(req, res, () => runMiddleware(index + 1, req, res));
-}
+const requestPipeline = createRequestPipeline({ middlewares });
+installProcessErrorGuards({
+  describeContext: () => requestPipeline.describeInFlightRequests(),
+});
 
-const server = http.createServer((req, res) => runMiddleware(0, req, res));
+const server = http.createServer(requestPipeline.handleRequest);
 
 try {
   port = await listenWithPortFallback({


### PR DESCRIPTION
## Problem

The CAD Viewer backend had no top-level protection against exceptions thrown from HTTP request handlers. `runMiddleware` invoked each middleware with no `try`/`catch`, and `http.createServer((req, res) => runMiddleware(0, req, res))` meant any synchronous throw escaped to the request listener and terminated the process — taking down any agent session that launched the Viewer.

This is a recurring class, not a one-off:

- #125: a malformed `dir=` query value killed the server process.
- #191 / #192: `GET /__cad/foo%zz.step` killed the server via an unguarded `decodeURIComponent` in `legacyCadAssetFileRef`.

Both were fixed at the individual call site. The amplifier was untouched, and there were no `unhandledRejection` / `uncaughtException` handlers anywhere in the backend.

## Change

The middleware chain moves out of `server.mjs` into a new `viewer/src/server/requestPipeline.mjs` so it is testable in isolation, and every `middleware(req, res, next)` call is contained:

- **Synchronous throws** are caught per-hop. `next()` recurses inside the parent's `try`, but each level has its own catch, so a downstream throw is handled at its own frame and never propagates outward.
- **Async rejections** are handled via `Promise.resolve(result).catch(fail)` when a middleware returns a thenable. Several middlewares are `async` and their promises were previously dropped entirely.
- **Responses**: 500 `Internal Server Error` when `!res.headersSent`; `res.destroy()` when headers are already on the wire; a nested `try`/`catch` in case sending the 500 itself fails. A latch means only the first failure per request responds.
- **404 fallthrough** behavior is unchanged.

`installProcessErrorGuards` adds last-resort `unhandledRejection` and `uncaughtException` handlers that log and keep the process alive.

`uncaughtException` was a deliberate call rather than an oversight: async throws from fs/stream callbacks escape the per-middleware `try` entirely, which is exactly the amplifier class in scope here. To offset the bug-masking risk, the pipeline tracks in-flight requests and both guards include them in the log line:

```
CAD Viewer backend uncaught exception: Error: ... [in-flight: GET /__cad/foo%zz.step]
```

## Verification

- 8 new tests in `viewer/src/server/requestPipeline.test.mjs`, all against a real `http.createServer`: sync throw → 500 and a follow-up request still returns 200; async rejection → 500 and still 200; failure after headers sent → response destroyed, server survives; 404 fallthrough; single-report latch; in-flight tracking; both process guards log without exiting.
- `npm --prefix viewer run test` → 409/409 pass.
- `scripts/test/test-js.sh` → cadjs 407, implicitjs 56, viewer 409, all pass (Node 22).
- **Live end-to-end**: on the pre-#192 tree, `GET /__cad/foo%zz.step` against the real server returned **500** with the `URIError: URI malformed` stack logged and the server stayed responsive — where that same request previously exited the process. After rebasing onto current `develop`, the request returns 400 from #192's call-site guard, so the two layers compose as intended.
- The pre-commit hook ran the full bundle check, including the esbuild bundle of the backend with the new module.

Nothing to regenerate: `bundle-cad-viewer.sh` esbuilds `src/server/server.mjs`, so the new sibling module is picked up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)