### PR TITLE
models: fix two path references the reorg missed

### DIFF
--- a/docs/src/components/hero-step-render.tsx
+++ b/docs/src/components/hero-step-render.tsx
@@ -21,7 +21,7 @@ import { cloneThemeSettings } from "cadjs/common/themeSettings.js";
 
 const HERO_STEP_URL = "/hero/planetary_gear_assembly.step.glb";
 const HERO_STEP_PARAMETER_URL = "/hero/planetary_gear_assembly.step.js";
-const HERO_STEP_CAD_PATH = "models/fun/planetary_gear_assembly.step";
+const HERO_STEP_CAD_PATH = "models/step/assemblies/planetary_gear_assembly.step";
 const HERO_STEP_DEMO_URL =
   "https://cad.fun/?file=fun%2Fplanetary_gear_assembly.step";
 const HERO_STEP_LABEL = "PLANETARY_GEAR_ASSEMBLY.STEP";

--- a/packages/cadjs/bench/composePackageBench.mjs
+++ b/packages/cadjs/bench/composePackageBench.mjs
@@ -35,7 +35,7 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "../../..");
 const DEFAULT_PACKAGE = path.join(
   REPO_ROOT,
-  "models/one-shots/falcon_heavy/__cadgen__/models/falcon_heavy.step.py",
+  "models/renders/falcon_heavy/__cadgen__/models/falcon_heavy.step.py",
 );
 
 function sumPartBytes(meshData) {


### PR DESCRIPTION
Follow-up to #199. Two references still point at directories the reorg removed.

**Why they were missed:** the sweep that caught every other call site filtered on `.md`/`.py`/`.js`/`.json`/`.sh`, so it never looked at `.mjs`, `.ts`, or `.tsx`. A no-filter sweep over every tracked file outside `models/` now reports these two and nothing else.

| File | Impact |
|---|---|
| `packages/cadjs/bench/composePackageBench.mjs:38` | **Real break.** `DEFAULT_PACKAGE` resolved `models/one-shots/falcon_heavy/…`, so running the bench with no argument failed outright. |
| `docs/src/components/hero-step-render.tsx:24` | **Cosmetic.** `HERO_STEP_CAD_PATH` is the identity/label passed to `loadSource`, not a fetched URL — the hero's real assets are the static `/hero/*.glb` and `/hero/*.step.js`, both present — but the label named `models/fun/`. |

`HERO_STEP_DEMO_URL` on the following line still reads `cad.fun/?file=fun%2Fplanetary_gear_assembly.step` and is **deliberately left alone**: that is the external site's own file namespace, which this repo's layout does not control. Changing it would more likely break the link than fix it.

Verified: no-filter sweep clean, cadjs tests pass (498/498), pre-commit build check passes. Docs deps aren't installed in this worktree so `next build` could not run; the change is a single string literal on an otherwise untouched line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)