### PR TITLE
viewer: reframe the camera when the viewport changes

### DIFF
--- a/viewer/src/client/components/CadViewer.js
+++ b/viewer/src/client/components/CadViewer.js
@@ -188,6 +188,7 @@ import {
   VIEW_PLANE_POLE_DIRECTION_NUDGE,
   VIEW_PLANE_TRANSITION_MS,
   viewPlaneOrientationEqual,
+  viewportFitScale,
   WORLD_UP
 } from "./viewer/viewportCameraKit";
 import { normalizeViewerRenderState } from "./viewer/renderState";
@@ -443,6 +444,9 @@ function runtimeZoomBaselineScale(runtime) {
 
 function resetRuntimeZoomBaseline(runtime) {
   const scale = runtimeZoomBaselineScale(runtime);
+  // The baseline is only ever reset right after the camera has been fitted, so
+  // this is also the moment the framing matches the live viewport.
+  captureRuntimeViewportFitScale(runtime);
   if (runtime?.camera?.isOrthographicCamera) {
     const halfHeight = readOrthographicHalfHeight(runtime);
     if (halfHeight) {
@@ -811,6 +815,122 @@ function frameRuntimeCameraForBoundingSphere(runtime, radius, sceneScaleMode, fr
   return fitDistance;
 }
 
+function runtimeViewportFitScale(runtime, frameMetrics) {
+  const camera = runtime?.camera;
+  const fitCamera = camera?.isPerspectiveCamera ? camera : runtime?.perspectiveCamera || camera;
+  return viewportFitScale({
+    orthographic: camera?.isOrthographicCamera === true,
+    fov: Number(fitCamera?.fov) || 48,
+    aspect: frameMetrics?.aspect,
+    height: frameMetrics?.height,
+    framedHeight: frameMetrics?.framedHeight
+  });
+}
+
+// Record the viewport the camera is currently framed for. Anything that fits the
+// camera afresh is by definition fitted to the viewport it ran in, so this is the
+// reference the next viewport change measures against.
+function captureRuntimeViewportFitScale(runtime, frameMetrics = null) {
+  if (!runtime?.camera) {
+    return;
+  }
+  const metrics = frameMetrics || getViewportFrameMetrics(runtime, runtime.frameInsetsRef?.current);
+  runtime.viewportFitScale = runtimeViewportFitScale(runtime, metrics);
+}
+
+// Only the active projection's baseline moves. An orthographic reframe changes
+// the half-height and leaves the camera position -- and with it the perspective
+// baseline -- untouched, and a perspective reframe is the mirror of that.
+function scaleRuntimeZoomBaseline(runtime, ratio) {
+  if (!runtime || !Number.isFinite(ratio) || ratio <= 0) {
+    return;
+  }
+  const baselineKey = runtime.camera?.isOrthographicCamera ? "zoomBaseHalfHeight" : "zoomBaseDistance";
+  const baseline = Number(runtime[baselineKey]);
+  if (Number.isFinite(baseline) && baseline > 1e-6) {
+    runtime[baselineKey] = baseline * ratio;
+  }
+}
+
+// A viewport change -- the window resizing, a side sheet opening, closing or
+// being dragged wider -- leaves the camera framed for the viewport it no longer
+// has. The vertical field of view is fixed and the orthographic half-height is
+// held constant across an aspect change, so a narrowing viewport crops a wide
+// model instead of shrinking it. Rescale the camera by the change in fit scale so
+// the model keeps its share of the framed area.
+//
+// The zoom baseline rides along by the same ratio. Without that, the percent
+// readout keeps describing the old viewport: it still says 100% while the framing
+// no longer fits, and the next reset re-fits for real and visibly moves the camera
+// with the readout unchanged at 100%.
+function syncRuntimeViewportFraming(runtime, frameMetrics = null) {
+  if (!runtime?.camera) {
+    return false;
+  }
+  const metrics = frameMetrics || getViewportFrameMetrics(runtime, runtime.frameInsetsRef?.current);
+  const previousFitScale = Number(runtime.viewportFitScale);
+  const nextFitScale = runtimeViewportFitScale(runtime, metrics);
+  // Claim the new viewport up front, including on the paths that bail below: the
+  // first call has no reference yet, and the rest only bail when the camera is in
+  // no state to be reframed. Carrying a stale reference forward would just save
+  // the move up for whichever later resize does find a usable camera.
+  runtime.viewportFitScale = nextFitScale;
+  if (
+    !Number.isFinite(previousFitScale) || previousFitScale <= 1e-6 ||
+    !Number.isFinite(nextFitScale) || nextFitScale <= 1e-6
+  ) {
+    return false;
+  }
+  const requestedRatio = nextFitScale / previousFitScale;
+  if (Math.abs(requestedRatio - 1) < 1e-6) {
+    return false;
+  }
+  const camera = runtime.camera;
+  let appliedRatio = requestedRatio;
+  if (camera.isOrthographicCamera) {
+    const halfHeight = readOrthographicHalfHeight(runtime);
+    if (!halfHeight) {
+      return false;
+    }
+    const nextHalfHeight = Math.max(halfHeight * requestedRatio, 1e-3);
+    appliedRatio = nextHalfHeight / halfHeight;
+    setOrthographicCameraHalfHeight(runtime, nextHalfHeight, metrics);
+  } else {
+    const target = runtime.controls?.target;
+    const distance = readCameraTargetDistance(runtime);
+    if (!target || !distance) {
+      return false;
+    }
+    const minDistance = Number.isFinite(Number(runtime.controls?.minDistance))
+      ? Number(runtime.controls.minDistance)
+      : 0.01;
+    const maxDistance = Number.isFinite(Number(runtime.controls?.maxDistance)) && Number(runtime.controls.maxDistance) > 0
+      ? Number(runtime.controls.maxDistance)
+      : Number.POSITIVE_INFINITY;
+    const nextDistance = clamp(distance * requestedRatio, minDistance, maxDistance);
+    appliedRatio = nextDistance / distance;
+    if (Math.abs(appliedRatio - 1) < 1e-6) {
+      return false;
+    }
+    // Scaling the target->camera offset moves the camera along the view ray, so
+    // the orientation and the pivot are untouched -- only the distance changes.
+    camera.position.copy(target.clone().add(camera.position.clone().sub(target).multiplyScalar(appliedRatio)));
+    camera.lookAt(target);
+  }
+  scaleRuntimeZoomBaseline(runtime, appliedRatio);
+  reapplyRuntimeCameraFrameInsets(runtime);
+  // Bare controls.update() ticks OrbitControls' auto-rotate branch, so a resize
+  // during a preview orbit would nudge the camera an extra step.
+  if (runtime.controls) {
+    const autoRotateBeforeResize = runtime.controls.autoRotate;
+    runtime.controls.autoRotate = false;
+    runtime.controls.update?.();
+    runtime.controls.autoRotate = autoRotateBeforeResize;
+  }
+  runtime.requestRender?.();
+  return true;
+}
+
 function syncRuntimeCameraProjection(runtime, projection, { scheduleIdle = true, requestRender = true } = {}) {
   if (!runtime?.camera || !runtime?.controls) {
     return false;
@@ -855,6 +975,10 @@ function syncRuntimeCameraProjection(runtime, projection, { scheduleIdle = true,
     runtime.syncCameraViewport?.(nextCamera, frameMetrics.width, frameMetrics.height);
   }
   applyCameraFrameInsets(runtime, runtime.frameInsetsRef?.current, { updateProjection: false });
+  // The switch preserves the framing rather than re-fitting, but perspective and
+  // orthographic measure the viewport differently, so the reference a later
+  // resize compares against has to be re-read in the new projection's terms.
+  captureRuntimeViewportFitScale(runtime, frameMetrics);
   // Recompute camera matrices without advancing auto-rotate. A bare controls.update()
   // ticks OrbitControls' frame-rate-dependent auto-rotation branch, so any projection
   // sync that fires during a preview orbit would nudge the camera forward an extra step.
@@ -2025,6 +2149,13 @@ const CadViewer = forwardRef(function CadViewer({
     if (!runtime) {
       return;
     }
+    // Sheets and the sidebar do not resize the canvas -- they inset the framed
+    // area over it -- so a sheet opening never reaches the resize path. It still
+    // shrinks the space the model has to live in, and needs the same reframing.
+    if (syncRuntimeViewportFraming(runtime)) {
+      syncCameraZoomPercent(runtime);
+      emitPerspectiveChange(runtime);
+    }
     applyCameraFrameInsets(runtime, normalizedViewportFrameInsets);
     runtime.requestRender?.();
   }, [
@@ -2169,6 +2300,14 @@ const CadViewer = forwardRef(function CadViewer({
     }
     return runWithoutPerspectiveEvents(() => applyPerspectiveSnapshot(runtime, nextPerspective, { scheduleIdle: false }));
   }, [perspectiveRef]);
+  const handleViewportResize = useCallback(() => {
+    const runtime = runtimeRef.current;
+    if (!syncRuntimeViewportFraming(runtime)) {
+      return;
+    }
+    syncCameraZoomPercent(runtime);
+    emitPerspectiveChange(runtime);
+  }, [syncCameraZoomPercent]);
   const applyZoomPercent = useCallback((nextZoomPercent) => {
     const runtime = runtimeRef.current;
     if (!setRuntimeZoomPercent(runtime, nextZoomPercent)) {
@@ -3445,6 +3584,7 @@ const CadViewer = forwardRef(function CadViewer({
     applySceneBackground: applyActiveSceneBackground,
     applyCameraFrameInsets,
     frameInsetsRef: viewportFrameInsetsRef,
+    onViewportResize: handleViewportResize,
     applyInitialPerspective,
     updateGridHelper: updateActiveGridHelper,
     clearSceneGroup,

--- a/viewer/src/client/components/viewer/viewportCameraKit.js
+++ b/viewer/src/client/components/viewer/viewportCameraKit.js
@@ -89,6 +89,37 @@ export function normalizeViewportFrameInsets(value = {}) {
   };
 }
 
+// How far back the camera has to sit (perspective) or how tall the orthographic
+// frustum has to be, per unit of model radius, for the model to be framed by the
+// given viewport. The absolute value is only meaningful against a radius; what
+// callers use is the RATIO between two viewports. Rescaling the camera by that
+// ratio keeps the model the same fraction of the framed area when the window
+// resizes or a side sheet opens or closes, which is what stops a wide model from
+// being cropped by a narrowing viewport.
+//
+// The formulas mirror getFitDistanceForBoundingSphere and
+// getOrthographicHalfHeightForBoundingSphere in CadViewer, so a viewport change
+// leaves the camera exactly where a fresh fit would have put it -- that is what
+// keeps "100%" honest across a resize.
+export function viewportFitScale({
+  orthographic = false,
+  fov = 48,
+  aspect = 1,
+  height = 1,
+  framedHeight = 1
+} = {}) {
+  const safeAspect = Math.max(finiteNumber(aspect, 1), 1e-3);
+  if (orthographic) {
+    const safeHeight = Math.max(finiteNumber(height, 1), 1);
+    const safeFramedHeight = Math.max(finiteNumber(framedHeight, safeHeight), 1);
+    return (1 / Math.min(safeAspect, 1)) * (safeHeight / safeFramedHeight);
+  }
+  const verticalHalfFov = (Math.max(finiteNumber(fov, 48), 1e-3) * Math.PI) / 360;
+  const horizontalHalfFov = Math.atan(Math.tan(verticalHalfFov) * safeAspect);
+  const limitingHalfFov = Math.max(Math.min(verticalHalfFov, horizontalHalfFov), 1e-3);
+  return 1 / Math.sin(limitingHalfFov);
+}
+
 export function getKeyboardOrbitCommand(event) {
   if (!event) {
     return null;

--- a/viewer/src/client/components/viewer/viewportCameraKit.test.js
+++ b/viewer/src/client/components/viewer/viewportCameraKit.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { viewportFitScale } from "./viewportCameraKit.js";
+
+// The framed area of a viewport with a top bar and no side sheets, then the same
+// window with a sheet open. Only the ratio between two scales is used, so these
+// read as "how much further back the camera has to sit than it did before".
+const wide = { aspect: 1120 / 756, height: 800, framedHeight: 756 };
+const narrow = { aspect: 355 / 756, height: 800, framedHeight: 756 };
+
+test("perspective fit scale is fixed while the framed area stays wider than tall", () => {
+  // The vertical field of view is what frames the model, so extra width changes
+  // nothing -- and a resize that only adds width must not move the camera.
+  const square = viewportFitScale({ fov: 48, aspect: 1 });
+  assert.ok(Math.abs(viewportFitScale({ fov: 48, aspect: 2.4 }) - square) < 1e-9);
+  assert.ok(Math.abs(viewportFitScale({ fov: 48, aspect: 1.4 }) - square) < 1e-9);
+  assert.ok(Math.abs(square - 1 / Math.sin((48 * Math.PI) / 360)) < 1e-9);
+});
+
+test("perspective fit scale grows once the framed area is taller than wide", () => {
+  const half = viewportFitScale({ fov: 48, aspect: 0.5 });
+  assert.ok(half > viewportFitScale({ fov: 48, aspect: 1 }));
+  // Width is the limiting dimension now, so halving it pulls the camera back
+  // by close to 2x -- exactly 2x only in the small-angle limit.
+  assert.ok(half / viewportFitScale({ fov: 48, aspect: 1 }) > 1.8);
+});
+
+test("orthographic fit scale tracks the smaller framed dimension", () => {
+  // R * height / min(framedWidth, framedHeight), expressed per unit radius.
+  assert.ok(Math.abs(viewportFitScale({ orthographic: true, ...wide }) - 800 / 756) < 1e-9);
+  assert.ok(Math.abs(viewportFitScale({ orthographic: true, ...narrow }) - 800 / 355) < 1e-9);
+});
+
+test("closing a sheet undoes the scale change that opening it made", () => {
+  // Reframing is applied as a ratio, so a viewport that comes back to where it
+  // started has to leave the camera where it started.
+  const opened = viewportFitScale({ orthographic: true, ...narrow }) / viewportFitScale({ orthographic: true, ...wide });
+  const closed = viewportFitScale({ orthographic: true, ...wide }) / viewportFitScale({ orthographic: true, ...narrow });
+  assert.ok(opened > 2);
+  assert.ok(Math.abs(opened * closed - 1) < 1e-12);
+});
+
+test("degenerate viewports fall back instead of producing a non-finite scale", () => {
+  for (const metrics of [
+    {},
+    { aspect: 0 },
+    { aspect: Number.NaN },
+    { orthographic: true, aspect: 0, height: 0, framedHeight: 0 },
+    { orthographic: true, aspect: Number.NaN, height: Number.NaN, framedHeight: Number.NaN },
+    { fov: 0, aspect: 1 },
+    { fov: Number.NaN, aspect: 1 }
+  ]) {
+    const scale = viewportFitScale(metrics);
+    assert.ok(Number.isFinite(scale) && scale > 0, `bad scale for ${JSON.stringify(metrics)}`);
+  }
+});


### PR DESCRIPTION
Narrowing the viewport cropped the model instead of shrinking it, and left the zoom percent describing a viewport that no longer existed.

## What was wrong

Two triggers, one missing behaviour:

- **Sheets never reached the resize path.** The canvas is always full-window; the sidebar and the sheets are *frame insets* painted over it. Opening, closing or dragging a sheet only re-centred the model through `applyCameraFrameInsets`, inside a framed area that had just got narrower.
- **The resize path only updated the camera aspect.** A perspective camera's vertical FOV is fixed and the orthographic half-height was held constant across an aspect change, so both projections kept the model at its old world size while the space it had to live in shrank. `useViewerRuntime` already called `runtime.onViewportResize` on resize — `CadViewer` never supplied one.

The zoom baseline (`zoomBaseDistance` / `zoomBaseHalfHeight`) is captured at fit time and was never revisited, which is the second half of the report: "100%" kept claiming a fit the viewport no longer had, and the next reset re-fitted for real and visibly moved the camera with the readout still reading 100%.

## The fix

`syncRuntimeViewportFraming` rescales the active camera by the change in fit scale and carries that projection's zoom baseline by the same ratio, so the model keeps its share of the framed area and the percent stays honest — at 100%, a reset after a resize is now a no-op. It is wired to both triggers, and the reference viewport is (re)captured wherever the camera is fitted (`resetRuntimeZoomBaseline`) or the projection switches, since perspective and orthographic measure a viewport differently.

`viewportFitScale` is a pure helper mirroring the two existing fit formulas, `getFitDistanceForBoundingSphere` and `getOrthographicHalfHeightForBoundingSphere`. Only the *ratio* between two viewports is used, so a reframe lands exactly where a fresh fit would have — including the pre-existing quirk that the perspective formula ignores the top-bar inset the orthographic one accounts for. Left alone here: changing it would move every fit and every stored perspective.

## Verification

Exercised in the browser in both projections:

- 1400px → 620px wide takes the model from 84% of the width (nearly clipping) to 68%.
- Reset at 100% after a resize no longer moves the camera.
- A 130% zoom survives a resize as 130%, with the model rescaled around it.
- Opening both sheets at 1000px shrinks the model to 71% of the framed strip; closing them returns it pixel-identical.

`viewer` (298), `cadjs` (498) and `implicitjs` (364) tests pass, `viewer run build` passes, `scripts/bundle/bundle.sh --check` is clean. Five new tests cover `viewportFitScale`, including the round-trip and degenerate-viewport cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
