### PR TITLE
cad: STEP generation reliability — contended builds, and CLI output

### DIFF
--- a/packages/cadgen/src/cadgen/_internal/cli_errors.py
+++ b/packages/cadgen/src/cadgen/_internal/cli_errors.py
@@ -1,0 +1,107 @@
+"""Compact failure reporting for the CAD CLIs.
+
+A generator that raises used to reach the interpreter uncaught, so an ordinary authoring
+mistake printed a 62-line, 4.2 KB traceback whose one useful line -- the exception -- was
+last, under ~50 frames of ``runpy``, the launcher, and cadgen internals. A `gen_step()`
+missing its return printed 43 lines to say ``must return one value``.
+
+What a caller actually needs is the failure and WHERE IN THEIR MODEL it happened. Those
+frames are already identifiable: :func:`is_first_party_source_file` is the same predicate
+the source-closure capture uses to tell model code from the stdlib, site-packages, and the
+running runtime. So the report keeps the model's own frames and drops everything else.
+
+``--verbose`` still prints the full traceback -- when the fault IS in cadgen, the internal
+frames are the point.
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from pathlib import Path
+from typing import TextIO
+
+# Deep recursion in a generator (a parametric model calling itself) can produce hundreds of
+# identical model frames. The innermost few are where the failure is.
+_MAX_FRAMES = 6
+
+
+def _display(filename: str) -> str:
+    """Cwd-relative where that is meaningful, otherwise the tail.
+
+    A runtime frame's absolute path runs through the symlinked skill bundle and is longer
+    than the line it is annotating; the last few components identify the module just as
+    well without burying the message above it.
+    """
+    try:
+        resolved = Path(filename).resolve()
+    except (OSError, ValueError):
+        return filename
+    try:
+        return resolved.relative_to(Path.cwd().resolve()).as_posix()
+    except ValueError:
+        parts = resolved.parts
+        return ("…/" + "/".join(parts[-3:])) if len(parts) > 3 else resolved.as_posix()
+
+
+def _model_frames(exc: BaseException) -> list[traceback.FrameSummary]:
+    """The frames in the caller's own CAD sources, outermost first.
+
+    Everything else -- the launcher, cadgen, build123d/OCP, the stdlib -- is runtime: it is
+    the same in every failure and says nothing about which model broke.
+    """
+    from cadgen._internal.source_hash import is_first_party_source_file
+
+    frames: list[traceback.FrameSummary] = []
+    for frame in traceback.extract_tb(exc.__traceback__):
+        try:
+            path = Path(frame.filename).resolve()
+        except (OSError, ValueError):
+            continue
+        if is_first_party_source_file(path):
+            frames.append(frame)
+    return frames
+
+
+def report_cli_error(
+    exc: BaseException,
+    *,
+    tool: str,
+    verbose: bool = False,
+    stream: TextIO | None = None,
+) -> int:
+    """Print ``exc`` as a CLI failure and return the exit code (always 1).
+
+    Under ``verbose`` this is the raw traceback, unchanged -- a cadgen bug needs its own
+    frames. Otherwise it is the exception plus the model frames that led to it.
+    """
+    out = stream if stream is not None else sys.stderr
+    if verbose:
+        traceback.print_exception(type(exc), exc, exc.__traceback__, file=out)
+        return 1
+
+    def line(text: str) -> None:
+        print(f"[{tool}] {text}", file=out)
+
+    detail = str(exc).strip()
+    line(f"FAILED: {type(exc).__name__}: {detail}" if detail else f"FAILED: {type(exc).__name__}")
+
+    frames = _model_frames(exc)
+    if frames:
+        if len(frames) > _MAX_FRAMES:
+            line(f"  ... {len(frames) - _MAX_FRAMES} earlier frame(s) omitted")
+        for frame in frames[-_MAX_FRAMES:]:
+            line(f"  {_display(frame.filename)}:{frame.lineno} in {frame.name}")
+            if frame.line:
+                line(f"      {frame.line.strip()}")
+    else:
+        # Nothing of the caller's ran -- a validation or resolution error raised before the
+        # generator was reached. Name the frame that raised so it is still diagnosable; the
+        # message itself usually already names the offending file.
+        raised = traceback.extract_tb(exc.__traceback__)
+        if raised:
+            innermost = raised[-1]
+            line(f"  raised in {_display(innermost.filename)}:{innermost.lineno}")
+
+    line("re-run with --verbose for the full traceback")
+    return 1

--- a/packages/cadgen/src/cadgen/_internal/cli_locking.py
+++ b/packages/cadgen/src/cadgen/_internal/cli_locking.py
@@ -1,0 +1,99 @@
+"""The CLI half of artifact coordination: how a command-line producer waits, reports the
+wait, and answers when it decides not to wait at all.
+
+One implementation for every artifact CLI (``step_artifact``, ``dxf_artifact``,
+``implicit_artifact``, and the ``gen``/``export`` paths in ``_internal.generation``),
+because the three things below have to agree across all of them:
+
+* the flag name and its default, since the CAD Viewer passes ``--lock-timeout`` to whichever
+  module a given entry maps to and a module that did not accept it would fail argument
+  parsing rather than build;
+* the wait notice, which is the only thing distinguishing a contended acquire from a hang --
+  cadgen's acquire is blocking by default, so without it a queued build emits nothing on
+  either stream for as long as the peer holds the lock;
+* the shape of the "a peer has it" payload, which the viewer branches on.
+
+Not in :mod:`cadgen.coordination`: that package is the cross-process protocol shared with
+the viewer's long-lived server, and it has no business knowing about argparse or loggers.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Callable
+
+from cadgen.cli_logging import CliLogger, format_elapsed
+
+# Waiting is the CLI default on purpose: an agent that asked for a build wants the build,
+# and giving up would leave it with no artifact and nothing to do about it. The viewer is
+# the caller that must not block, and it passes an explicit timeout.
+WAIT_FOREVER = 0.0
+
+_LOCK_TIMEOUT_HELP = (
+    "Give up after SECONDS if another run holds this model's generation lock, reporting "
+    '{"ok":true,"contended":true} instead of building. 0 (the default) waits for the peer; '
+    "either way the wait itself is reported on stderr."
+)
+
+
+def add_lock_timeout_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--lock-timeout",
+        type=float,
+        default=WAIT_FOREVER,
+        metavar="SECONDS",
+        help=_LOCK_TIMEOUT_HELP,
+    )
+
+
+def deadline_ms(lock_timeout_s: float | None) -> float | None:
+    """``deadline_ms`` for :func:`cadgen.coordination.artifact_build`. None means block."""
+    timeout = float(lock_timeout_s or 0.0)
+    return timeout * 1000.0 if timeout > 0 else None
+
+
+def lock_wait_notice(logger: CliLogger | None, ref: str) -> Callable[[float], None] | None:
+    """A callback that says WHY the process is sitting still, while it still is.
+
+    Repeats on the interval :mod:`cadgen.coordination.lock` applies, so a long wait keeps
+    proving it is alive instead of looking wedged."""
+    if logger is None:
+        return None
+
+    def notice(elapsed_s: float) -> None:
+        logger.info(
+            f"waiting for another run to finish building {ref} "
+            f"({format_elapsed(elapsed_s)} so far)"
+        )
+
+    return notice
+
+
+def contended_payload(
+    *,
+    source_ref: str,
+    cad_ref: str = "",
+    package_dir: Path | str | None = None,
+    **extra: object,
+) -> dict[str, object]:
+    """The answer when a peer holds the lock and this run declined to wait for it.
+
+    ``ok`` is true because nothing went wrong -- the model is being built, just not here --
+    and ``contended`` is what a caller branches on. Deliberately claims no artifact: the
+    peer decides what the package ends up containing.
+    """
+    payload: dict[str, object] = {
+        "ok": True,
+        "contended": True,
+        "skipped": True,
+        "sourceRef": source_ref,
+    }
+    if cad_ref:
+        payload["cadPath"] = cad_ref
+    if package_dir is not None:
+        from cadgen.render import relative_to_cwd
+
+        payload["packagePath"] = relative_to_cwd(Path(package_dir))
+    payload.update({key: value for key, value in extra.items() if value is not None})
+    return payload

--- a/packages/cadgen/src/cadgen/_internal/generation.py
+++ b/packages/cadgen/src/cadgen/_internal/generation.py
@@ -29,6 +29,7 @@ from cadgen.catalog import (
     source_from_path,
 )
 from cadgen.cli_logging import CliLogger
+from cadgen._internal.cli_locking import lock_wait_notice
 from cadgen._internal.file_metadata import text_to_cad_identity_metadata, write_dxf_text_to_cad_metadata
 from cadgen._internal.package_freshness import (
     ASSEMBLY_PACKAGE_SCHEMA_VERSION,
@@ -980,7 +981,7 @@ def run_script_generator(
     # count, so this reports a phase, not a fraction. Readers estimate it against the
     # duration the model's previous build recorded.
     resolve_progress(progress).phase(PHASE_GENERATE)
-    with _track_spec_generation(spec, generator_name, intent=lock_intent):
+    with _track_spec_generation(spec, generator_name, intent=lock_intent, logger=logger):
         return _run_script_generator_inner(
             spec,
             generator_name,
@@ -1809,6 +1810,7 @@ def _track_spec_generation(
     generator_name: str,
     *,
     intent: str = "write",
+    logger: CliLogger | None = None,
 ) -> contextlib.AbstractContextManager[object]:
     """Coordinate a generator run against the model's render package.
 
@@ -1818,15 +1820,21 @@ def _track_spec_generation(
     writes the package nothing -- an export, an on-demand topology extraction, an
     interference check -- takes the generator lock instead. Taking the writer lock for
     those made a fully-current model report `generating` with an empty bar for the whole
-    length of an export; taking nothing at all would let a real build run the same
-    generator concurrently.
+    length of an export.
+
+    The two sentinels are different files, so they do NOT exclude each other: a build and
+    an export of one model each run its ``gen_step()``, concurrently, in separate
+    processes. That is duplicated work rather than a hazard (no shared in-process state,
+    different outputs), and it is the price of letting a reader tell "being rewritten"
+    from "generator busy" -- see :func:`cadgen.coordination.generator_busy`.
     """
     output_dir = _spec_output_dir(spec, generator_name)
     if output_dir is None:
         return contextlib.nullcontext()
+    on_wait = lock_wait_notice(logger, spec.source_ref)
     if intent == "generate":
-        return generator_busy(STEP_PACKAGE, output_dir)
-    return exclusive(write_lock_path(output_dir))
+        return generator_busy(STEP_PACKAGE, output_dir, on_wait=on_wait)
+    return exclusive(write_lock_path(output_dir), on_wait=on_wait)
 
 
 def _run_with_spec_generation_status(
@@ -1836,6 +1844,7 @@ def _run_with_spec_generation_status(
     *,
     skip_if_current: Callable[[EntrySpec], bool] | None = None,
     progress_sink: object | None = None,
+    logger: CliLogger | None = None,
 ) -> object:
     """Run ``action`` while holding the model's build lock, reporting its progress.
 
@@ -1851,11 +1860,15 @@ def _run_with_spec_generation_status(
     ``action`` is called as ``action(spec, run)``; ``run`` is the progress reporter.
     """
     kind = DRAWING_PACKAGE if generator_name == "gen_dxf" else STEP_PACKAGE
+    # No output dir means no lock, so there is nothing to wait on and no ref to name in a
+    # notice -- and a spec that never reaches a lock is not required to have one.
+    output_dir = _spec_output_dir(spec, generator_name)
     with artifact_build(
         kind,
-        _spec_output_dir(spec, generator_name),
+        output_dir,
         is_current=(lambda: bool(skip_if_current(spec))) if skip_if_current is not None else None,
         sink=progress_sink,
+        on_wait=lock_wait_notice(logger, spec.source_ref) if output_dir is not None else None,
     ) as run:
         if run.skipped:
             return _SkippedGeneration(spec)
@@ -2250,6 +2263,7 @@ def generate_step_targets(
             build,
             skip_if_current=_built_by_a_peer,
             progress_sink=progress_sink,
+            logger=logger,
         )
 
     _run_selected_specs(
@@ -2347,6 +2361,7 @@ def generate_dxf_targets(
                     tracked_spec, "gen_dxf", logger=logger, progress=reporter
                 ),
                 skip_if_current=_built_by_a_peer,
+                logger=logger,
             ),
             logger=logger,
             success_message=_generated_dxf_summary,

--- a/packages/cadgen/src/cadgen/_internal/generation.py
+++ b/packages/cadgen/src/cadgen/_internal/generation.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import io
 import importlib.util
 import json
 import math
@@ -129,50 +128,6 @@ class _CliTargetSpec:
     output_path: Path | None = None
 
 
-class InlineStatusBoard:
-    def __init__(self, labels: Sequence[str], *, initial_status: str, stream: object | None = None) -> None:
-        self._stream = stream or sys.stdout
-        self._is_tty = getattr(self._stream, "isatty", lambda: False)()
-        self._labels = list(labels)
-        self._statuses = {label: initial_status for label in self._labels}
-        self._rendered_rows = 0
-        if self._labels and self._is_tty:
-            self._render()
-        else:
-            for label in self._labels:
-                print(self._row(label), file=self._stream)
-
-    def set(self, label: str, status: str) -> None:
-        previous = self._statuses.get(label)
-        if previous == status:
-            return
-        if label not in self._statuses:
-            self._labels.append(label)
-        self._statuses[label] = status
-        if self._is_tty:
-            self._render()
-        else:
-            print(self._row(label), file=self._stream)
-
-    def _row(self, label: str) -> str:
-        width = max(len(item) for item in self._labels)
-        return f"{label:<{width}} : {self._statuses.get(label, '')}"
-
-    def _render(self) -> None:
-        if not self._labels:
-            return
-        rows = [self._row(label) for label in self._labels]
-        if self._rendered_rows:
-            print(f"\x1b[{self._rendered_rows}F", end="", file=self._stream)
-        for row in rows:
-            print(f"\x1b[2K{row}", file=self._stream)
-        if self._rendered_rows > len(rows):
-            for _ in range(self._rendered_rows - len(rows)):
-                print("\x1b[2K", file=self._stream)
-        self._rendered_rows = len(rows)
-        self._stream.flush()
-
-
 class InlineProgressLine:
     """A single self-erasing progress line for one model's build.
 
@@ -181,8 +136,9 @@ class InlineProgressLine:
     a log record. Disabled (and completely silent) when the stream is not a tty: a
     redirected log wants the logger's lines, not a bar smeared over hundreds of writes.
 
-    Separate from :class:`InlineStatusBoard`, which paints a persistent row per model
-    for callers that run without a logger."""
+    Goes to STDERR, with the rest of the narration. A sibling class used to paint a
+    persistent per-model board on STDOUT with cursor-movement escapes, for callers that ran
+    without a logger; there were none, and stdout is the CLIs' result channel."""
 
     def __init__(self, *, stream: TextIO | None = None, enabled: bool = True) -> None:
         self._stream = stream if stream is not None else sys.stderr
@@ -1894,63 +1850,33 @@ def _progress_status_text(event: ProgressEvent, *, fallback: str) -> str:
 def _run_selected_specs(
     selected_specs: Sequence[EntrySpec],
     *,
-    initial_status: str = "Queued",
     action_status: str = "Generating...",
     done_status: str = "Generated",
     action: Callable[..., object],
-    quiet: bool = False,
-    status_stream: object | None = None,
-    action_stdout: object | None = None,
-    logger: CliLogger | None = None,
+    logger: CliLogger,
     success_message: Callable[[EntrySpec], str] | None = _generated_output_summary,
 ) -> list[object]:
-    results: list[object] = []
-    # Only the status-board branch renders progress. A quiet run has nowhere to put it,
-    # and a verbose run is already narrating each stage through the logger — a bar
-    # repainting between log lines would fight with them. Both still write the sidecar,
-    # so an open CAD Viewer sees the build either way.
-    if quiet:
-        for spec in selected_specs:
-            with contextlib.redirect_stdout(io.StringIO()):
-                results.append(action(spec, None))
-        return results
-    if logger is not None:
-        for spec in selected_specs:
-            logger.debug(f"{action_status} {spec.source_ref}")
-            with _cli_progress_line(spec, logger=logger, fallback=action_status) as progress_sink:
-                with logger.timed(f"{done_status.lower()} {spec.source_ref}"):
-                    if action_stdout is None:
-                        result = action(spec, progress_sink)
-                    else:
-                        with contextlib.redirect_stdout(action_stdout):
-                            result = action(spec, progress_sink)
-            results.append(result)
-            if isinstance(result, _SkippedGeneration):
-                logger.info(f"{spec.cad_ref} was built by a concurrent run; skipped")
-            elif success_message is not None:
-                message_spec = result.spec if isinstance(result, GeneratedStepResult) else spec
-                logger.info(success_message(message_spec))
-        return results
-    status_board = InlineStatusBoard(
-        [spec.source_ref for spec in selected_specs],
-        initial_status=initial_status,
-        stream=status_stream,
-    )
-    for spec in selected_specs:
-        status_board.set(spec.source_ref, action_status)
-        # Repaint this spec's row from its build's own progress events. The board
-        # already redraws in place on a tty and degrades to one line per change
-        # otherwise, so a bar costs it nothing new.
-        def progress_sink(event: ProgressEvent, ref: str = spec.source_ref) -> None:
-            status_board.set(ref, _progress_status_text(event, fallback=action_status))
+    """Run ``action`` for each spec, narrating to ``logger`` and painting one progress line.
 
-        if action_stdout is None:
-            result = action(spec, progress_sink)
-        else:
-            with contextlib.redirect_stdout(action_stdout):
+    A generator's own prints go straight through to stdout: the CLIs reserve stdout for the
+    result (``--json``) and put every log line on stderr, so there is nothing to protect it
+    from. Progress is a transient tty line that erases itself — see
+    :func:`_cli_progress_line`, which stays silent under ``--verbose`` where the logger is
+    already narrating every stage. The sidecar is written either way, so an open CAD Viewer
+    tracks the build regardless of what this prints.
+    """
+    results: list[object] = []
+    for spec in selected_specs:
+        logger.debug(f"{action_status} {spec.source_ref}")
+        with _cli_progress_line(spec, logger=logger, fallback=action_status) as progress_sink:
+            with logger.timed(f"{done_status.lower()} {spec.source_ref}"):
                 result = action(spec, progress_sink)
         results.append(result)
-        status_board.set(spec.source_ref, done_status)
+        if isinstance(result, _SkippedGeneration):
+            logger.info(f"{spec.cad_ref} was built by a concurrent run; skipped")
+        elif success_message is not None:
+            message_spec = result.spec if isinstance(result, GeneratedStepResult) else spec
+            logger.info(success_message(message_spec))
     return results
 
 

--- a/packages/cadgen/src/cadgen/_internal/generation.py
+++ b/packages/cadgen/src/cadgen/_internal/generation.py
@@ -4,6 +4,7 @@ import argparse
 import contextlib
 import io
 import importlib.util
+import json
 import math
 import os
 import shutil
@@ -2190,9 +2191,36 @@ def generate_step_targets(
     step_options: StepImportOptions | None = None,
     force: bool = False,
     verbose: bool = False,
+    json_output: bool = False,
 ) -> int:
+    """Build render packages for ``targets``. Returns the process exit code.
+
+    ``json_output`` additionally prints one JSON line per target to STDOUT. The exit code
+    alone cannot say WHICH targets were rebuilt and which were already current, and the
+    logger's prose goes to stderr by design -- so without this a caller reading the streams
+    apart had no machine-readable result at all.
+    """
     tool_name = "scripts/gen"
     logger = CliLogger("scripts/gen", verbose=verbose)
+    reported: list[dict[str, object]] = []
+
+    def _emit(spec: EntrySpec, outcome: str) -> None:
+        if not json_output:
+            return
+        reported.append(
+            {
+                "ok": True,
+                "sourceRef": spec.source_ref,
+                "cadPath": spec.cad_ref,
+                "kind": spec.kind,
+                "outcome": outcome,
+                "packagePath": _display_path(render_package_dir(spec.entry_path)),
+            }
+        )
+
+    def _flush() -> None:
+        for entry in reported:
+            print(json.dumps(entry, separators=(",", ":")))
     all_specs, selected_specs, target_output_paths = _selected_specs_for_targets(
         targets,
         step_options=step_options,
@@ -2229,10 +2257,12 @@ def generate_step_targets(
         if current_specs:
             for spec in current_specs:
                 logger.info(f"{spec.cad_ref} is current; skipped recompose")
+                _emit(spec, "current")
             current_refs = {spec.source_ref for spec in current_specs}
             selected_specs = [spec for spec in selected_specs if spec.source_ref not in current_refs]
             if not selected_specs:
                 logger.total()
+                _flush()
                 return 0
     entries_by_step_path = _entries_by_step_path([*all_specs, *selected_specs])
 
@@ -2266,13 +2296,16 @@ def generate_step_targets(
             logger=logger,
         )
 
-    _run_selected_specs(
+    results = _run_selected_specs(
         selected_specs,
         action=generate_step,
         logger=logger,
         success_message=_generated_python_glb_summary,
     )
+    for spec, result in zip(selected_specs, results):
+        _emit(spec, "skipped-peer" if isinstance(result, _SkippedGeneration) else "built")
     logger.total()
+    _flush()
     return 0
 
 

--- a/packages/cadgen/src/cadgen/coordination/__init__.py
+++ b/packages/cadgen/src/cadgen/coordination/__init__.py
@@ -62,6 +62,7 @@ from cadgen.coordination.lock import (
 )
 from cadgen.coordination.paths import (
     generator_lock_path,
+    generator_status_path,
     status_path,
     write_lock_path,
 )
@@ -104,6 +105,7 @@ __all__ = [
     "artifact_build",
     "generator_busy",
     "generator_lock_path",
+    "generator_status_path",
     "phase_weights_from_stage_ms",
     "render_progress_bar",
     "require_write_lock",
@@ -186,12 +188,17 @@ class BuildRun:
     holding one -- which is how a stale record used to be rendered as live.
     """
 
-    __slots__ = ("_reporter", "run_id", "skipped")
+    __slots__ = ("_reporter", "contended", "run_id", "skipped")
 
     def __init__(self, reporter: Any, run_id: str | None) -> None:
         self._reporter = reporter
         self.run_id = run_id
+        # Two ways to have no work to do, and a producer must handle both. ``skipped``: we
+        # HELD the lock and found the artifact already current. ``contended``: we never got
+        # the lock, because a peer holds it and the caller set a deadline. Neither is an
+        # error; both mean "do not write the package".
         self.skipped = False
+        self.contended = False
 
     def phase(self, name: str, *, total: int | None = None, detail: str = "") -> None:
         self._reporter.phase(name, total=total, detail=detail)
@@ -214,13 +221,15 @@ def artifact_build(
     is_current: Callable[[], bool] | None = None,
     force: bool = False,
     deadline_ms: float | None = None,
+    on_wait: Callable[[float], None] | None = None,
     sink: Callable[[ProgressEvent], None] | None = None,
 ) -> Iterator[BuildRun]:
     """Own the write lock, the status record, and the post-lock freshness re-check.
 
     Order of operations, and every part of it matters:
 
-    1. Acquire the write lock (blocking, or bounded and raising :class:`Contended`).
+    1. Acquire the write lock (blocking, or bounded by ``deadline_ms`` -- in which case a
+       peer holding it yields a run with ``contended`` set and nothing else happens).
     2. Mint a run id, stamp it into the sentinel, and publish a ``starting`` record --
        synchronously, BEFORE any work and before yielding. This is what closes the window
        in which a reader could attribute a previous run's record to this one.
@@ -234,6 +243,8 @@ def artifact_build(
 
     ``force=True`` skips only the ``is_current()`` call, never the lock.
     ``output_dir`` of None (a producer with no coordinated output) yields an inert run.
+    ``on_wait`` reports a contended acquire while it is still waiting -- see
+    :func:`cadgen.coordination.lock.exclusive`.
     """
     if output_dir is None:
         # Uncoordinated (a producer with no output dir of its own). There is no lock and no
@@ -250,7 +261,23 @@ def artifact_build(
     started_at_ms = time.time() * 1000.0
     target = status_path(output_dir)
 
-    with exclusive(write_lock_path(output_dir), deadline_ms=deadline_ms) as run_id:
+    # The acquire is entered separately from the body so a deadline that expires can be
+    # reported as an OUTCOME (run.contended) rather than thrown through the caller. A peer
+    # holding the lock is an ordinary answer to "should I build this?", the same shape as
+    # run.skipped -- and a caller that ignores it and writes anyway is caught at the
+    # mutation boundary by require_write_lock().
+    stack = contextlib.ExitStack()
+    try:
+        run_id = stack.enter_context(
+            exclusive(write_lock_path(output_dir), deadline_ms=deadline_ms, on_wait=on_wait)
+        )
+    except Contended:
+        contended_run = BuildRun(NULL_PROGRESS, None)
+        contended_run.contended = True
+        yield contended_run
+        return
+
+    with stack:
         if run_id is None:
             # Degraded (no fcntl, unwritable dir, or a filesystem without advisory locks).
             # Still report progress -- a bar with no mutual exclusion is better than no bar,
@@ -365,22 +392,38 @@ def generator_busy(
     output_dir: Path | str | None,
     *,
     deadline_ms: float | None = None,
+    on_wait: Callable[[float], None] | None = None,
 ) -> Iterator[str | None]:
     """Occupy an artifact's GENERATOR without claiming to rewrite its package.
 
     An export runs the model's ``gen_step()`` for a minute and writes a file somewhere else
     entirely. Taking the write lock for that made a fully-current model report `generating`
-    with an empty bar; taking nothing would let a real build run the same generator
-    concurrently. This is the third option, and it is why there are two sentinels.
+    with an empty bar; taking nothing would let a reader think the generator is free. This
+    is the third option, and it is why there are two sentinels.
+
+    Note what this does NOT do: the generator sentinel is a different file from the writer
+    sentinel, so ``flock`` cannot make the two exclude each other. A build and an export of
+    one model DO run its ``gen_step()`` concurrently, each in its own process. That is
+    wasteful but not unsafe -- they share no in-process state and write different outputs.
+    What it buys is a state a reader can distinguish: a busy generator does not hide the
+    package on disk, and a writer does.
+
+    Its record goes to :func:`generator_status_path`, NOT to the writer's record. Sharing
+    one file let this run stomp a live build's progress and erase the stage times the next
+    build weights its bar from -- and the two runs cannot exclude each other, so there was
+    no lock that would have prevented it.
     """
     if output_dir is None:
         yield None
         return
     started_at_ms = time.time() * 1000.0
-    with exclusive(generator_lock_path(output_dir), deadline_ms=deadline_ms) as run_id:
+    target = generator_status_path(output_dir)
+    with exclusive(
+        generator_lock_path(output_dir), deadline_ms=deadline_ms, on_wait=on_wait
+    ) as run_id:
         if run_id is not None:
             _record.write_record(
-                status_path(output_dir),
+                target,
                 _record.build_record(
                     run_id=run_id,
                     kind=kind.name,
@@ -394,7 +437,7 @@ def generator_busy(
         finally:
             if run_id is not None:
                 _record.write_record(
-                    status_path(output_dir),
+                    target,
                     _record.build_record(
                         run_id=run_id,
                         kind=kind.name,

--- a/packages/cadgen/src/cadgen/coordination/lock.py
+++ b/packages/cadgen/src/cadgen/coordination/lock.py
@@ -36,7 +36,7 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Iterator, NamedTuple
+from typing import Callable, Iterator, NamedTuple
 
 try:  # POSIX only; on a platform without fcntl every operation degrades to a no-op.
     import fcntl
@@ -47,6 +47,13 @@ except ImportError:  # pragma: no cover - not reachable on darwin/linux CI
 _HELD = threading.local()
 _RUN_ID_BYTES = 32
 _POLL_INTERVAL_S = 0.02
+
+# How long a wait has to last before it is worth announcing, and how often to repeat the
+# announcement afterwards. A wait is normally either instant or long: the grace keeps the
+# common instant acquire silent, and the repeat is what stops a long one from reading as a
+# hung process to whoever (or whatever) is watching the stream.
+_WAIT_NOTICE_GRACE_S = 0.25
+_WAIT_NOTICE_INTERVAL_S = 30.0
 
 
 class Contended(RuntimeError):
@@ -125,6 +132,7 @@ def exclusive(
     *,
     run_id: str | None = None,
     deadline_ms: float | None = None,
+    on_wait: Callable[[float], None] | None = None,
 ) -> Iterator[str | None]:
     """Hold ``lock_path`` exclusively for the body. Yields the run id actually recorded.
 
@@ -132,6 +140,11 @@ def exclusive(
     writing the same directory underneath its peer. With ``deadline_ms`` the wait is
     bounded and raises :class:`Contended` instead, which is what lets a request handler
     refuse to block.
+
+    ``on_wait(elapsed_seconds)`` is called once the wait passes a short grace period and
+    every :data:`_WAIT_NOTICE_INTERVAL_S` after that, so a caller can say WHY it is
+    stalled. Without it a contended acquire is indistinguishable from a hang: the process
+    sits in ``flock`` emitting nothing for as long as the peer holds the lock.
 
     ``None`` (a producer with no coordinated output dir) is a no-op, and so is every
     failure to lock: an unwritable ``__cadgen__``, a filesystem without advisory locks, or
@@ -164,10 +177,7 @@ def exclusive(
     held.add(key)
     try:
         try:
-            if deadline_ms is None:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-            else:
-                _acquire_by_deadline(handle, path, deadline_ms)
+            _acquire(handle, path, deadline_ms=deadline_ms, on_wait=on_wait)
         except OSError:
             # ENOLCK/EOPNOTSUPP and friends. The old code left this call OUTSIDE its
             # try/except, so such a filesystem turned advisory coordination into a hard
@@ -189,25 +199,46 @@ def exclusive(
             handle.close()
 
 
-def _acquire_by_deadline(handle, path: Path, deadline_ms: float) -> None:
-    """Poll for the lock until ``deadline_ms`` elapses, then raise :class:`Contended`.
+def _acquire(
+    handle,
+    path: Path,
+    *,
+    deadline_ms: float | None,
+    on_wait: Callable[[float], None] | None,
+) -> None:
+    """Take ``LOCK_EX``, honouring an optional deadline and an optional wait notice.
 
-    ``flock`` has no timeout, and alarm-based interruption is not thread-safe, so a bounded
-    wait has to poll. The interval is short enough to be imperceptible and the wait is
-    expected to be either instant or abandoned.
+    With neither, this is a plain blocking ``flock`` -- the kernel queues us and the hot
+    path costs one syscall. With either, the wait has to POLL: ``flock`` has no timeout,
+    and alarm-based interruption is not thread-safe, so there is no way to bound the wait
+    or to get control back periodically while blocked inside it. The interval is short
+    enough to be imperceptible against a wait long enough to be worth reporting.
+
+    Raises :class:`Contended` when ``deadline_ms`` elapses with a peer still holding it.
     """
-    deadline = time.monotonic() + (max(0.0, deadline_ms) / 1000.0)
+    if deadline_ms is None and on_wait is None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        return
+
+    started = time.monotonic()
+    deadline = None if deadline_ms is None else started + (max(0.0, deadline_ms) / 1000.0)
+    next_notice_at = _WAIT_NOTICE_GRACE_S
     while True:
         try:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             return
         except OSError as exc:
-            import errno as _errno
-
-            if exc.errno not in (_errno.EWOULDBLOCK, _errno.EAGAIN):
+            if exc.errno not in (errno.EWOULDBLOCK, errno.EAGAIN):
                 raise
-        if time.monotonic() >= deadline:
+        now = time.monotonic()
+        if deadline is not None and now >= deadline:
             raise Contended(path)
+        elapsed = now - started
+        if on_wait is not None and elapsed >= next_notice_at:
+            next_notice_at = elapsed + _WAIT_NOTICE_INTERVAL_S
+            # A reporting callback must never be able to fail an acquire.
+            with contextlib.suppress(Exception):
+                on_wait(elapsed)
         time.sleep(_POLL_INTERVAL_S)
 
 

--- a/packages/cadgen/src/cadgen/coordination/paths.py
+++ b/packages/cadgen/src/cadgen/coordination/paths.py
@@ -39,6 +39,16 @@ GENERATOR_LOCK_SUFFIX = ".generator.lock"
 # cutover and the reader cutover -- where the viewer showed `generating` with no bar.
 STATUS_SUFFIX = ".generation.progress.json"
 
+# The GENERATOR run's status record, and the reason there are two. Generator runs and writer
+# runs take different sentinels ON PURPOSE, so they do not exclude each other -- which meant
+# that while they shared one record file, an export's record landed on top of a live build's
+# progress. `snapshot()` attributes progress only to the WRITE sentinel's holder, so the
+# export's run id did not match and the build's bar vanished mid-run; worse, the export's
+# terminal record carries no `stageMs`, so it also erased the phase weighting the next build
+# reads. Nothing consumes this file today -- it exists so a generator run has somewhere of
+# its own to report, and cannot reach the writer's record.
+GENERATOR_STATUS_SUFFIX = ".generator.progress.json"
+
 
 def _sibling(output_dir: Path | str, suffix: str) -> Path:
     package = Path(output_dir)
@@ -56,5 +66,11 @@ def generator_lock_path(output_dir: Path | str) -> Path:
 
 
 def status_path(output_dir: Path | str) -> Path:
-    """The status/progress record describing the most recent run for ``output_dir``."""
+    """The status/progress record describing the most recent WRITER run for ``output_dir``."""
     return _sibling(output_dir, STATUS_SUFFIX)
+
+
+def generator_status_path(output_dir: Path | str) -> Path:
+    """The status record for a run that occupies ``output_dir``'s generator but writes no
+    package. Separate from :func:`status_path` so it cannot overwrite a live build's."""
+    return _sibling(output_dir, GENERATOR_STATUS_SUFFIX)

--- a/packages/cadgen/src/cadgen/dxf_artifact.py
+++ b/packages/cadgen/src/cadgen/dxf_artifact.py
@@ -5,6 +5,12 @@ import json
 from pathlib import Path
 
 from cadgen.cli_logging import CliLogger
+from cadgen._internal.cli_locking import (
+    add_lock_timeout_argument,
+    contended_payload,
+    deadline_ms,
+    lock_wait_notice,
+)
 from cadgen.coordination import DRAWING_PACKAGE, PHASE_FINALIZE, artifact_build
 from cadgen._internal.drawing_package import (
     drawing_package_current,
@@ -72,6 +78,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--export", help="Also write the (fresh) drawing DXF to this path.")
     parser.add_argument("--force", action="store_true", help="Regenerate even if a current artifact exists.")
     parser.add_argument("--verbose", action="store_true", help="Show detailed timing on stderr.")
+    add_lock_timeout_argument(parser)
     return parser
 
 
@@ -94,6 +101,7 @@ def build_dxf_artifact(
     force: bool = False,
     reset_runtime_closure: bool = False,
     logger: CliLogger | None = None,
+    lock_timeout_s: float = 0.0,
 ) -> dict[str, object]:
     """Build the drawing-package artifact for one DXF entry and RETURN the result payload
     (the exact dict the CLI prints). Mirrors :func:`cadgen.step_artifact.build_step_artifact`
@@ -126,7 +134,14 @@ def build_dxf_artifact(
         package_dir,
         is_current=lambda: drawing_package_current(resolved_source),
         force=force,
+        deadline_ms=deadline_ms(lock_timeout_s),
+        on_wait=lock_wait_notice(logger, relative_to_cwd(resolved_source)),
     ) as run:
+        if run.contended:
+            logger.info(f"another run is building {relative_to_cwd(resolved_source)}; not waiting")
+            return contended_payload(
+                source_ref=relative_to_cwd(resolved_source), package_dir=package_dir
+            )
         skipped = run.skipped
         if not skipped:
             if imported:
@@ -175,6 +190,7 @@ def run_cli_payload(
         force=bool(args.force),
         reset_runtime_closure=reset_runtime_closure,
         logger=logger,
+        lock_timeout_s=float(args.lock_timeout or 0.0),
     )
     logger.total()
     return payload

--- a/packages/cadgen/src/cadgen/implicit_artifact.py
+++ b/packages/cadgen/src/cadgen/implicit_artifact.py
@@ -30,6 +30,12 @@ from cadgen._internal.implicit_package import (
 )
 from cadgen.catalog import render_package_dir
 from cadgen.cli_logging import CliLogger
+from cadgen._internal.cli_locking import (
+    add_lock_timeout_argument,
+    contended_payload,
+    deadline_ms,
+    lock_wait_notice,
+)
 from cadgen.coordination import IMPLICIT_PACKAGE, artifact_build
 from cadgen.render import relative_to_cwd
 
@@ -96,6 +102,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--force", action="store_true", help="Regenerate even if a current artifact exists.")
     parser.add_argument("--verbose", action="store_true", help="Show detailed timing on stderr.")
+    add_lock_timeout_argument(parser)
     return parser
 
 
@@ -109,6 +116,7 @@ def build_implicit_artifact(
     force: bool = False,
     logger: CliLogger | None = None,
     sink: object | None = None,
+    lock_timeout_s: float = 0.0,
 ) -> dict[str, object]:
     """Build the implicit package for one model and RETURN the result payload (the exact
     dict the CLI prints). Mirrors :func:`cadgen.dxf_artifact.build_dxf_artifact`.
@@ -143,7 +151,14 @@ def build_implicit_artifact(
         is_current=_is_current,
         force=force,
         sink=sink,
+        deadline_ms=deadline_ms(lock_timeout_s),
+        on_wait=lock_wait_notice(logger, relative_to_cwd(resolved_source)),
     ) as run:
+        if run.contended:
+            logger.info(f"another run is building {relative_to_cwd(resolved_source)}; not waiting")
+            return contended_payload(
+                source_ref=relative_to_cwd(resolved_source), package_dir=package_dir
+            )
         if run.skipped:
             payload = _result_payload(
                 resolved_source,
@@ -194,6 +209,7 @@ def run_cli_payload(
         write_glb=Path(args.write_glb) if args.write_glb else None,
         force=bool(args.force),
         logger=logger,
+        lock_timeout_s=float(args.lock_timeout or 0.0),
     )
     logger.total()
     return payload

--- a/packages/cadgen/src/cadgen/step_artifact.py
+++ b/packages/cadgen/src/cadgen/step_artifact.py
@@ -6,6 +6,12 @@ import json
 from pathlib import Path
 
 from cadgen.cli_logging import CliLogger
+from cadgen._internal.cli_locking import (
+    add_lock_timeout_argument,
+    contended_payload,
+    deadline_ms,
+    lock_wait_notice,
+)
 from cadgen._internal.generation import (
     EntrySpec,
     _assembly_glb_package_current,
@@ -259,6 +265,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--mesh-tolerance", type=float, help="Override automatic mesh linear deflection.")
     parser.add_argument("--mesh-angular-tolerance", type=float, help="Override automatic mesh angular deflection.")
     parser.add_argument("--verbose", action="store_true", help="Show detailed timing on stderr.")
+    add_lock_timeout_argument(parser)
     return parser
 
 
@@ -274,6 +281,7 @@ def build_step_artifact(
     reset_runtime_closure: bool = False,
     verbose: bool = False,
     logger: CliLogger | None = None,
+    lock_timeout_s: float = 0.0,
 ) -> dict[str, object]:
     """Build the GLB/topology artifact for one STEP/.step.py and RETURN the result
     payload (the exact dict the CLI prints). This is the single source of truth,
@@ -287,7 +295,13 @@ def build_step_artifact(
 
     ``reset_runtime_closure`` (default-off) is for warm worker processes: it makes
     the generator's recorded source closure deterministic across repeated in-process
-    builds — see :func:`cadgen.generation.run_script_generator`."""
+    builds — see :func:`cadgen.generation.run_script_generator`.
+
+    ``lock_timeout_s`` bounds the wait for a peer's generation lock. 0 waits (the CLI
+    default: an agent asking for a build wants the build). A caller that must not block —
+    the CAD Viewer's request path, which shares ONE serial warm worker across every model —
+    passes a short one and gets ``{"ok": True, "contended": True}`` back, so it can report
+    the peer's run instead of occupying the worker until the peer finishes."""
     repo_root = Path(repo_root).expanduser().resolve()
     step_path = Path(step).expanduser().resolve()
     from_generator = source_path is not None
@@ -376,7 +390,19 @@ def build_step_artifact(
         package_dir,
         is_current=lambda: _current_artifact_for_spec(existing_spec) is not None,
         force=force,
+        deadline_ms=deadline_ms(lock_timeout_s),
+        on_wait=lock_wait_notice(logger, existing_spec.source_ref),
     ) as progress:
+        if progress.contended:
+            # A peer holds this model's lock and the caller asked not to wait it out. Not
+            # an error: the model IS being built, just not by us.
+            logger.info(f"another run is building {existing_spec.source_ref}; not waiting")
+            return contended_payload(
+                source_ref=existing_spec.source_ref,
+                cad_ref=existing_spec.cad_ref,
+                package_dir=package_dir,
+                stepPath=relative_to_cwd(existing_spec.step_path),
+            )
         if progress.skipped:
             artifact = _current_artifact_for_spec(existing_spec)
             if artifact is not None:
@@ -442,6 +468,7 @@ def run_cli_payload(
         mesh_angular_tolerance=args.mesh_angular_tolerance,
         reset_runtime_closure=reset_runtime_closure,
         logger=logger,
+        lock_timeout_s=float(args.lock_timeout or 0.0),
     )
     logger.total()
     return payload

--- a/skills/cad/SKILL.md
+++ b/skills/cad/SKILL.md
@@ -54,6 +54,19 @@ python scripts/artifact ...  # debug one on-demand render-package build (importe
 
 Use the active project Python interpreter; treat `python` in examples as an interpreter placeholder. Use `python scripts/<tool> --help` for the complete current command interface; reference docs show recommended workflows, not every flag.
 
+**Streams.** stdout carries the result; stderr carries progress, timing, and failures. The two never interleave, so `2>/dev/null` leaves a clean parseable result and `>/dev/null` leaves a readable log. For machine-readable output: `gen`, `export`, and `snapshot` take `--json`; `inspect` already emits JSON and takes `--format text` for prose. `--verbose` adds stage timing (and full tracebacks) on stderr. Output volume does not grow with model size — a 600-occurrence assembly logs the same dozen lines a single part does.
+
+**Failures** print the exception and the frames *in your own generator*, not the runtime's:
+
+```text
+[scripts/gen] FAILED: ValueError: bad radius
+[scripts/gen]   models/step/parts/widget.step.py:9 in gen_step
+[scripts/gen]       return _profile(radius)
+[scripts/gen] re-run with --verbose for the full traceback
+```
+
+**A build waits for a concurrent build of the same model** rather than racing it, and says so on stderr (`waiting for another run to finish building ...`), repeating while it waits. Pass `--lock-timeout SECONDS` to give up instead and report `{"ok":true,"contended":true}`. With `--json`, each target's `outcome` is `built`, `current`, or `skipped-peer`.
+
 Target paths resolve from the command's current working directory, not from the skill directory. Run commands from the workspace that owns the artifacts and pass cwd-relative target paths so project CAD files never resolve accidentally under the skill directory. Keep a STEP output and its Python generator in the same directory with the same basename unless the user explicitly requests otherwise.
 
 CAD references are `#...` selector tokens local to a target, for example `#o1.2` or `#o1.2.f1`. Pass the STEP/CAD file as a separate target argument when using CAD CLIs.

--- a/skills/cad/scripts/export/cli.py
+++ b/skills/cad/scripts/export/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from collections.abc import Sequence
 
 from cadgen.metadata import normalize_mesh_numeric
@@ -14,6 +15,12 @@ def export_cad_target(*args, **kwargs):
     from cadgen.step_export_target import export_cad_target as export
 
     return export(*args, **kwargs)
+
+
+def report_cli_error(*args, **kwargs):
+    from cadgen._internal.cli_errors import report_cli_error as report
+
+    return report(*args, **kwargs)
 
 
 def _normalize_cli_numeric(value: object, *, field_name: str, parser: argparse.ArgumentParser) -> float | None:
@@ -65,6 +72,14 @@ def _add_export_arguments(parser: argparse.ArgumentParser) -> None:
         "--verbose",
         action="store_true",
         help="Show detailed progress and timing information.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Print the export result as one JSON line on stdout instead of the "
+            "'wrote STL: ...' lines. Human progress stays on stderr."
+        ),
     )
 
 
@@ -121,6 +136,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
     except ValueError as exc:
         parser.error(str(exc))
+    except Exception as exc:  # noqa: BLE001 — the CLI boundary: report, do not traceback
+        return report_cli_error(exc, tool="scripts/export", verbose=bool(args.verbose))
+    if args.json:
+        print(json.dumps({"ok": True, **payload}, separators=(",", ":")))
+        return 0
     for entry in payload["files"]:
         print(f"wrote {entry['format'].upper()}: {entry['path']}")
     return 0

--- a/skills/cad/scripts/gen/cli.py
+++ b/skills/cad/scripts/gen/cli.py
@@ -17,6 +17,12 @@ def generate_step_targets(*args, **kwargs):
     return generate(*args, **kwargs)
 
 
+def report_cli_error(*args, **kwargs):
+    from cadgen._internal.cli_errors import report_cli_error as report
+
+    return report(*args, **kwargs)
+
+
 def _normalize_cli_numeric(value: object, *, field_name: str, parser: argparse.ArgumentParser) -> float | None:
     try:
         return normalize_mesh_numeric(value, field_name=field_name)
@@ -62,6 +68,15 @@ def _add_gen_arguments(parser: argparse.ArgumentParser) -> None:
         "--verbose",
         action="store_true",
         help="Show detailed progress and timing information.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Print one JSON line per target on stdout reporting what happened to it "
+            "(built, current, or built by a concurrent run) and where its package is. "
+            "Human progress stays on stderr, so the two never interleave."
+        ),
     )
 
 
@@ -137,12 +152,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             parser=parser,
         ),
     )
-    return generate_step_targets(
-        _targets_with_step_outputs(args.targets, args.write, parser=parser),
-        step_options=step_options,
-        force=bool(args.force),
-        verbose=bool(args.verbose),
-    )
+    try:
+        return generate_step_targets(
+            _targets_with_step_outputs(args.targets, args.write, parser=parser),
+            step_options=step_options,
+            force=bool(args.force),
+            verbose=bool(args.verbose),
+            json_output=bool(args.json),
+        )
+    except Exception as exc:  # noqa: BLE001 — the CLI boundary: report, do not traceback
+        return report_cli_error(exc, tool="scripts/gen", verbose=bool(args.verbose))
 
 
 if __name__ == "__main__":

--- a/skills/dxf/scripts/gen/cli.py
+++ b/skills/dxf/scripts/gen/cli.py
@@ -4,6 +4,12 @@ import argparse
 from collections.abc import Sequence
 
 
+def report_cli_error(*args, **kwargs):
+    from cadgen._internal.cli_errors import report_cli_error as report
+
+    return report(*args, **kwargs)
+
+
 def generate_dxf_targets(*args, **kwargs):
     from cadgen.generation import generate_dxf_targets as generate
 
@@ -92,13 +98,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             parser.error("--output cannot be combined with SOURCE=OUTPUT targets")
         if len(args.targets) != 1:
             parser.error("--output can only be used with exactly one target")
-    return generate_dxf_targets(
-        args.targets,
-        output=args.output,
-        write_dxf=bool(args.write),
-        force=bool(args.force),
-        verbose=bool(args.verbose),
-    )
+    try:
+        return generate_dxf_targets(
+            args.targets,
+            output=args.output,
+            write_dxf=bool(args.write),
+            force=bool(args.force),
+            verbose=bool(args.verbose),
+        )
+    except Exception as exc:  # noqa: BLE001 — the CLI boundary: report, do not traceback
+        return report_cli_error(exc, tool="scripts/gen", verbose=bool(args.verbose))
 
 
 if __name__ == "__main__":

--- a/tests/python/packages/cadgen/test_cli_errors.py
+++ b/tests/python/packages/cadgen/test_cli_errors.py
@@ -1,0 +1,113 @@
+"""A CAD CLI failure has to lead with the failure, and name the caller's own code.
+
+Before this, an uncaught generator exception reached the interpreter: a `gen_step()` that
+raised printed a 62-line traceback whose only useful line was last, and one missing its
+return printed 43 lines to say "must return one value". Both are ordinary authoring
+mistakes, so both are what an agent hits most.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from pathlib import Path
+
+from tests.python.support.paths import add_repo_path
+
+add_repo_path("packages/cadgen/src")
+
+from cadgen._internal.cli_errors import report_cli_error  # noqa: E402
+
+
+def _raise_from_model(model: Path) -> BaseException:
+    """Run a throwaway generator from ``model`` so the traceback carries its frames."""
+    namespace: dict[str, object] = {}
+    code = compile(model.read_text(), str(model), "exec")
+    try:
+        exec(code, namespace)  # noqa: S102 - the fixture IS a model source
+        namespace["gen_step"]()
+    except Exception as exc:  # noqa: BLE001
+        return exc
+    raise AssertionError("fixture did not raise")
+
+
+class ReportCliErrorTest(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+
+        self.root = Path(tempfile.mkdtemp())
+        self.addCleanup(__import__("shutil").rmtree, self.root, True)
+        self.model = self.root / "widget.step.py"
+        self.model.write_text(
+            "def _inner():\n"
+            "    raise ValueError('bad radius')\n"
+            "\n"
+            "\n"
+            "def gen_step():\n"
+            "    return _inner()\n"
+        )
+
+    def _report(self, exc, **kwargs) -> str:
+        stream = io.StringIO()
+        code = report_cli_error(exc, tool="scripts/gen", stream=stream, **kwargs)
+        self.assertEqual(1, code, "a reported failure is still a failure")
+        return stream.getvalue()
+
+    def test_it_leads_with_the_failure(self):
+        text = self._report(_raise_from_model(self.model))
+        self.assertTrue(
+            text.splitlines()[0].endswith("FAILED: ValueError: bad radius"),
+            f"the failure must be the FIRST line, got: {text.splitlines()[0]!r}",
+        )
+
+    def test_it_names_the_models_own_frames(self):
+        text = self._report(_raise_from_model(self.model))
+        self.assertIn("widget.step.py:6 in gen_step", text)
+        self.assertIn("widget.step.py:2 in _inner", text)
+
+    def test_it_drops_the_runtime_frames(self):
+        # A model that fails INSIDE cadgen: the traceback carries a cadgen frame, and the
+        # report must not. Those frames are identical in every failure and say nothing
+        # about which model broke -- they are the ~50 lines this reporter exists to remove.
+        self.model.write_text(
+            "from cadgen.metadata import normalize_mesh_numeric\n"
+            "\n"
+            "\n"
+            "def gen_step():\n"
+            "    return normalize_mesh_numeric(-1, field_name='mesh_tolerance')\n"
+        )
+        text = self._report(_raise_from_model(self.model))
+        self.assertIn("widget.step.py:5 in gen_step", text, "the model's frame is kept")
+        self.assertNotIn("metadata.py", text, "a cadgen frame is runtime, not the model")
+        self.assertLess(len(text.splitlines()), 10, "a compact report stays compact")
+
+    def test_verbose_restores_the_full_traceback(self):
+        text = self._report(_raise_from_model(self.model), verbose=True)
+        self.assertIn("Traceback (most recent call last)", text)
+        self.assertIn("test_cli_errors.py", text, "internal frames are the point of --verbose")
+
+    def test_a_failure_with_no_model_frames_still_names_where_it_came_from(self):
+        # A validation error raised before the generator ever ran, so every frame is
+        # runtime. The message already names the model; the report points at the raiser so
+        # a cadgen-side fault is still diagnosable without --verbose.
+        import cadgen._internal.cli_errors as cli_errors
+
+        original = cli_errors.__dict__.get("_model_frames")
+        self.addCleanup(lambda: cli_errors.__dict__.__setitem__("_model_frames", original))
+        cli_errors._model_frames = lambda exc: []
+        try:
+            raise ValueError("widget.step.py gen_step() must return one value")
+        except ValueError as exc:
+            text = self._report(exc)
+        self.assertIn("must return one value", text)
+        self.assertIn("raised in", text)
+        self.assertLess(len(text.splitlines()), 5)
+
+    def test_an_exception_that_was_never_raised_still_reports(self):
+        # Defensive: a caller may report a constructed exception with no traceback at all.
+        text = self._report(ValueError("no traceback here"))
+        self.assertIn("FAILED: ValueError: no traceback here", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/packages/cadgen/test_coordination.py
+++ b/tests/python/packages/cadgen/test_coordination.py
@@ -105,6 +105,50 @@ class SnapshotTest(CoordinationTestCase):
         self.assertEqual("busy", snap.state)
 
 
+class GeneratorRecordIsolationTest(CoordinationTestCase):
+    """The two sentinels do NOT exclude each other, so a generator run and a writer run
+    overlap by design. They must not share a record file: while they did, an export landed
+    on top of a live build's progress and the viewer's bar vanished mid-build."""
+
+    def test_a_generator_run_does_not_touch_the_writers_record(self):
+        with exclusive(write_lock_path(self.out)) as write_run:
+            record_mod.write_record(
+                status_path(self.out),
+                record_mod.build_record(
+                    run_id=write_run,
+                    kind="step-package",
+                    intent="write",
+                    started_at_ms=0.0,
+                    outcome=None,
+                    progress={"phase": "components", "done": 7, "total": 9, "ratio": 0.5},
+                ),
+            )
+            with generator_busy(STEP_PACKAGE, self.out):
+                snap = snapshot(self.out)
+            self.assertEqual("writing", snap.state, "the writer still holds its sentinel")
+            self.assertIsNotNone(
+                snap.progress, "an overlapping export must not erase the build's bar"
+            )
+            self.assertEqual("components", snap.progress["phase"])
+
+    def test_a_generator_run_does_not_erase_the_learned_stage_times(self):
+        # An export leaves a terminal record with no stageMs. Sharing the writer's file made
+        # that record the one the NEXT build read, so the model forgot its phase weighting.
+        with artifact_build(STEP_PACKAGE, self.out, is_current=lambda: False) as run:
+            run.phase(PHASE_COMPONENTS, total=2)
+            run.advance()
+        learned = record_mod.read_stage_ms(status_path(self.out))
+        self.assertTrue(learned, "a successful build records what its phases cost")
+
+        with generator_busy(STEP_PACKAGE, self.out):
+            pass
+        self.assertEqual(
+            learned,
+            record_mod.read_stage_ms(status_path(self.out)),
+            "an export must not cost the next build its learned phase weighting",
+        )
+
+
 class RunAttributionTest(CoordinationTestCase):
     def test_a_dead_runs_record_is_not_shown_as_the_live_runs_progress(self):
         # Simulate a SIGKILLed build: a non-terminal record left behind forever.
@@ -287,17 +331,56 @@ class PostLockFreshnessTest(CoordinationTestCase):
 
 
 class BoundedWaitTest(CoordinationTestCase):
-    def test_deadline_raises_contended_instead_of_blocking(self):
+    def test_deadline_reports_contended_instead_of_blocking(self):
         self._spawn_holder(hold=10.0)
         started = time.monotonic()
-        with self.assertRaises(Contended):
-            with artifact_build(
-                STEP_PACKAGE, self.out, is_current=lambda: False, deadline_ms=300
-            ):
-                pass
+        with artifact_build(
+            STEP_PACKAGE, self.out, is_current=lambda: False, deadline_ms=300
+        ) as run:
+            self.assertTrue(run.contended, "a peer holds the lock; this run got nothing")
+            self.assertIsNone(run.run_id, "a contended run never became a run")
         self.assertLess(
             time.monotonic() - started, 5.0, "a bounded wait must not block for the full run"
         )
+
+    def test_an_acquired_run_is_not_contended(self):
+        with artifact_build(
+            STEP_PACKAGE, self.out, is_current=lambda: False, deadline_ms=5000
+        ) as run:
+            self.assertFalse(run.contended)
+            self.assertIsNotNone(run.run_id)
+
+    def test_exclusive_still_raises_contended_for_lower_level_callers(self):
+        # artifact_build turns a lost race into run.contended; the primitive underneath it
+        # keeps raising, so a caller with no BuildRun to inspect still cannot miss it.
+        self._spawn_holder(hold=10.0)
+        with self.assertRaises(Contended):
+            with exclusive(write_lock_path(self.out), deadline_ms=300):
+                pass
+
+    def test_a_contended_run_writes_no_record(self):
+        # The peer owns the record. A run that never took the lock must not touch it --
+        # overwriting it is exactly how a live build's bar used to disappear.
+        self._spawn_holder(hold=10.0)
+        before = status_path(self.out).read_bytes() if status_path(self.out).exists() else None
+        with artifact_build(
+            STEP_PACKAGE, self.out, is_current=lambda: False, deadline_ms=300
+        ) as run:
+            self.assertTrue(run.contended)
+        after = status_path(self.out).read_bytes() if status_path(self.out).exists() else None
+        self.assertEqual(before, after)
+
+    def test_a_blocked_acquire_reports_that_it_is_waiting(self):
+        # Without this a contended acquire emits nothing at all for as long as the peer
+        # holds the lock, which is indistinguishable from a hung process.
+        self._spawn_holder(hold=1.5)
+        waits = []
+        with artifact_build(
+            STEP_PACKAGE, self.out, is_current=lambda: False, on_wait=waits.append
+        ) as run:
+            self.assertFalse(run.contended, "no deadline: it must wait the peer out")
+        self.assertTrue(waits, "a wait long enough to notice must be reported")
+        self.assertGreater(waits[0], 0.0)
 
     def test_reentrant_acquire_in_one_thread_does_not_deadlock(self):
         with exclusive(write_lock_path(self.out)) as outer:

--- a/tests/python/skills/cad/gen/test_cli.py
+++ b/tests/python/skills/cad/gen/test_cli.py
@@ -28,6 +28,33 @@ class GenCliTests(unittest.TestCase):
         self.assertFalse(generate.call_args.kwargs["force"])
         self.assertFalse(generate.call_args.kwargs["verbose"])
 
+    def test_json_is_off_by_default_and_forwarded_when_asked(self) -> None:
+        with mock.patch.object(cli, "generate_step_targets", return_value=0) as generate:
+            cli.main(["parts/sample.step.py"])
+        self.assertFalse(generate.call_args.kwargs["json_output"])
+
+        with mock.patch.object(cli, "generate_step_targets", return_value=0) as generate:
+            cli.main(["parts/sample.step.py", "--json"])
+        self.assertTrue(generate.call_args.kwargs["json_output"])
+
+    def test_a_generator_failure_is_reported_not_tracebacked(self) -> None:
+        # An uncaught generator exception used to reach the interpreter and print ~60
+        # lines of runtime frames. The CLI is the boundary that turns it into a report.
+        boom = ValueError("bad radius")
+        stderr = io.StringIO()
+        with mock.patch.object(cli, "generate_step_targets", side_effect=boom):
+            with contextlib.redirect_stderr(stderr):
+                self.assertEqual(1, cli.main(["parts/sample.step.py"]))
+        self.assertIn("FAILED: ValueError: bad radius", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_verbose_still_gets_the_full_traceback(self) -> None:
+        stderr = io.StringIO()
+        with mock.patch.object(cli, "generate_step_targets", side_effect=ValueError("bad radius")):
+            with contextlib.redirect_stderr(stderr):
+                self.assertEqual(1, cli.main(["parts/sample.step.py", "--verbose"]))
+        self.assertIn("Traceback", stderr.getvalue())
+
     def test_passes_force_and_verbose_flags(self) -> None:
         with mock.patch.object(cli, "generate_step_targets", return_value=0) as generate:
             self.assertEqual(0, cli.main(["parts/sample.step.py", "--force", "--verbose"]))

--- a/viewer/server_py/backend.py
+++ b/viewer/server_py/backend.py
@@ -21,6 +21,11 @@ from .urls import local_asset_url_for_path
 
 _STEP_EXPORT_FORMAT_SUFFIX = {"step": "step", "stl": "stl", "3mf": "3mf", "glb": "glb"}
 
+# How long an artifact build may wait for a peer's generation lock before reporting the
+# peer's run instead. Long enough that an UNCONTENDED acquire never trips it (it is a
+# couple of syscalls), short enough that a POST cannot park the shared warm worker.
+_ARTIFACT_LOCK_TIMEOUT_SECONDS = 0.5
+
 # The formats an `.implicit.js` model exports to. Rejected here only so a bad request fails
 # before a Node process is spawned; `cadgen.implicit_export` holds the authoritative list
 # beside the exporter it drives, and validates again.
@@ -428,9 +433,22 @@ class LocalAssetBackend:
         full_args = ["--repo-root", root_path, *args]
         if force:
             full_args += ["--force"]
+        # NEVER wait out a peer inside a build. cadgen's acquire is blocking by default,
+        # which is right for a CLI (an agent asking for a build wants the build) and wrong
+        # here: this request runs in the ONE serial warm worker, so a build parked on
+        # another process's lock stops every OTHER model's build and export for as long as
+        # the peer runs -- measured at 32s for an unrelated, already-current model. The
+        # snap.writing pre-check in resolve_artifact narrows the window but cannot close it
+        # (a peer can take the lock right after the snapshot, and force= skips the check
+        # entirely). This is the part that actually cannot block.
+        full_args += ["--lock-timeout", str(_ARTIFACT_LOCK_TIMEOUT_SECONDS)]
         if os.environ.get("VIEWER_STEP_ARTIFACT_VERBOSE") == "1":
             full_args += ["--verbose"]
         result = cadgen_bridge.run_cadgen(module, full_args, root_path)
+        if result.get("contended"):
+            # A peer holds the lock. Nothing failed and nothing was built: the caller
+            # reports the peer's run so the client attaches to its progress.
+            return {"ok": True, "contended": True, "error": "", "result": result}
         error = "" if result.get("ok") else str(result.get("error") or error_label)
         return {"ok": bool(result.get("ok")), "error": error, "result": result}
 
@@ -460,6 +478,14 @@ class LocalAssetBackend:
                 result["runId"] = snap.run_id
             return result
         built = fmt["build"](file_ref, force, resolved_root, catalog)
+        if built.get("contended"):
+            # The peer took the lock between the snapshot above and the build (or force=
+            # skipped that check). Same answer as the pre-check: attach to their run.
+            result = {"ok": True, "state": artifact_mod.ARTIFACT_STATE_GENERATING, "ref": ref}
+            live = artifact_mod.generation_snapshot(scanner.render_package_dir(artifact_source))
+            if live.run_id:
+                result["runId"] = live.run_id
+            return result
         if built["ok"]:
             return {"ok": True, "state": artifact_mod.ARTIFACT_STATE_READY, "ref": ref}
         return {"ok": False, "state": artifact_mod.ARTIFACT_STATE_ERROR, "error": built["error"]}

--- a/viewer/server_py/backend.py
+++ b/viewer/server_py/backend.py
@@ -361,8 +361,11 @@ class LocalAssetBackend:
         if code in artifact_mod.BUILDABLE_ARTIFACT_CODES:
             status = {"state": artifact_mod.ARTIFACT_STATE_NEEDS_BUILD, "reason": code, "ref": ref}
             if snap.busy:
-                # Stale AND the generator is occupied: a build would just block on the
-                # peer. Tell the client to wait rather than POST.
+                # Stale AND the generator is occupied (an export is running this model's
+                # gen_step). A build would NOT block on it -- the two take different
+                # sentinels precisely so they do not exclude each other -- it would run the
+                # same generator a second time, concurrently, for nothing. Telling the
+                # client to wait is an efficiency call, not a deadlock avoidance one.
                 status["blocked"] = True
             return status
         return {"state": artifact_mod.ARTIFACT_STATE_ERROR, "reason": code, "error": code, "ref": ref}
@@ -471,6 +474,11 @@ class LocalAssetBackend:
         #
         # Reporting `generating` immediately lets the client attach to the peer's run and
         # watch its live progress instead, which is both faster and truthful.
+        #
+        # This check is the FAST PATH, not the guarantee: it is a snapshot, so a peer can
+        # take the lock immediately after it, and force= skips it entirely. The guarantee is
+        # the bounded --lock-timeout in _run_artifact_build, whose contended result lands on
+        # the same answer below.
         snap = artifact_mod.generation_snapshot(scanner.render_package_dir(artifact_source))
         if not force and snap.writing:
             result = {"ok": True, "state": artifact_mod.ARTIFACT_STATE_GENERATING, "ref": ref}


### PR DESCRIPTION
A deep review of STEP generation reliability on `release/0.4.0`, focused on the lock system under concurrency and on how the CLIs talk to an agent. Every claim below was measured, not read off the code.

## The flock core is sound

Verified before changing anything:

| Test | Result |
|---|---|
| 6 concurrent cold builds of one model (5 s part **and** 16 s / 600-occurrence assembly) | 1 built, 5 skipped, all exit 0 |
| 32,000 concurrent probes of an *unheld* sentinel, 8 threads | 0 false positives |
| 32,000 concurrent probes of a *held* sentinel | 0 false negatives |
| `SIGKILL` mid-build | reads `idle` instantly, no phantom progress, no partial descriptor, no orphan temp files |
| Generator raises mid-build | `outcome: failed`, `stageMs: null`, lock released, no partial package |

The flakiness was not in the lock. It was in what surrounds it.

## Fixed

**A contended acquire was silent and unbounded.** `deadline_ms` and `Contended` existed, were tested, and had no production caller — so every acquire blocked forever with nothing on either stream. `cad gen --force` behind a peer's lock sat for 35 s emitting zero bytes; a wedged holder hangs it for good. `exclusive()` now takes `on_wait` and reports at 256 ms, repeating every 30 s. The artifact CLIs take `--lock-timeout`.

**One contended model froze the CAD Viewer's builds for every model.** A POST runs in the one serial warm worker, so a build parked on another process's lock stopped every other model's build and export. Measured: an unrelated, already-current model waited **31.99 s**. The `snap.writing` pre-check narrowed the window but could not close it — a peer can take the lock right after the snapshot, and `force=` skipped the check outright. The viewer now passes a bounded `--lock-timeout` and reports the peer's run. **32 s → 0.0 s.**

**An export erased a live build's progress.** `generator_busy` and `artifact_build` take different sentinels on purpose, so they cannot exclude each other — but they shared one record file. An export's record landed on a running build's and `snapshot()` rejected it on the run id: the bar vanished for 2.2 s mid-build. Its terminal record carries no `stageMs`, so an export also wiped the phase weighting the next build reads. The generator run now writes its own record; nothing ever read it.

**CLI failures dumped raw tracebacks.** A `gen_step()` that raised printed 62 lines / 4.2 KB whose one useful line was last, under ~50 frames of runpy, the launcher and cadgen internals. Now **6 lines / 413 B**, keeping the frames in your own model and dropping the runtime's — reusing the same first-party predicate the source closure already uses. `--verbose` still prints everything.

**Results were unreadable by anything but a human.** `gen` wrote nothing at all to stdout, and its per-target outcome (built / already current / built by a peer) is not something an exit code can express. `gen` and `export` gained `--json`.

## Left alone, on purpose

A build and an export still run the same `gen_step()` concurrently — measured 6.7 s of overlap. That is duplicated CPU, not a hazard (separate processes, different outputs), and it is the price of a reader being able to tell "being rewritten" from "generator busy". `_track_spec_generation`'s docstring claimed otherwise; the docstring is now correct.

Queued runs that skip still hold the write lock for ~50–110 ms each, so the viewer can briefly re-report "generating" right after a build finishes. Cosmetic, and the fix has real design thinking behind it.

## Also

`InlineStatusBoard` is deleted — it painted a per-model board on **stdout** with cursor escapes for callers running without a logger, and there were none. With `gen --json` now writing to stdout, that branch would have corrupted the result stream the moment anyone wired it up. Four parameters only it could reach went with it.

## Verification

Full Python suite, viewer server tests (136), cadjs (498), implicitjs (364), viewer JS (298), bundle check, symlink layout, version check, docs check — all pass on this branch's tip.

Note for anyone hitting failures locally: `packages/cadjs` and `packages/implicitjs` need `npm install` in a fresh worktree. Without `meshoptimizer` the JS suites fail, the docs check fails, **and** `bundle.sh --check` reports `snapshot-render.js` stale — that last one is a false alarm from the missing dep, not real staleness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
