### PR TITLE
test: make snapshot path assertions Windows-portable

### DIFF
--- a/packages/implicitjs/scripts/snapshot.test.mjs
+++ b/packages/implicitjs/scripts/snapshot.test.mjs
@@ -225,7 +225,7 @@ test("legacy top-level theme and params fields are rejected", () => withTempImpl
 test("timestamp output path preserves extension", () => {
   assert.equal(
     timestampOutputPath("snapshots/review.png", "20260527T163012Z"),
-    "snapshots/review_20260527T163012Z.png"
+    path.join("snapshots", "review_20260527T163012Z.png")
   );
 });
 

--- a/tests/python/skills/cad/snapshot/test_cli.py
+++ b/tests/python/skills/cad/snapshot/test_cli.py
@@ -614,7 +614,7 @@ class SnapshotCliTests(unittest.TestCase):
     def test_timestamp_output_path_preserves_extension(self) -> None:
         self.assertEqual(
             timestamp_output_path("snapshots/review.png", "20260527T163012Z"),
-            "snapshots/review_20260527T163012Z.png",
+            str(Path("snapshots") / "review_20260527T163012Z.png"),
         )
 
     def test_removed_daemon_flags_stay_removed(self) -> None:


### PR DESCRIPTION
## Summary
- use platform-native path construction in the Python and JavaScript timestamp-output tests
- keep the runtime helpers unchanged while covering Windows path separators

Fixes #196.

## Validation
- PYTHONPATH=packages/cadpy/src python -m unittest tests.python.skills.cad.snapshot.test_cli (27 passed)
- 
ode --test packages/implicitjs/scripts/snapshot.test.mjs (13 passed)
- git diff --check

The existing runtime behavior is platform-native; this aligns both assertions with that contract.