### PR TITLE
Report each build phase on its own, not as one guessed bar

### DIFF
--- a/design/artifact-generation-coordination.md
+++ b/design/artifact-generation-coordination.md
@@ -142,6 +142,8 @@ Three rules close D6:
 
 Version handling: a reader that sees `schemaVersion != 2` returns *no progress* but still reports `generating` from the lock — the same safe degradation as an unreadable file today (`artifact.py:231-232`).
 
+> **Superseded in part (schema v3).** The locking, attribution and `starting`-record rules above all shipped and still hold. The *progress* half did not survive contact with a slow model: one overall `ratio` has to weight the phases against each other, the weights came from the previous build's `stageMs`, and a first build has none — so an F-14 whose `generate` phase is 84% of a 12-minute run displayed exactly 0% for ten minutes and then jumped to the `components` band floor at 46%. v3 drops `ratio`, `ratioFloor`, `ratioCeiling` and `phaseExpectedMs`, and reports each phase on its own: `index`/`count` for its place in the run, plus *either* `done`/`total` *or* a `detail` label naming the sub-unit in flight. `stageMs` is still written on `outcome=="done"`, but nothing reads it back — it is a record of what the run cost, not an input. See `coordination/phases.py`.
+
 ### 3.3 API surface
 
 **Producer — one context manager that owns lock + progress + post-lock re-check:**

--- a/models/renders/f14d/f14d.step.py
+++ b/models/renders/f14d/f14d.step.py
@@ -36,6 +36,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from build123d import Compound
 
+from cadgen import track
+
 # Order here IS the occurrence order (o1.1, o1.2, ...).
 SYSTEMS = [
     "airframe",
@@ -100,10 +102,17 @@ for _name in COSMETIC_CUTTER_MODULES:
 
 
 def gen_step():
+    # Report the walk through the systems. This phase is ~85% of the build (10 minutes of a
+    # 12-minute run, measured), and without this it is the one stretch that says nothing at
+    # all -- the viewer and the CLI both sat on "Building geometry" for its whole duration.
+    #
+    # The systems are counted AFTER dropping the ones that failed to import, so the
+    # denominator is work that will actually run. Note the units are nowhere near equal:
+    # `airframe` alone is over half the phase (see the cutter note above), so 1/13 sits for
+    # minutes and the tail ticks past quickly. The count is true, not linear.
+    buildable = [(name, module) for name, module in _MODULES if module is not None]
     groups = []
-    for name, module in _MODULES:
-        if module is None:
-            continue
+    for name, module in track(buildable, label=lambda entry: entry[0]):
         try:
             groups.append(module.build())
         except Exception as exc:  # noqa: BLE001

--- a/packages/cadgen/src/cadgen/__init__.py
+++ b/packages/cadgen/src/cadgen/__init__.py
@@ -9,7 +9,9 @@ __all__ = [
     "ensure_step_glb_artifact",
     "label_text",
     "label_shape",
+    "report",
     "target",
+    "track",
     "validate_step_glb_artifact",
 ]
 
@@ -41,4 +43,8 @@ def __getattr__(name: str):
         from cadgen.instances import compound_from_instances
 
         return compound_from_instances
+    if name in {"report", "track"}:
+        from cadgen.progress import report, track
+
+        return {"report": report, "track": track}[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/cadgen/src/cadgen/_internal/generation.py
+++ b/packages/cadgen/src/cadgen/_internal/generation.py
@@ -50,7 +50,14 @@ from cadgen.coordination import (
     artifact_build,
     generator_busy,
     render_progress_bar,
+    reporting_as,
     resolve as resolve_progress,
+)
+from cadgen.cli_progress import (
+    InlineProgressLine,
+    _finished_phase_text,
+    _progress_status_text,
+    cli_progress_line,
 )
 from cadgen.coordination.lock import exclusive
 from cadgen.coordination.paths import write_lock_path
@@ -128,96 +135,14 @@ class _CliTargetSpec:
     output_path: Path | None = None
 
 
-class InlineProgressLine:
-    """A single self-erasing progress line for one model's build.
-
-    Repaints in place with ``\\r`` and erases itself when the build ends, so the only
-    durable output is still the logger's own lines -- the bar is transient status, not
-    a log record. Disabled (and completely silent) when the stream is not a tty: a
-    redirected log wants the logger's lines, not a bar smeared over hundreds of writes.
-
-    Goes to STDERR, with the rest of the narration. A sibling class used to paint a
-    persistent per-model board on STDOUT with cursor-movement escapes, for callers that ran
-    without a logger; there were none, and stdout is the CLIs' result channel."""
-
-    def __init__(self, *, stream: TextIO | None = None, enabled: bool = True) -> None:
-        self._stream = stream if stream is not None else sys.stderr
-        self._enabled = bool(enabled) and getattr(self._stream, "isatty", lambda: False)()
-        self._width = 0
-
-    def update(self, text: str) -> None:
-        if not self._enabled:
-            return
-        # Pad to the previous width so a shorter line cannot leave the tail of a longer
-        # one behind it.
-        padding = max(0, self._width - len(text))
-        self._width = len(text)
-        print(f"\r{text}{' ' * padding}", end="", file=self._stream, flush=True)
-
-    def clear(self) -> None:
-        if not self._enabled or not self._width:
-            return
-        print(f"\r{' ' * self._width}\r", end="", file=self._stream, flush=True)
-        self._width = 0
-
-
-@contextlib.contextmanager
-def cli_progress_line(
-    label: str,
-    *,
-    logger: CliLogger,
-    fallback: str,
-) -> Iterator[Callable[[ProgressEvent], None] | None]:
-    """The same one-line build progress `gen` paints, for any caller with a label.
-
-    `scripts/artifact` builds exactly what `scripts/gen` builds and reported nothing while
-    doing it -- the sidecar record went to the viewer, and a terminal caller watched a
-    silent process. Sharing this is what stops the two disagreeing about whether a build is
-    worth narrating."""
-    if logger.verbose:
-        yield None
-        return
-    line = InlineProgressLine(stream=logger.stream)
-
-    def paint(event: ProgressEvent) -> None:
-        if event.finished:
-            return
-        line.update(f"{label}  {_progress_status_text(event, fallback=fallback)}")
-
-    try:
-        yield paint
-    finally:
-        line.clear()
-
-
-@contextlib.contextmanager
 def _cli_progress_line(
     spec: EntrySpec,
     *,
     logger: CliLogger,
     fallback: str,
-) -> Iterator[Callable[[ProgressEvent], None] | None]:
-    """Yield a progress sink that paints ``spec``'s build onto one tty line.
-
-    Yields None -- reporting nothing -- under ``--verbose``, where the logger is already
-    narrating every stage and a bar repainting between its lines would fight with them.
-    The sidecar is written regardless, so an open CAD Viewer still tracks the build."""
-    if logger.verbose:
-        yield None
-        return
-    line = InlineProgressLine(stream=logger.stream)
-
-    def paint(event: ProgressEvent) -> None:
-        # The terminal event exists to record the run's stage times in the sidecar;
-        # painting it would flash a completed bar onto a line about to be erased.
-        if event.finished:
-            return
-        line.update(f"{spec.source_ref}  {_progress_status_text(event, fallback=fallback)}")
-
-    try:
-        yield paint
-    finally:
-        line.clear()
+) -> "contextlib.AbstractContextManager[Callable[[ProgressEvent], None] | None]":
+    """:func:`cli_progress_line` keyed to a spec's source ref."""
+    return cli_progress_line(spec.source_ref, logger=logger, fallback=fallback)
 
 
 def _display_name_for_path(path: Path) -> str:
@@ -963,19 +888,45 @@ def run_script_generator(
         raise RuntimeError(f"Unsupported generator: {generator_name}")
     if spec.script_path is None or spec.generator_metadata is None:
         raise ValueError(f"{spec.source_ref} is not a generated Python CAD source")
-    # Opaque by nature: the generator is arbitrary user code with no unit of work to
-    # count, so this reports a phase, not a fraction. Readers estimate it against the
-    # duration the model's previous build recorded.
-    resolve_progress(progress).phase(PHASE_GENERATE)
-    with _track_spec_generation(spec, generator_name, intent=lock_intent, logger=logger):
-        return _run_script_generator_inner(
-            spec,
-            generator_name,
-            logger=logger,
-            force=force,
-            reset_runtime_closure=reset_runtime_closure,
-            progress=progress,
-        )
+    # A WRITER arrives with the BuildRun that already owns this model's status record and
+    # its progress line. An EXPORT arrives with neither: it takes the generator lock instead
+    # of the write lock, and until that lock carried a reporter, `cad export` ran the same
+    # multi-minute gen_step() a build runs and said nothing on any surface. So the run the
+    # lock yields becomes the reporter when nobody above us is one.
+    owns_reporting = progress is None
+    with _generator_progress_line(spec, logger=logger, active=owns_reporting) as sink:
+        with _track_spec_generation(
+            spec, generator_name, intent=lock_intent, logger=logger, sink=sink
+        ) as generator_run:
+            active = generator_run if owns_reporting else progress
+            # The phase opens INSIDE the lock: before this it opened first, so a run queued
+            # behind a peer reported "building geometry" for the whole time it was waiting.
+            resolve_progress(active).phase(PHASE_GENERATE)
+            return _run_script_generator_inner(
+                spec,
+                generator_name,
+                logger=logger,
+                force=force,
+                reset_runtime_closure=reset_runtime_closure,
+                progress=active,
+            )
+
+
+@contextlib.contextmanager
+def _generator_progress_line(
+    spec: EntrySpec, *, logger: CliLogger | None, active: bool
+) -> Iterator[Callable[[ProgressEvent], None] | None]:
+    """The terminal line for a generator run that owns its own reporting.
+
+    Inactive when a build above us already paints one — two painters on one tty interleave
+    into nonsense — and when there is no logger to paint through."""
+    if not active:
+        yield None
+        return
+    with cli_progress_line(
+        spec.source_ref, logger=logger or CliLogger("cad"), fallback="Building..."
+    ) as sink:
+        yield sink
 
 
 def _run_script_generator_inner(
@@ -1001,7 +952,12 @@ def _run_script_generator_inner(
         generator = getattr(module, generator_name, None)
         if not callable(generator):
             raise RuntimeError(f"{_display_path(spec.script_path)} does not define callable {generator_name}()")
-        with logger.timed(f"run {generator_name} {spec.source_ref}"):
+        # Bind the lock holder as the ambient reporter for the generator's own code. This is
+        # the in-process twin of `run_node_builder`, which lets a Node child describe its
+        # work over a pipe: gen_step() takes no arguments and so cannot be handed the run,
+        # and without this the longest phase of most builds reports nothing at all. Silent
+        # generators are unaffected -- nothing reads the binding unless they ask for it.
+        with logger.timed(f"run {generator_name} {spec.source_ref}"), reporting_as(progress):
             raw_payload = generator()
 
     source_closure: PythonSourceClosure | None = None
@@ -1797,6 +1753,7 @@ def _track_spec_generation(
     *,
     intent: str = "write",
     logger: CliLogger | None = None,
+    sink: Callable[[ProgressEvent], None] | None = None,
 ) -> contextlib.AbstractContextManager[object]:
     """Coordinate a generator run against the model's render package.
 
@@ -1819,8 +1776,21 @@ def _track_spec_generation(
         return contextlib.nullcontext()
     on_wait = lock_wait_notice(logger, spec.source_ref)
     if intent == "generate":
-        return generator_busy(STEP_PACKAGE, output_dir, on_wait=on_wait)
-    return exclusive(write_lock_path(output_dir), on_wait=on_wait)
+        # The kind decides which phase set the run reports over, so a drawing generator
+        # counts its own phases rather than a STEP package's.
+        kind = DRAWING_PACKAGE if generator_name == "gen_dxf" else STEP_PACKAGE
+        return generator_busy(kind, output_dir, on_wait=on_wait, sink=sink)
+    # A writer already has its BuildRun from artifact_build; this only needs the lock, and
+    # yields None so the caller's `progress or this` choice stays a simple one.
+    return _write_lock_without_reporting(write_lock_path(output_dir), on_wait=on_wait)
+
+
+@contextlib.contextmanager
+def _write_lock_without_reporting(
+    path: Path, *, on_wait: Callable[[float], None] | None
+) -> Iterator[None]:
+    with exclusive(path, on_wait=on_wait):
+        yield None
 
 
 def _run_with_spec_generation_status(
@@ -1859,21 +1829,6 @@ def _run_with_spec_generation_status(
         if run.skipped:
             return _SkippedGeneration(spec)
         return action(spec, run)
-
-
-def _progress_status_text(event: ProgressEvent, *, fallback: str) -> str:
-    """One status-board row for a build in flight.
-
-    A determinate phase reports its real count (``31/50``); an opaque one reports only
-    which phase is running, with the bar sitting wherever the phase weighting puts it.
-    Nothing here invents a denominator the build does not have."""
-    if event.finished:
-        return fallback
-    label = (event.label or fallback).lower()
-    bar = f"{render_progress_bar(event.ratio)} {int(event.ratio * 100):>3d}%"
-    if event.determinate and event.total:
-        return f"{bar}  {label} {event.done}/{event.total}"
-    return f"{bar}  {label}"
 
 
 def _run_selected_specs(

--- a/packages/cadgen/src/cadgen/_internal/node_runtime.py
+++ b/packages/cadgen/src/cadgen/_internal/node_runtime.py
@@ -225,6 +225,12 @@ def _dispatch(message: Mapping[str, Any], run: Any) -> bool:
         detail = message.get("detail")
         run.advance(int(count), detail=str(detail) if isinstance(detail, str) else None)
         return True
+    if kind == "detail":
+        detail = message.get("detail")
+        if not isinstance(detail, str):
+            return False
+        run.detail(detail)
+        return True
     return False
 
 
@@ -278,6 +284,7 @@ def run_node_builder(
     ``{"type":"phase","phase":"sample","total":96|null}``        ``run.phase(phase, total=total)``
     ``{"type":"total","total":973214}``                          ``run.set_total(total)``
     ``{"type":"advance","n":1,"detail":"slice 12/96"}``          ``run.advance(n, detail=detail)``
+    ``{"type":"detail","detail":"welding seams"}``               ``run.detail(detail)``
     ``{"type":"result","ok":true,...}``                          becomes the return value
     ==========================================================  ==================================
 

--- a/packages/cadgen/src/cadgen/cli_progress.py
+++ b/packages/cadgen/src/cadgen/cli_progress.py
@@ -1,0 +1,152 @@
+"""Painting a build's phases onto a terminal.
+
+Separate from the code that RUNS builds on purpose. This is imported by the snapshot CLI,
+which is pinned by tests/python/skills/cad/snapshot/test_cli.py to import no heavy CAD
+modules at all -- and while these few hundred lines lived in ``_internal/generation``,
+reaching for a progress line dragged OCP and build123d in behind it.
+
+Nothing here knows what a build is. It renders :class:`ProgressEvent`s, which is why the
+same painter serves a STEP package, a drawing, an export and a snapshot render.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from typing import Callable, Iterator, TextIO
+
+from cadgen.cli_logging import CliLogger
+from cadgen.coordination import ProgressEvent, render_progress_bar
+
+
+class InlineProgressLine:
+    """The transient bottom line of a model's build, plus the finished lines above it.
+
+    ``update`` repaints in place with ``\\r``; ``commit`` freezes the current line with a
+    newline and starts a fresh one below it. That pairing is what makes the build read as a
+    sequence: each phase is live while it runs and then settles into a durable line with its
+    duration, instead of one line mutating through four phases and erasing the evidence.
+
+    Disabled (and completely silent) when the stream is not a tty: a redirected log wants the
+    logger's lines, not a bar smeared over hundreds of writes.
+
+    Goes to STDERR, with the rest of the narration. A sibling class used to paint a
+    persistent per-model board on STDOUT with cursor-movement escapes, for callers that ran
+    without a logger; there were none, and stdout is the CLIs' result channel."""
+
+    def __init__(self, *, stream: TextIO | None = None, enabled: bool = True) -> None:
+        self._stream = stream if stream is not None else sys.stderr
+        self._enabled = bool(enabled) and getattr(self._stream, "isatty", lambda: False)()
+        self._width = 0
+
+    def update(self, text: str) -> None:
+        if not self._enabled:
+            return
+        # Pad to the previous width so a shorter line cannot leave the tail of a longer
+        # one behind it.
+        padding = max(0, self._width - len(text))
+        self._width = len(text)
+        print(f"\r{text}{' ' * padding}", end="", file=self._stream, flush=True)
+
+    def commit(self, text: str) -> None:
+        """Freeze ``text`` as a durable line and start a fresh transient one below it."""
+        if not self._enabled:
+            return
+        padding = max(0, self._width - len(text))
+        print(f"\r{text}{' ' * padding}", file=self._stream, flush=True)
+        self._width = 0
+
+    def clear(self) -> None:
+        if not self._enabled or not self._width:
+            return
+        print(f"\r{' ' * self._width}\r", end="", file=self._stream, flush=True)
+        self._width = 0
+
+
+@contextlib.contextmanager
+def cli_progress_line(
+    label: str,
+    *,
+    logger: CliLogger,
+    fallback: str,
+) -> Iterator[Callable[[ProgressEvent], None] | None]:
+    """Paint a build as a sequence of phases: one durable line each, live one at the bottom.
+
+    Yields None -- reporting nothing -- under ``--verbose``, where the logger is already
+    narrating every stage and a bar repainting between its lines would fight with them. The
+    status record is written regardless, so an open CAD Viewer still tracks the build.
+
+    `scripts/artifact` builds exactly what `scripts/gen` builds and reported nothing while
+    doing it -- the record went to the viewer, and a terminal caller watched a silent
+    process. Sharing this is what stops the two disagreeing about whether a build is worth
+    narrating."""
+    if logger.verbose:
+        yield None
+        return
+    line = InlineProgressLine(stream=logger.stream)
+    # The phase currently on the live line: its name, its human label, and the wall clock at
+    # which it started. Kept here rather than read back off the event because the event that
+    # ENDS a phase is the one that opens the next, and its own start time is the boundary.
+    state = {"phase": "", "label": "", "started": 0.0, "header": False}
+
+    def paint(event: ProgressEvent) -> None:
+        if not state["header"]:
+            line.commit(label)
+            state["header"] = True
+        if event.phase != state["phase"]:
+            if state["phase"] and state["started"]:
+                line.commit(
+                    _finished_phase_text(
+                        str(state["label"]) or fallback,
+                        event.phase_started_at_ms - float(state["started"]),
+                    )
+                )
+            state.update(
+                phase=event.phase, label=event.label, started=event.phase_started_at_ms
+            )
+        # The terminal event's only job here was to close the last phase's line, just done.
+        if event.finished:
+            return
+        line.update(f"    {_progress_status_text(event, fallback=fallback)}")
+
+    try:
+        yield paint
+    finally:
+        line.clear()
+
+
+def _format_elapsed(elapsed_ms: float) -> str:
+    """A duration a human reads at a glance: ``259ms``, ``1.1s``, ``10m03s``."""
+    milliseconds = max(0.0, float(elapsed_ms))
+    seconds = milliseconds / 1000.0
+    if seconds < 1.0:
+        return f"{int(round(milliseconds))}ms"
+    if seconds < 60.0:
+        return f"{seconds:.1f}s"
+    minutes, remainder = divmod(int(round(seconds)), 60)
+    return f"{minutes}m{remainder:02d}s"
+
+
+def _finished_phase_text(label: str, elapsed_ms: float) -> str:
+    """The durable line a phase leaves behind once it ends."""
+    return f"  ✓ {label.lower():<26}{_format_elapsed(elapsed_ms):>9}"
+
+
+def _progress_status_text(event: ProgressEvent, *, fallback: str) -> str:
+    """The live line for the phase in flight.
+
+    A phase that can count gets a bar and its real count (``312/1127``). One that cannot
+    gets its label and, when it knows, the sub-unit it is working on -- which is a true
+    statement about now, where a percentage would have been a guess about the end. Nothing
+    here invents a denominator the build does not have."""
+    if event.finished:
+        return fallback
+    text = (event.label or fallback).lower()
+    fraction = event.fraction
+    if fraction is not None:
+        text = f"{text}  {render_progress_bar(fraction)}  {event.done}/{event.total}"
+    if event.detail:
+        text = f"{text}  {event.detail}"
+    return text
+
+

--- a/packages/cadgen/src/cadgen/coordination/__init__.py
+++ b/packages/cadgen/src/cadgen/coordination/__init__.py
@@ -23,9 +23,10 @@ Producer::
                         force=force) as run:
         if run.skipped:                 # is_current() re-evaluated UNDER the lock
             return existing_payload()
-        run.phase(PHASE_GENERATE)
-        ...
-        run.advance()
+        run.phase(PHASE_COMPONENTS, total=len(work))  # a phase that can count
+        run.advance(detail=name)
+        run.phase(PHASE_GENERATE)                     # a phase that cannot
+        run.detail("airframe")
 
 Reader::
 
@@ -38,6 +39,7 @@ Reader::
 from __future__ import annotations
 
 import contextlib
+import contextvars
 import os
 import time
 import warnings
@@ -49,6 +51,9 @@ from cadgen.coordination import record as _record
 from cadgen.coordination.kinds import (
     DRAWING_PACKAGE,
     IMPLICIT_PACKAGE,
+    PHASE_BROWSER,
+    PHASE_RENDER,
+    SNAPSHOT,
     STEP_PACKAGE,
     ArtifactKind,
 )
@@ -77,16 +82,19 @@ from cadgen.coordination.phases import (
     PHASE_PACKAGE,
     ProgressEvent,
     ProgressReporter,
-    phase_weights_from_stage_ms,
     render_progress_bar,
     resolve,
 )
 
 __all__ = [
     "ArtifactKind",
+    "BuildRun",
     "Contended",
     "DRAWING_PACKAGE",
     "IMPLICIT_PACKAGE",
+    "PHASE_BROWSER",
+    "PHASE_RENDER",
+    "SNAPSHOT",
     "NULL_PROGRESS",
     "PHASE_COMPONENTS",
     "PHASE_DONE",
@@ -103,11 +111,12 @@ __all__ = [
     "STATE_IDLE",
     "STATE_WRITING",
     "artifact_build",
+    "current_build",
     "generator_busy",
     "generator_lock_path",
     "generator_status_path",
-    "phase_weights_from_stage_ms",
     "render_progress_bar",
+    "reporting_as",
     "require_write_lock",
     "resolve",
     "snapshot",
@@ -169,7 +178,15 @@ def snapshot(output_dir: Path | str) -> Snapshot:
 
     generator_probe = probe(generator_lock_path(output_dir))
     if generator_probe.held:
-        return Snapshot(state=STATE_BUSY, run_id=read_run_id(generator_lock_path(output_dir)))
+        # A busy generator reports its phases too (an export runs the same gen_step a build
+        # does). Its record is a DIFFERENT file from the writer's, and attribution works the
+        # same way: only the run holding this sentinel may be rendered.
+        run_id = read_run_id(generator_lock_path(output_dir))
+        return Snapshot(
+            state=STATE_BUSY,
+            run_id=run_id,
+            progress=_record.progress_for_run(generator_status_path(output_dir), run_id),
+        )
 
     return Snapshot(
         state=STATE_IDLE,
@@ -209,8 +226,49 @@ class BuildRun:
     def advance(self, count: int = 1, *, detail: str | None = None) -> None:
         self._reporter.advance(count, detail=detail)
 
+    def detail(self, text: str) -> None:
+        self._reporter.detail(text)
+
     def stage_ms_snapshot(self) -> dict[str, float]:
         return self._reporter.stage_ms_snapshot()
+
+
+# The run whose lock is held on this thread, for code that is too far from `artifact_build`
+# to be handed it. `run_node_builder` solves the same problem across a PIPE -- the Node
+# child describes its work and the holder publishes it -- and this is the in-process twin:
+# a generator's `gen_step()` is called with no arguments and cannot be given the BuildRun,
+# so it looks the run up instead. A ContextVar rather than a global because the viewer's
+# warm worker is long-lived and must never leak one build's reporter into another's.
+_CURRENT_BUILD: contextvars.ContextVar[BuildRun | None] = contextvars.ContextVar(
+    "cadgen_current_build", default=None
+)
+
+
+def current_build() -> BuildRun | None:
+    """The :class:`BuildRun` reporting for the work on this thread, or None outside a build.
+
+    Callers report through it and must never assume it exists: the same generator runs under
+    the CLI, the viewer's worker, a test harness, and a plain `python model.step.py`.
+    """
+    return _CURRENT_BUILD.get()
+
+
+@contextlib.contextmanager
+def reporting_as(run: BuildRun | None) -> Iterator[None]:
+    """Make ``run`` the :func:`current_build` for the duration of the block.
+
+    Nested binds are IGNORED: a model that composes child generators would otherwise have
+    the child's loop retarget the parent's phase, and the outermost loop is the one whose
+    count means anything to a reader.
+    """
+    if run is None or _CURRENT_BUILD.get() is not None:
+        yield
+        return
+    token = _CURRENT_BUILD.set(run)
+    try:
+        yield
+    finally:
+        _CURRENT_BUILD.reset(token)
 
 
 @contextlib.contextmanager
@@ -302,17 +360,10 @@ def artifact_build(
                 ),
             )
 
-        # Read the PREVIOUS run's measured stage times BEFORE publishing anything. The
-        # `starting` record carries stageMs: None (it is not a `done` outcome), so publishing
-        # first overwrites the very record this reads -- every build then fell back to the
-        # default phase split and the learned weighting was dead on arrival.
-        learned_stage_ms = _record.read_stage_ms(target)
-
         _publish(_record.OUTCOME_RUNNING)
 
         reporter = ProgressReporter(
             sinks=[s for s in (lambda e: _publish(None, e), sink) if s is not None],
-            stage_ms=learned_stage_ms,
             phases=kind.phases,
             labels=kind.labels,
         )
@@ -340,14 +391,12 @@ def _terminal_event(reporter: ProgressReporter) -> ProgressEvent:
     return ProgressEvent(
         phase=PHASE_DONE,
         label=PHASE_LABELS[PHASE_DONE],
+        index=0,
+        count=0,
         done=0,
         total=None,
         determinate=False,
-        ratio=1.0,
-        ratio_floor=1.0,
-        ratio_ceiling=1.0,
         phase_started_at_ms=time.time() * 1000.0,
-        phase_expected_ms=None,
         elapsed_ms=0.0,
         stage_ms=reporter.stage_ms_snapshot(),
     )
@@ -393,7 +442,8 @@ def generator_busy(
     *,
     deadline_ms: float | None = None,
     on_wait: Callable[[float], None] | None = None,
-) -> Iterator[str | None]:
+    sink: Callable[[ProgressEvent], None] | None = None,
+) -> Iterator[BuildRun | None]:
     """Occupy an artifact's GENERATOR without claiming to rewrite its package.
 
     An export runs the model's ``gen_step()`` for a minute and writes a file somewhere else
@@ -408,10 +458,16 @@ def generator_busy(
     What it buys is a state a reader can distinguish: a busy generator does not hide the
     package on disk, and a writer does.
 
-    Its record goes to :func:`generator_status_path`, NOT to the writer's record. Sharing
-    one file let this run stomp a live build's progress and erase the stage times the next
-    build weights its bar from -- and the two runs cannot exclude each other, so there was
-    no lock that would have prevented it.
+    Its record goes to :func:`generator_status_path`, NOT to the writer's record. Sharing one
+    file let this run stomp a live build's progress -- and the two runs cannot exclude each
+    other, so there was no lock that would have prevented it.
+
+    Yields a :class:`BuildRun`, exactly as :func:`artifact_build` does, so the work under it
+    reports through the same phases. This run does the SAME ``gen_step()`` a build does -- for
+    a large assembly that is minutes -- and it used to report nothing at all to either
+    surface, because it had no reporter to report through. The only thing that differs is
+    where the record lands, and what a reader is entitled to conclude from it: an occupied
+    generator does not hide the package on disk.
     """
     if output_dir is None:
         yield None
@@ -421,7 +477,12 @@ def generator_busy(
     with exclusive(
         generator_lock_path(output_dir), deadline_ms=deadline_ms, on_wait=on_wait
     ) as run_id:
-        if run_id is not None:
+        if run_id is None:
+            # Degraded locking. Still report: a bar with no mutual exclusion beats no bar,
+            # and the reader surfaces `degraded` separately.
+            run_id = new_run_id()
+
+        def _publish(outcome: str | None, event: ProgressEvent | None = None) -> None:
             _record.write_record(
                 target,
                 _record.build_record(
@@ -429,20 +490,27 @@ def generator_busy(
                     kind=kind.name,
                     intent=_record.INTENT_GENERATE,
                     started_at_ms=started_at_ms,
-                    outcome=_record.OUTCOME_RUNNING,
+                    outcome=outcome,
+                    progress=event.progress_payload() if event is not None else None,
+                    stage_ms=(
+                        event.stage_ms
+                        if (event is not None and outcome == _record.OUTCOME_DONE)
+                        else None
+                    ),
                 ),
             )
+
+        _publish(_record.OUTCOME_RUNNING)
+        reporter = ProgressReporter(
+            sinks=[s for s in (lambda e: _publish(None, e), sink) if s is not None],
+            phases=kind.phases,
+            labels=kind.labels,
+        )
+        run = BuildRun(reporter, run_id)
         try:
-            yield run_id
-        finally:
-            if run_id is not None:
-                _record.write_record(
-                    target,
-                    _record.build_record(
-                        run_id=run_id,
-                        kind=kind.name,
-                        intent=_record.INTENT_GENERATE,
-                        started_at_ms=started_at_ms,
-                        outcome=_record.OUTCOME_DONE,
-                    ),
-                )
+            yield run
+        except BaseException:
+            _publish(_record.OUTCOME_FAILED)
+            raise
+        reporter.finish()
+        _publish(_record.OUTCOME_DONE, _terminal_event(reporter))

--- a/packages/cadgen/src/cadgen/coordination/kinds.py
+++ b/packages/cadgen/src/cadgen/coordination/kinds.py
@@ -83,6 +83,24 @@ IMPLICIT_PACKAGE = ArtifactKind(
     },
 )
 
+# A snapshot render. Not a coordinated artifact -- it takes no lock and writes no status
+# record, because it produces an image, not a package another process might read half-built.
+# It is a kind anyway so its CLI reports through the same phase model as everything else;
+# before this it had a second, unrelated progress implementation of its own.
+#
+# Note what is NOT a phase here: resolving the input. That step builds the STEP/drawing
+# package when the model is cold, which is the slowest part of a whole snapshot -- and that
+# build reports its OWN phases through artifact_build. Declaring a `resolve` phase here would
+# put two painters on one terminal and replace the build's detail with the word "resolving".
+PHASE_BROWSER = "browser"
+PHASE_RENDER = "render"
+
+SNAPSHOT = ArtifactKind(
+    name="snapshot",
+    phases=(PHASE_BROWSER, PHASE_RENDER),
+    labels={PHASE_BROWSER: "Starting browser", PHASE_RENDER: "Rendering"},
+)
+
 # An export (STEP/STL/3MF/GLB/DXF) writes no package -- it occupies the model's GENERATOR
 # and writes a file elsewhere -- so it is coordinated with generator_busy() against the
 # model's own kind rather than being a kind of its own. Add one here when something needs

--- a/packages/cadgen/src/cadgen/coordination/phases.py
+++ b/packages/cadgen/src/cadgen/coordination/phases.py
@@ -1,34 +1,33 @@
-"""Phase model and progress accounting for one artifact build.
+"""Phase model for one artifact build.
 
-A build has stages that cost real time, and only one of them has a denominator known before
-the work starts:
+A build runs an ordered set of phases and reports EACH ONE SEPARATELY. There is no global
+percentage, because there is no honest way to compute one. Measured across this repo's own
+models, ``generate`` is 11% of one build and 84% of another, so a single bar spanning every
+phase is a guess wearing a measurement's clothes -- and on a FIRST build, where nothing
+about the model has been measured yet, it is a guess with no inputs at all. That is what
+pinned a ten-minute F-14 ``generate`` phase at exactly 0% and then jumped it straight to
+46% the instant the phase ended.
 
-* ``generate`` -- running the model's ``gen_step()`` (or parsing an imported STEP).
-  Arbitrary user code; there is no unit of work to count.
-* ``package`` -- walking the composed compound, serializing each leaf's BREP and
-  content-hashing it. Countable only as it goes: the leaf count is not known until the
-  walk ends.
-* ``components`` -- meshing + selector-extracting every component GLB not already in the
-  package's content-addressed cache. The work list is built in full before the first mesh
-  runs, so ``done``/``total`` here is MEASURED, not estimated -- and this is where most of
-  a slow build's time goes.
-* ``finalize`` -- descriptor write + orphan prune. Fast.
+What a phase can honestly say is one of two things:
 
-So the honest report is an exact count during ``components`` and a phase label for the
-opaque stages. Every event also carries ``ratioFloor``/``ratioCeiling`` and the phase's
-expected duration, so a reader that polls -- the CAD Viewer -- can interpolate an
-indeterminate stage against the wall clock without the build having to say anything while
-it is busy.
+* a real FRACTION -- ``done``/``total`` -- when the work list is known. Meshing components
+  builds its work list in full before the first mesh runs, so it reports ``312/1127``.
+* a LABEL -- the name of the sub-unit in flight ("airframe") -- when it is not. A generator
+  walking an assembly's systems knows what it is working on even when it cannot say how
+  much is left, and the leaf walk that packages a compound knows which leaf it is on.
 
-**Events are emitted at work boundaries, never from a timer.** A heartbeat thread is
-precisely what the generation lock had to stop relying on: OCP meshing holds the GIL inside
-C for long stretches, so a heartbeat starves during exactly the work it is meant to be
-reporting. Readers interpolate instead.
+Both are true statements about the present, and neither extrapolates. A reader renders them
+differently: a fraction becomes a bar, a label becomes an indeterminate bar naming the
+sub-unit.
+
+**Events are emitted at work boundaries, never from a timer.** OCP meshing holds the GIL
+inside C for long stretches, so a heartbeat thread starves during exactly the work it is
+meant to be reporting. A phase that cannot count says what it is DOING instead -- which is
+information no timer could have produced anyway.
 """
 
 from __future__ import annotations
 
-import math
 import time
 from dataclasses import dataclass
 from typing import Callable, Mapping, Sequence
@@ -37,8 +36,8 @@ PHASE_GENERATE = "generate"
 PHASE_PACKAGE = "package"
 PHASE_COMPONENTS = "components"
 PHASE_FINALIZE = "finalize"
-# Terminal marker. Not a phase with a weight -- it means "this record describes a finished
-# run", and a reader must never render it as an in-flight build.
+# Terminal marker. Not a phase -- it means "this record describes a finished run", and a
+# reader must never render it as an in-flight build.
 PHASE_DONE = "done"
 
 PHASE_ORDER = (PHASE_GENERATE, PHASE_PACKAGE, PHASE_COMPONENTS, PHASE_FINALIZE)
@@ -51,68 +50,17 @@ PHASE_LABELS = {
     PHASE_DONE: "Done",
 }
 
-# Fallback split, used only for an artifact that has never recorded a build. Rough by
-# definition; the first completed build replaces it with this artifact's real times.
-DEFAULT_PHASE_WEIGHTS = {
-    PHASE_GENERATE: 0.34,
-    PHASE_PACKAGE: 0.12,
-    PHASE_COMPONENTS: 0.50,
-    PHASE_FINALIZE: 0.04,
-}
-# Floor on any learned weight: a stage that was instant last time (every component cached,
-# say) must still leave the bar somewhere to go if it is slow this time.
-MIN_PHASE_WEIGHT = 0.02
-# An indeterminate phase never fills its whole band -- reaching 100% of a stage whose end we
-# cannot see would be a lie, and leaves nothing for the handoff.
-INDETERMINATE_PHASE_CEILING = 0.95
-# Floor between record writes / status repaints for INDETERMINATE ticks, so the per-leaf
-# walk of a large assembly cannot spend the build's time on reporting. Determinate ticks
-# (see ProgressReporter.advance) bypass it.
+# Floor between record writes / status repaints for ticks that carry no count, so the
+# per-leaf walk of a large assembly cannot spend the build's time on reporting. Ticks that
+# move a real fraction (see ProgressReporter.advance) bypass it: those are the measured
+# ones and they are coarse -- often seconds apart -- so dropping one to a rate limit would
+# pin a visible count at a stale value for however long the next unit takes.
 MIN_EMIT_INTERVAL_MS = 100.0
-
-
-def phase_weights_from_stage_ms(
-    stage_ms: object, *, phases: Sequence[str] = PHASE_ORDER
-) -> dict[str, float] | None:
-    """Phase weights proportional to a previous build's measured stage times.
-
-    An artifact whose generator dominates and one whose meshing dominates need very
-    different splits before one overall bar moves evenly, and the last build of THIS
-    artifact is the best available predictor of the next one. Returns None when there is
-    nothing usable to learn from, leaving :data:`DEFAULT_PHASE_WEIGHTS` in place."""
-    if not isinstance(stage_ms, Mapping):
-        return None
-    values: dict[str, float] = {}
-    for phase in phases:
-        try:
-            value = float(stage_ms.get(phase))  # type: ignore[arg-type]
-        except (TypeError, ValueError):
-            continue
-        if math.isfinite(value) and value >= 0.0:
-            values[phase] = value
-    total = sum(values.values())
-    if len(values) < 2 or total <= 0.0:
-        return None
-    floored = {phase: max(value / total, MIN_PHASE_WEIGHT) for phase, value in values.items()}
-    scale = sum(floored.values())
-    return {phase: weight / scale for phase, weight in floored.items()}
-
-
-def _even_weights(phases: Sequence[str]) -> dict[str, float]:
-    """Fallback split for a kind that has never recorded a build.
-
-    DEFAULT_PHASE_WEIGHTS is the measured-ish split for the STEP phase set; any other
-    phase set gets an even split until its first completed build replaces it with real
-    times."""
-    if tuple(phases) == PHASE_ORDER:
-        return dict(DEFAULT_PHASE_WEIGHTS)
-    share = 1.0 / max(1, len(phases))
-    return {phase: share for phase in phases}
 
 
 def render_progress_bar(ratio: float, width: int = 18) -> str:
     """A fixed-width unicode bar. Shared by the CLI sink and its tests so the two cannot
-    disagree about what a given ratio looks like."""
+    disagree about what a given fraction looks like."""
     width = max(1, int(width))
     clamped = min(1.0, max(0.0, float(ratio)))
     filled = int(round(clamped * width))
@@ -121,20 +69,21 @@ def render_progress_bar(ratio: float, width: int = 18) -> str:
 
 @dataclass(frozen=True)
 class ProgressEvent:
-    """One observation of a build's position. ``total`` is None for a phase with no knowable
-    denominator; ``determinate`` says whether ``done``/``total`` is a real count or the
-    phase is being estimated against the clock."""
+    """One observation of a build's position.
+
+    ``index``/``count`` place the phase in the run (phase 2 of 4). ``done``/``total`` is a
+    real fraction when ``determinate``; otherwise ``detail`` names the sub-unit in flight
+    and there is no fraction to show.
+    """
 
     phase: str
     label: str
+    index: int
+    count: int
     done: int
     total: int | None
     determinate: bool
-    ratio: float
-    ratio_floor: float
-    ratio_ceiling: float
     phase_started_at_ms: float
-    phase_expected_ms: float | None
     elapsed_ms: float
     detail: str = ""
     stage_ms: Mapping[str, float] | None = None
@@ -143,23 +92,28 @@ class ProgressEvent:
     def finished(self) -> bool:
         return self.phase == PHASE_DONE
 
+    @property
+    def fraction(self) -> float | None:
+        """This phase's completed share, or None when it has no denominator."""
+        if not self.determinate or not self.total:
+            return None
+        return min(1.0, max(0.0, self.done / float(self.total)))
+
     def progress_payload(self) -> dict[str, object]:
-        """The phase/ratio block of a status record (camelCase -- it is read by the viewer).
+        """The phase block of a status record (camelCase -- it is read by the viewer).
 
         Identity, outcome and stage times are the RECORD's business, not the event's; see
         :func:`cadgen.coordination.record.build_record`."""
         return {
             "phase": self.phase,
             "label": self.label,
+            "index": self.index,
+            "count": self.count,
             "detail": self.detail,
             "done": self.done,
             "total": self.total,
             "determinate": self.determinate,
-            "ratio": round(self.ratio, 4),
-            "ratioFloor": round(self.ratio_floor, 4),
-            "ratioCeiling": round(self.ratio_ceiling, 4),
             "phaseStartedAt": round(self.phase_started_at_ms),
-            "phaseExpectedMs": (round(self.phase_expected_ms) if self.phase_expected_ms else None),
             "elapsedMs": round(self.elapsed_ms),
         }
 
@@ -167,32 +121,25 @@ class ProgressEvent:
 class ProgressReporter:
     """Tracks the current phase and pushes :class:`ProgressEvent`s to its sinks.
 
-    ``stage_ms`` is the previous build's measured per-phase durations: it both weights the
-    overall bar and supplies the expected duration an indeterminate phase is interpolated
-    against. A reporter with no sinks is inert bookkeeping, which is what makes the
-    no-progress call paths free of branching."""
+    A reporter with no sinks is inert bookkeeping, which is what keeps the no-progress call
+    paths free of branching.
+    """
 
     def __init__(
         self,
         *,
         sinks: Sequence[Callable[[ProgressEvent], None]] = (),
-        stage_ms: Mapping[str, float] | None = None,
         clock: Callable[[], float] = time.monotonic,
         phases: Sequence[str] = PHASE_ORDER,
         labels: Mapping[str, str] | None = None,
     ) -> None:
         self._sinks = [sink for sink in sinks if sink is not None]
         self._clock = clock
-        self._expected = dict(stage_ms or {})
-        # An artifact kind declares the phases it actually has. A DXF drawing has no
-        # meshing stage, so weighting its bar over the STEP phase set left half the bar
-        # reserved for work that never happens and the drawing appeared to stall at ~46%.
+        # An artifact kind declares the phases it actually has, so "phase 2 of 4" counts
+        # the phases this kind runs rather than some global set.
         self._phases = tuple(phases) or PHASE_ORDER
         # Shared vocabulary, overridden by whatever this kind introduces.
         self._labels = {**PHASE_LABELS, **(labels or {})}
-        self._weights = phase_weights_from_stage_ms(stage_ms, phases=self._phases) or _even_weights(
-            self._phases
-        )
         self._started = clock()
         self._phase = ""
         self._phase_started = self._started
@@ -200,7 +147,6 @@ class ProgressReporter:
         self._done = 0
         self._total: int | None = None
         self._detail = ""
-        self._ratio = 0.0
         self._stage_ms: dict[str, float] = {}
         self._last_emit = 0.0
         self._finished = False
@@ -221,7 +167,7 @@ class ProgressReporter:
         self._emit(force=True)
 
     def set_total(self, total: int | None) -> None:
-        """Supply a denominator discovered mid-phase (a walk that has just ended)."""
+        """Supply a denominator discovered mid-phase (a work list just built)."""
         if self._finished:
             return
         self._total = total
@@ -234,22 +180,33 @@ class ProgressReporter:
         self._done += count
         if detail is not None:
             self._detail = detail
-        # Every tick of a DETERMINATE phase reports, unthrottled. Those ticks are the
-        # measured ones and they are coarse -- one per component GLB, often seconds apart --
-        # so dropping one to a rate limit would pin a visible count at a stale value for
-        # however long the next component takes. Only the indeterminate walk, which ticks
-        # once per assembly leaf, is throttled.
         self._emit(force=self._determinate())
 
+    def detail(self, text: str) -> None:
+        """Name the sub-unit now in flight, without claiming any fraction.
+
+        A CHANGED label is published immediately; only a repeat of the one already showing
+        is throttled. Rate-limiting a change would defeat the point of the call: the first
+        label of a phase lands microseconds after the ``phase``/``set_total`` that opened it,
+        so a blanket throttle silently swallowed it and the phase then ran for minutes with
+        an empty label -- exactly the silence this exists to end.
+        """
+        if self._finished:
+            return
+        text = str(text or "")
+        changed = text != self._detail
+        self._detail = text
+        self._emit(force=changed)
+
     def finish(self) -> None:
-        """Terminal event: ratio 1.0, ``phase: done``, and the run's measured stage times so
-        the next build of this artifact can weight its bar from them."""
+        """Terminal event: ``phase: done``, plus the run's measured stage times."""
         if self._finished:
             return
         self._close_phase()
         self._finished = True
         self._phase = PHASE_DONE
-        self._ratio = 1.0
+        # Stamped now, so a reader can time the phase that just ended by the difference.
+        self._phase_started_wall_ms = time.time() * 1000.0
         self._done = 0
         self._total = None
         self._detail = ""
@@ -274,32 +231,12 @@ class ProgressReporter:
     def _determinate(self) -> bool:
         return self._total is not None and self._total > 0
 
-    def _bounds(self) -> tuple[float, float]:
-        """The (floor, ceiling) of the current phase's band in the overall bar."""
+    def _position(self) -> tuple[int, int]:
+        """(index, count) of the current phase, 1-based. Index 0 for a phase this kind did
+        not declare -- it still reports, it just has no place in the sequence."""
         if self._phase not in self._phases:
-            return (self._ratio, self._ratio)
-        index = self._phases.index(self._phase)
-        floor = sum(self._weights.get(phase, 0.0) for phase in self._phases[:index])
-        span = self._weights.get(self._phase, 0.0)
-        ceiling = floor + span * (1.0 if self._determinate() else INDETERMINATE_PHASE_CEILING)
-        return (floor, ceiling)
-
-    def _compute_ratio(self, floor: float, ceiling: float) -> float:
-        if self._finished:
-            return 1.0
-        if self._determinate():
-            within = min(1.0, self._done / float(self._total))  # type: ignore[arg-type]
-        else:
-            expected = self._expected.get(self._phase)
-            if expected and expected > 0:
-                elapsed_ms = (self._clock() - self._phase_started) * 1000.0
-                within = min(1.0, elapsed_ms / float(expected))
-            else:
-                within = 0.0
-        # The bar must never go backwards WITHIN a run: a learned weight can be wrong, and a
-        # phase transition that lowered the number would read as a build losing ground.
-        # Across runs the reader resets on a new runId instead.
-        return max(self._ratio, min(1.0, floor + (ceiling - floor) * within))
+            return (0, len(self._phases))
+        return (self._phases.index(self._phase) + 1, len(self._phases))
 
     def _emit(self, *, force: bool = False) -> None:
         if not self._sinks:
@@ -308,19 +245,16 @@ class ProgressReporter:
         if not force and (now_ms - self._last_emit) < MIN_EMIT_INTERVAL_MS:
             return
         self._last_emit = now_ms
-        floor, ceiling = self._bounds()
-        self._ratio = self._compute_ratio(floor, ceiling)
+        index, count = self._position()
         event = ProgressEvent(
             phase=self._phase,
             label=self._labels.get(self._phase, self._phase or ""),
+            index=index,
+            count=count,
             done=self._done,
             total=self._total,
             determinate=self._determinate(),
-            ratio=self._ratio,
-            ratio_floor=floor,
-            ratio_ceiling=ceiling,
             phase_started_at_ms=self._phase_started_wall_ms,
-            phase_expected_ms=self._expected.get(self._phase),
             elapsed_ms=(self._clock() - self._started) * 1000.0,
             detail=self._detail,
             stage_ms=(self.stage_ms_snapshot() if self._finished else None),
@@ -342,6 +276,9 @@ class _NullProgressReporter:
         return None
 
     def advance(self, *args: object, **kwargs: object) -> None:
+        return None
+
+    def detail(self, *args: object, **kwargs: object) -> None:
         return None
 
     def finish(self) -> None:

--- a/packages/cadgen/src/cadgen/coordination/record.py
+++ b/packages/cadgen/src/cadgen/coordination/record.py
@@ -5,19 +5,27 @@ and nothing here. That separation is deliberate: a status file is written data w
 liveness guarantee, and inferring "a build is running" from one reintroduces exactly the
 stale-heartbeat failure the flock replaced.
 
-The record is never unlinked. Its terminal payload carries ``stageMs`` -- the run's measured
-per-phase durations -- which the NEXT build of the same artifact reads to weight its
-progress bar. Unlinking would also race: a reader mid-read would see the file vanish.
+The record is never unlinked. Unlinking would race: a reader mid-read would see the file
+vanish. Its terminal payload carries ``stageMs``, the run's measured per-phase durations --
+kept as a record of what the run cost (the CLI prints it), NOT as an input to anything.
+Nothing predicts the next build from the last one any more; each phase reports itself.
 
-**Run attribution is the point of schema v2.** v1 carried no identity, so a record left
-behind by a SIGKILLed run was indistinguishable from the live one, and any later lock holder
-that never reported progress (an export, say) made the viewer render the corpse's position --
-"Meshing components 31/50" for a run that had meshed nothing -- and then jump backwards when
-a real build finally started. A reader now accepts a record only when its ``runId`` matches
-the run id stamped in the sentinel by the current holder.
+**Run attribution.** A record carries the id of the run that wrote it, because a record left
+behind by a SIGKILLed run is otherwise indistinguishable from the live one: any later lock
+holder that never reported progress (an export, say) made the viewer render the corpse's
+position -- "Meshing components 31/50" for a run that had meshed nothing. A reader accepts a
+record only when its ``runId`` matches the run id stamped in the sentinel by the current
+holder.
 
-``stageMs`` is written ONLY on ``outcome == "done"``, so a failed or killed run cannot teach
-the next build's bar from partial stage times.
+**Schema v3 reports each phase on its own.** v2 carried a global ``ratio`` plus the band
+(``ratioFloor``/``ratioCeiling``) and expectation (``phaseExpectedMs``) a reader needed to
+interpolate one overall bar across every phase. Those are gone: a phase now reports its
+position in the run (``index``/``count``) and either a real fraction (``done``/``total``) or
+a ``detail`` label naming the sub-unit in flight. A reader that does not understand this
+version renders no bar, which is the same safe degradation as an unreadable file.
+
+``stageMs`` is written ONLY on ``outcome == "done"``: partial times from a killed run are
+not durations anyone should print.
 """
 
 from __future__ import annotations
@@ -30,7 +38,7 @@ import time
 from pathlib import Path
 from typing import Any, Mapping
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 OUTCOME_RUNNING = None
 OUTCOME_DONE = "done"
@@ -110,27 +118,6 @@ def read_record(path: Path | str) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
-def read_stage_ms(path: Path | str) -> dict[str, float] | None:
-    """The measured stage times left behind by this artifact's last SUCCESSFUL run.
-
-    A record whose outcome is not ``done`` carries no ``stageMs`` by construction, so a
-    killed run cannot poison the next build's phase weighting.
-    """
-    payload = read_record(path)
-    if payload is None:
-        return None
-    stage_ms = payload.get("stageMs")
-    if not isinstance(stage_ms, dict):
-        return None
-    recorded: dict[str, float] = {}
-    for phase, value in stage_ms.items():
-        try:
-            recorded[str(phase)] = float(value)
-        except (TypeError, ValueError):
-            continue
-    return recorded or None
-
-
 def _as_int(value: Any) -> int:
     try:
         return int(value)
@@ -181,14 +168,12 @@ def progress_for_run(path: Path | str, run_id: str | None) -> dict[str, Any] | N
         "phase": phase,
         "label": str(payload.get("label") or ""),
         "detail": str(payload.get("detail") or ""),
+        "index": _as_int(payload.get("index")),
+        "count": _as_int(payload.get("count")),
         "done": _as_int(payload.get("done")),
         "total": _as_int(total) if total is not None else None,
         "determinate": bool(payload.get("determinate")),
-        "ratio": _as_float(payload.get("ratio")),
-        "ratioFloor": _as_float(payload.get("ratioFloor")),
-        "ratioCeiling": _as_float(payload.get("ratioCeiling")),
         "phaseStartedAt": _as_float(payload.get("phaseStartedAt")),
-        "phaseExpectedMs": _as_float(payload.get("phaseExpectedMs")) or None,
         "updatedAt": _as_float(payload.get("updatedAt")),
         "runId": str(payload.get("runId") or "") or None,
     }

--- a/packages/cadgen/src/cadgen/progress.py
+++ b/packages/cadgen/src/cadgen/progress.py
@@ -1,0 +1,87 @@
+"""What a CAD generator can say about its own progress.
+
+``gen_step()`` is called with no arguments and is usually the longest phase of a build --
+ten minutes for the F-14, against two for meshing everything it produced. Until this module
+it had no way to say anything: the build reported "Building geometry" once, at the start,
+and then went silent until the generator returned. The viewer and the CLI both showed a
+stalled bar for the entire run.
+
+Nothing here is required. A generator that says nothing behaves exactly as it always has,
+and outside a build (a plain ``python model.step.py``, a test) every call is a no-op -- so
+instrumentation costs a generator nothing at import time and never needs guarding.
+
+Two shapes, matching the two things a phase can honestly report::
+
+    from cadgen.progress import report, track
+
+    def gen_step():
+        for name, module in track(SYSTEMS, label=lambda pair: pair[0]):
+            ...                      # -> "Building geometry  4/13  engines"
+
+    def gen_step():
+        report("lofting the skin")   # -> "Building geometry  lofting the skin"
+        ...
+
+:func:`track` gives a real fraction when the work list has a length; :func:`report` names
+the sub-unit in flight when it does not. Neither invents a number.
+
+A caveat worth knowing before reading too much into a count: units are rarely equal in
+cost. The F-14's 13 systems include one airframe loft that is over half the phase, so
+``1/13`` sits for minutes and then several tick past in seconds. The count is true; it is
+just not linear in time, and no reporting layer can make it so.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Iterator, Sized
+
+from cadgen.coordination import current_build
+
+__all__ = ["report", "track"]
+
+
+def report(detail: str) -> None:
+    """Name the part of the model being built right now.
+
+    For a phase with no countable work list. The label replaces whatever was showing; it
+    does not accumulate.
+    """
+    run = current_build()
+    if run is not None:
+        run.detail(str(detail or ""))
+
+
+def _label_for(item: Any, label: Callable[[Any], str] | None) -> str:
+    if label is not None:
+        try:
+            return str(label(item) or "")
+        except Exception:  # noqa: BLE001 - a label must never break a build
+            return ""
+    return item if isinstance(item, str) else ""
+
+
+def track(
+    items: Iterable[Any], *, label: Callable[[Any], str] | None = None
+) -> Iterator[Any]:
+    """Iterate ``items``, reporting the build's way through them.
+
+    The count advances when an item's work is DONE (after the loop body returns), while the
+    label names the item in flight -- so a reader sees "3 finished, now on engines" rather
+    than claiming an item is complete the moment it starts.
+
+    ``items`` is only measured when it already has a length. A lazy iterable is passed
+    through lazily and reported by label alone, because consuming it here to obtain a
+    denominator would change when the caller's work actually runs.
+    """
+    run = current_build()
+    if run is None:
+        yield from items
+        return
+    if isinstance(items, Sized):
+        total = len(items)
+        if total:
+            run.set_total(total)
+    for item in items:
+        run.detail(_label_for(item, label))
+        yield item
+        run.advance()

--- a/packages/cadgen/src/cadgen/snapshot_cli.py
+++ b/packages/cadgen/src/cadgen/snapshot_cli.py
@@ -35,6 +35,9 @@ import cadgen.lookup as lookup
 from cadgen.catalog import render_package_dir
 from cadgen.step_targets import ResolvedStepTarget, StepTopologyArtifact, StepTopologyArtifactError
 
+from cadgen.cli_logging import CliLogger
+from cadgen.coordination import PHASE_BROWSER, SNAPSHOT, ProgressReporter
+from cadgen.cli_progress import cli_progress_line
 from cadgen.snapshot_core import (
     THEME_OPTION_KEYS,
     BatchSnapshotRenderer,
@@ -73,7 +76,6 @@ from cadgen.snapshot_core import (
     SUPPORTED_OUTPUT_KEYS,
     SUPPORTED_RENDER_MODES,
     SnapshotError,
-    SnapshotProgress,
     TOPOLOGY_DISPLAY_MODES,
     WORKBENCH_RENDER_THEME_IDS,
     theme_id_for_job,
@@ -1466,6 +1468,16 @@ def resolve_render_job_packet(
 
 
 
+def snapshot_progress_label(packet: object) -> str:
+    """The header the progress line commits: what this run is rendering."""
+    jobs = packet.get("jobs") if isinstance(packet, dict) else None
+    if not isinstance(jobs, list) or not jobs:
+        return "snapshot"
+    if len(jobs) == 1:
+        return str(jobs[0].get("input") or "snapshot")
+    return f"snapshot ({len(jobs)} jobs)"
+
+
 async def run_render_cli_async(
     argv: Sequence[str],
     *,
@@ -1490,18 +1502,27 @@ async def run_render_cli_async(
     if options.help:
         stdout.write(help_text(kinds=enabled, prog=prog))
         return 0
-    # Resolution is where a STEP or drawing package gets built, and on a cold model that is
-    # the SLOWEST part of a snapshot -- longer than the render. It has to report before it
-    # starts, not after.
-    progress = SnapshotProgress()
     raw_payload = load_job_from_options(options, stdin=stdin, cwd=cwd)
-    progress.phase("resolving input (building render artifacts if needed)")
+    # Resolution is where a STEP or drawing package gets built, and on a cold model that is
+    # the SLOWEST part of a snapshot -- longer than the render. It is deliberately NOT
+    # wrapped in a phase of ours: that build reports its own phases through artifact_build,
+    # and a second painter on the same terminal would both interleave with it and replace
+    # its detail with the single word "resolving".
     packet = resolve_render_job_packet(raw_payload, cwd=cwd, kinds=enabled)
-    progress.phase("starting browser")
-    result = await render_resolved_job_packet(
-        packet, runtime_dir=Path(runtime_dir), progress=progress
-    )
-    progress.clear()
+    logger = CliLogger("snapshot", verbose=False)
+    with cli_progress_line(
+        snapshot_progress_label(packet), logger=logger, fallback="Rendering..."
+    ) as sink:
+        progress = ProgressReporter(
+            sinks=[sink] if sink is not None else (),
+            phases=SNAPSHOT.phases,
+            labels=SNAPSHOT.labels,
+        )
+        progress.phase(PHASE_BROWSER)
+        result = await render_resolved_job_packet(
+            packet, runtime_dir=Path(runtime_dir), progress=progress
+        )
+        progress.finish()
     write_render_outputs(result)
     print_render_result(result, json_output=options.json, stdout=stdout)
     return 0

--- a/packages/cadgen/src/cadgen/snapshot_core.py
+++ b/packages/cadgen/src/cadgen/snapshot_core.py
@@ -32,6 +32,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote, unquote, urlparse
 
+from cadgen.coordination import PHASE_RENDER, resolve as resolve_progress
+
 
 SNAPSHOT_ORIGIN = "http://snapshot.local"
 SNAPSHOT_RENDER_URL = f"{SNAPSHOT_ORIGIN}/render.html"
@@ -858,44 +860,15 @@ class BatchSnapshotRenderer:
         self.page = None
         self.started = False
 # --- progress ----------------------------------------------------------------------
-# A snapshot was silent for its ENTIRE run. On a cold assembly that is an artifact build
-# plus a browser launch plus a render -- tens of seconds of nothing on either stream, which
-# is indistinguishable from a hang. Every other long operation in this repo reports (a
-# generation lock now says why it is waiting; `gen` paints a phase bar), and this did not.
+# A snapshot was silent for its ENTIRE run, then grew a progress class of its own: free-text
+# phases, its own tty handling, its own clear(). Two implementations of one idea, sharing
+# nothing, guaranteed to drift.
 #
-# Same shape as those: a self-erasing line on a tty, and on a non-tty -- an agent's captured
-# log -- one durable line per PHASE CHANGE rather than a bar smeared over hundreds of
-# writes. Never on stdout: stdout is the result.
-class SnapshotProgress:
-    """Reports what a snapshot is doing, to stderr, without becoming part of the result."""
+# It reports through the shared phase model now (SNAPSHOT in coordination/kinds.py). The
+# per-job counter that used to be formatted INTO a phase name ("rendering 3/12 model.step")
+# is a real done/total, so a reader can render it as a bar like any other counted phase --
+# and the CLI line, the tty handling and the non-tty degradation all come from one place.
 
-    __slots__ = ("_stream", "_is_tty", "_width", "_last", "_enabled")
-
-    def __init__(self, stream: Any = None, *, enabled: bool = True) -> None:
-        self._stream = stream if stream is not None else sys.stderr
-        self._is_tty = bool(getattr(self._stream, "isatty", lambda: False)())
-        self._enabled = bool(enabled)
-        self._width = 0
-        self._last = ""
-
-    def phase(self, text: str) -> None:
-        if not self._enabled or text == self._last:
-            return
-        self._last = text
-        if self._is_tty:
-            padding = max(0, self._width - len(text))
-            self._width = len(text)
-            print(f"\r{text}{' ' * padding}", end="", file=self._stream, flush=True)
-        else:
-            print(text, file=self._stream, flush=True)
-
-    def clear(self) -> None:
-        if self._enabled and self._is_tty and self._width:
-            print(f"\r{' ' * self._width}\r", end="", file=self._stream, flush=True)
-        self._width = 0
-
-
-NULL_SNAPSHOT_PROGRESS = SnapshotProgress(enabled=False)
 
 
 async def render_resolved_job_packet(
@@ -903,18 +876,19 @@ async def render_resolved_job_packet(
     *,
     runtime_dir: Path,
     renderer: BatchSnapshotRenderer | None = None,
-    progress: SnapshotProgress | None = None,
+    progress: object | None = None,
 ) -> dict[str, object]:
     snapshot_renderer = renderer or BatchSnapshotRenderer(runtime_dir)
-    report = progress if progress is not None else NULL_SNAPSHOT_PROGRESS
+    report = resolve_progress(progress)
     started = time.perf_counter()
     results: list[dict[str, object]] = []
     total = len(packet["jobs"])
+    # The job list is known in full before the first render, so this is a real count rather
+    # than a number formatted into a phase name. Same shape as meshing components.
+    report.phase(PHASE_RENDER, total=total)
     try:
-        for index, job in enumerate(packet["jobs"], start=1):
-            label = str(job.get("input") or "")
-            counter = f" {index}/{total}" if total > 1 else ""
-            report.phase(f"rendering{counter} {label}".rstrip())
+        for job in packet["jobs"]:
+            report.detail(str(job.get("input") or ""))
             result = await snapshot_renderer.render(job)
             # The browser result knows nothing about artifact resolution; --debug
             # diagnostics are attached at resolve time, so merge them into the
@@ -924,8 +898,8 @@ async def render_resolved_job_packet(
             if is_plain_object(debug_info) and is_plain_object(result):
                 result = {**result, "debug": debug_info}
             results.append(result if packet["single"] else {"input": job.get("input"), **result})
+            report.advance()
     finally:
-        report.clear()
         await snapshot_renderer.close()
     if packet["single"]:
         return results[0]

--- a/packages/cadgen/src/cadgen/step_artifacts.py
+++ b/packages/cadgen/src/cadgen/step_artifacts.py
@@ -1,17 +1,26 @@
 from __future__ import annotations
 
+import contextlib
 import time
 from dataclasses import replace
 from pathlib import Path
+from typing import Iterator
 
 from cadgen.catalog import source_from_path
 from cadgen.cli_logging import CliLogger
-from cadgen.coordination import STEP_PACKAGE, artifact_build
+from cadgen.coordination import (
+    PHASE_GENERATE,
+    STEP_PACKAGE,
+    artifact_build,
+    resolve as resolve_progress,
+)
 from cadgen._internal.generation import (
     EntrySpec,
     _entry_spec_from_source,
     _existing_topology_artifact_matches_spec_without_scene,
     _generate_part_outputs,
+    cli_progress_line,
+    relative_to_cwd,
     run_script_generator,
 )
 from cadgen.metadata import DEFAULT_MESH_ANGULAR_TOLERANCE, DEFAULT_MESH_TOLERANCE
@@ -53,19 +62,47 @@ def ensure_step_topology_artifact(
     surface it as opt-in diagnostics without adding overhead when `debug` is None."""
     started = time.perf_counter() if debug is not None else None
     try:
-        return _ensure_step_topology_artifact(
-            target,
-            artifact_path=artifact_path,
-            require_selector=require_selector,
-            force=force,
-            logger=logger,
-            mesh_tolerance=mesh_tolerance,
-            mesh_angular_tolerance=mesh_angular_tolerance,
-            debug=debug,
-        )
+        # Every CLI that needs a STEP package comes through here -- inspect, snapshot -- and
+        # the rebuild below can be the same multi-minute generator `cad gen` runs. It used to
+        # take the lock and report to the VIEWER only, so a terminal caller watched a silent
+        # process while an open viewer showed the phases. The progress line is built here, at
+        # the one shared entry point, rather than asked of every caller.
+        with _topology_progress_line(target, logger=logger) as sink:
+            return _ensure_step_topology_artifact(
+                target,
+                artifact_path=artifact_path,
+                require_selector=require_selector,
+                force=force,
+                logger=logger,
+                mesh_tolerance=mesh_tolerance,
+                mesh_angular_tolerance=mesh_angular_tolerance,
+                debug=debug,
+                sink=sink,
+            )
     finally:
         if debug is not None and started is not None:
             debug["tookMs"] = (time.perf_counter() - started) * 1000
+
+
+@contextlib.contextmanager
+def _topology_progress_line(
+    target: ResolvedStepTarget, *, logger: CliLogger | None
+) -> "Iterator[object | None]":
+    """The shared build progress line for every caller of this entry point.
+
+    Deliberately defaulted rather than required. `inspect` reaches this through four layers
+    that carry no logger, and threading one down each of them to earn a progress bar is the
+    kind of plumbing that simply does not get done -- which is why inspect's rebuilds were
+    silent. Painting is already gated on the stream being a tty, so the callers that must
+    stay quiet stay quiet on their own: the viewer's warm worker writes to a pipe, and so
+    does anything capturing output.
+    """
+    with cli_progress_line(
+        relative_to_cwd(target.step_path),
+        logger=logger or CliLogger("cad"),
+        fallback="Building...",
+    ) as sink:
+        yield sink
 
 
 def _ensure_step_topology_artifact(
@@ -78,6 +115,7 @@ def _ensure_step_topology_artifact(
     mesh_tolerance: float | None,
     mesh_angular_tolerance: float | None,
     debug: dict[str, object] | None,
+    sink: object | None = None,
 ) -> StepTopologyArtifact:
     spec = _entry_spec_for_target(
         target,
@@ -135,8 +173,12 @@ def _ensure_step_topology_artifact(
         # write that followed was completely uncoordinated. A viewer polling during that
         # window read "no build in flight", found the package stale, and started a SECOND
         # full build into the same directory.
-        with artifact_build(STEP_PACKAGE, render_package_dir(spec.entry_path)) as run:
-            spec, scene = _scene_for_regeneration(spec, logger=logger, force=force)
+        with artifact_build(
+            STEP_PACKAGE, render_package_dir(spec.entry_path), sink=sink
+        ) as run:
+            spec, scene = _scene_for_regeneration(
+                spec, logger=logger, force=force, progress=run
+            )
             _generate_part_outputs(
                 spec,
                 entries_by_step_path={spec.step_path: spec},
@@ -411,18 +453,25 @@ def _scene_for_regeneration(
     *,
     logger: CliLogger | None,
     force: bool,
+    progress: object | None = None,
 ) -> tuple[EntrySpec, LoadedStepScene]:
     if spec.source == "generated":
+        # The run holding the lock, so the generator reports its phase (and whatever the
+        # generator itself reports through cadgen.progress). Without it this call -- which
+        # for a large assembly is the longest thing inspect does -- opened the build with no
+        # `generate` phase at all: the bar jumped straight to `collecting parts`.
         scene = run_script_generator(
             spec,
             "gen_step",
             logger=logger,
             force=force,
+            progress=progress,
         )
         if scene is None:
             raise RuntimeError(f"Python generator did not produce a STEP scene: {spec.source_ref}")
         return spec, scene
 
+    resolve_progress(progress).phase(PHASE_GENERATE)
     with (logger.timed(f"load STEP {spec.cad_ref}") if logger is not None else _null_context()):
         scene = load_step_scene_cached(spec.step_path)
     inferred_kind = infer_entry_kind(spec.step_path, scene)

--- a/tests/python/packages/cadgen/test_coordination.py
+++ b/tests/python/packages/cadgen/test_coordination.py
@@ -120,7 +120,7 @@ class GeneratorRecordIsolationTest(CoordinationTestCase):
                     intent="write",
                     started_at_ms=0.0,
                     outcome=None,
-                    progress={"phase": "components", "done": 7, "total": 9, "ratio": 0.5},
+                    progress={"phase": "components", "done": 7, "total": 9, "determinate": True},
                 ),
             )
             with generator_busy(STEP_PACKAGE, self.out):
@@ -131,21 +131,21 @@ class GeneratorRecordIsolationTest(CoordinationTestCase):
             )
             self.assertEqual("components", snap.progress["phase"])
 
-    def test_a_generator_run_does_not_erase_the_learned_stage_times(self):
-        # An export leaves a terminal record with no stageMs. Sharing the writer's file made
-        # that record the one the NEXT build read, so the model forgot its phase weighting.
+    def test_a_generator_run_does_not_overwrite_the_writers_record(self):
+        # An export leaves a terminal record of its own. While it shared the writer's file,
+        # that record replaced the build's -- erasing what the build reported it had done.
         with artifact_build(STEP_PACKAGE, self.out, is_current=lambda: False) as run:
             run.phase(PHASE_COMPONENTS, total=2)
             run.advance()
-        learned = record_mod.read_stage_ms(status_path(self.out))
-        self.assertTrue(learned, "a successful build records what its phases cost")
+        recorded = record_mod.read_record(status_path(self.out))["stageMs"]
+        self.assertTrue(recorded, "a successful build records what its phases cost")
 
         with generator_busy(STEP_PACKAGE, self.out):
             pass
         self.assertEqual(
-            learned,
-            record_mod.read_stage_ms(status_path(self.out)),
-            "an export must not cost the next build its learned phase weighting",
+            recorded,
+            record_mod.read_record(status_path(self.out))["stageMs"],
+            "an export must not overwrite the build's own record",
         )
 
 
@@ -161,7 +161,7 @@ class RunAttributionTest(CoordinationTestCase):
                 intent="write",
                 started_at_ms=0.0,
                 outcome=None,
-                progress={"phase": "components", "done": 31, "total": 50, "ratio": 0.77},
+                progress={"phase": "components", "done": 31, "total": 50, "determinate": True},
             ),
         )
         with exclusive(write_lock_path(self.out)) as run_id:
@@ -183,7 +183,7 @@ class RunAttributionTest(CoordinationTestCase):
         self.assertEqual("failed", payload["outcome"])
         self.assertIsNone(
             payload["stageMs"],
-            "a failed run must not teach the next build's bar from partial stage times",
+            "partial times from a failed run are not durations anyone should print",
         )
 
     def test_stage_ms_is_recorded_after_a_successful_run(self):
@@ -194,28 +194,21 @@ class RunAttributionTest(CoordinationTestCase):
         self.assertEqual("done", payload["outcome"])
         self.assertIsInstance(payload["stageMs"], dict)
 
-    def test_the_next_run_learns_the_previous_runs_stage_times(self):
-        """The bar is weighted from the LAST build of this artifact.
+    def test_a_run_records_every_phase_it_entered(self):
+        """stageMs is a record of what THIS run cost, phase by phase.
 
-        artifact_build publishes a `starting` record before yielding, and that record carries
-        stageMs: None by construction. Reading the previous run's times AFTER publishing
-        therefore read the record just written and learned nothing -- silently reverting every
-        build to the default phase split. That matters most for a long indeterminate phase,
-        which is interpolated against the learned duration.
+        Nothing reads it back to predict the next build any more -- each phase reports itself
+        -- but the CLI prints a phase's duration as it closes, so the times have to be there
+        for every phase the run actually entered.
         """
         with artifact_build(STEP_PACKAGE, self.out, is_current=lambda: False) as run:
             run.phase("generate")
             time.sleep(0.05)
             run.phase(PHASE_COMPONENTS, total=1)
             run.advance()
-        recorded = record_mod.read_stage_ms(status_path(self.out))
-        self.assertTrue(recorded, "the first run must record its stage times")
-
-        with artifact_build(STEP_PACKAGE, self.out, is_current=lambda: False) as run:
-            learned = dict(run._reporter._expected)
-        self.assertEqual(
-            sorted(recorded), sorted(learned), "the next run did not learn the previous times"
-        )
+        recorded = record_mod.read_record(status_path(self.out))["stageMs"]
+        self.assertEqual({"generate", "components"}, set(recorded))
+        self.assertGreater(recorded["generate"], 0)
 
     def test_a_finished_run_reports_no_progress(self):
         with artifact_build(STEP_PACKAGE, self.out, is_current=lambda: False) as run:

--- a/tests/python/packages/cadgen/test_node_runtime.py
+++ b/tests/python/packages/cadgen/test_node_runtime.py
@@ -339,10 +339,10 @@ reportResult({ ok: true, packagePath: process.argv[2] });
         self.assertEqual(4, sampled[-1].total)
         self.assertEqual("slice 4/4", sampled[-1].detail)
 
-        # The bar advanced through the child's work rather than sitting at the phase floor.
-        self.assertGreater(sampled[-1].ratio, sampled[0].ratio)
-        # And the terminal record carries the phases the CHILD reported, so the next build of
-        # this artifact weights its bar from them.
+        # The count advanced through the child's work rather than sitting at zero.
+        self.assertGreater(sampled[-1].fraction, sampled[0].fraction)
+        # And the terminal record carries the phases the CHILD reported, so the run's own
+        # timings account for the work it did.
         self.assertIn("sample", events[-1].stage_ms or {})
 
 

--- a/tests/python/packages/cadgen/test_progress.py
+++ b/tests/python/packages/cadgen/test_progress.py
@@ -1,0 +1,117 @@
+"""The two shapes a phase can report, and the generator-facing API that produces them."""
+
+from __future__ import annotations
+
+import unittest
+
+from cadgen.coordination import BuildRun, current_build, reporting_as
+from cadgen.coordination.phases import PHASE_COMPONENTS, PHASE_GENERATE, ProgressReporter
+from cadgen.progress import report, track
+
+
+def _recording_reporter() -> tuple[ProgressReporter, list]:
+    events: list = []
+    return ProgressReporter(sinks=[events.append]), events
+
+
+class PhaseShapeTest(unittest.TestCase):
+    def test_a_phase_with_a_total_reports_a_real_fraction(self):
+        reporter, events = _recording_reporter()
+        reporter.phase(PHASE_COMPONENTS, total=4)
+        reporter.advance(detail="a1b2")
+        self.assertTrue(events[-1].determinate)
+        self.assertEqual(0.25, events[-1].fraction)
+        self.assertEqual(1, events[-1].done)
+        self.assertEqual(4, events[-1].total)
+
+    def test_a_phase_without_a_total_has_no_fraction_to_report(self):
+        reporter, events = _recording_reporter()
+        reporter.phase(PHASE_GENERATE)
+        self.assertFalse(events[-1].determinate)
+        self.assertIsNone(events[-1].fraction, "a phase with no denominator must not imply one")
+
+    def test_a_changed_label_is_published_even_inside_the_throttle_window(self):
+        """The bug this pairing was written for.
+
+        `detail` is throttled so a chatty caller cannot spend the build's time on reporting.
+        But a phase's FIRST label lands microseconds after the phase/set_total that opened
+        it, so a blanket throttle swallowed it -- and because an uncountable phase emits
+        nothing else, the label then stayed empty for the entire phase.
+        """
+        reporter, events = _recording_reporter()
+        reporter.phase(PHASE_GENERATE)
+        reporter.detail("airframe")
+        self.assertEqual("airframe", events[-1].detail)
+
+    def test_repeating_the_label_already_showing_is_throttled(self):
+        reporter, events = _recording_reporter()
+        reporter.phase(PHASE_GENERATE)
+        reporter.detail("airframe")
+        before = len(events)
+        for _ in range(50):
+            reporter.detail("airframe")
+        self.assertEqual(before, len(events), "a repeat says nothing new and must not be written")
+
+    def test_a_phase_reports_its_position_in_the_run(self):
+        reporter, events = _recording_reporter()
+        reporter.phase(PHASE_COMPONENTS)
+        self.assertEqual((3, 4), (events[-1].index, events[-1].count))
+
+    def test_an_undeclared_phase_reports_no_position_rather_than_a_wrong_one(self):
+        reporter, events = _recording_reporter()
+        reporter.phase("polishing")
+        self.assertEqual(0, events[-1].index)
+
+
+class GeneratorApiTest(unittest.TestCase):
+    def test_track_outside_a_build_is_a_transparent_pass_through(self):
+        # The same generator runs under the CLI, the viewer's worker, a test, and a plain
+        # `python model.step.py`. Instrumentation must never need guarding.
+        self.assertIsNone(current_build())
+        self.assertEqual([1, 2, 3], list(track([1, 2, 3])))
+
+    def test_report_outside_a_build_does_nothing(self):
+        report("airframe")  # must not raise
+
+    def test_track_counts_completed_work_and_labels_what_is_in_flight(self):
+        reporter, events = _recording_reporter()
+        reporter.phase(PHASE_GENERATE)
+        run = BuildRun(reporter, "run-1")
+        seen = []
+        with reporting_as(run):
+            for name in track(["airframe", "cockpit"], label=lambda item: item):
+                # Mid-item: this one is named, and NOT yet counted.
+                seen.append((events[-1].detail, events[-1].done))
+        self.assertEqual([("airframe", 0), ("cockpit", 1)], seen)
+        self.assertEqual(2, events[-1].done, "the last item is counted once its work returns")
+        self.assertEqual(2, events[-1].total)
+
+    def test_track_leaves_a_lazy_iterable_lazy_and_reports_it_by_label_alone(self):
+        # Consuming it here to obtain a denominator would change WHEN the caller's work runs.
+        reporter, events = _recording_reporter()
+        reporter.phase(PHASE_GENERATE)
+        with reporting_as(BuildRun(reporter, "run-1")):
+            list(track((name for name in ["airframe"]), label=lambda item: item))
+        # The label is the only event: with no denominator the count says nothing, so its
+        # tick stays throttled while the label — which does say something — is published.
+        self.assertFalse(events[-1].determinate)
+        self.assertEqual("airframe", events[-1].detail)
+
+    def test_a_nested_bind_does_not_retarget_the_outer_run(self):
+        # A model that composes child generators would otherwise have the child's loop
+        # overwrite the parent's phase, and the outer count is the one a reader can use.
+        outer = BuildRun(ProgressReporter(), "outer")
+        with reporting_as(outer):
+            with reporting_as(BuildRun(ProgressReporter(), "inner")):
+                self.assertIs(outer, current_build())
+        self.assertIsNone(current_build())
+
+    def test_a_label_callable_that_raises_cannot_break_a_build(self):
+        reporter, events = _recording_reporter()
+        reporter.phase(PHASE_GENERATE)
+        with reporting_as(BuildRun(reporter, "run-1")):
+            self.assertEqual([1], list(track([1], label=lambda item: 1 / 0)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/server_py/backend.py
+++ b/viewer/server_py/backend.py
@@ -357,6 +357,14 @@ class LocalAssetBackend:
             status = {"state": artifact_mod.ARTIFACT_STATE_READY, "ref": ref}
             if snap.busy:
                 status["busy"] = True
+                # An occupied generator (an export, an on-demand topology extraction) runs
+                # the same multi-minute gen_step a build does. It does NOT hide the model —
+                # nothing is being rewritten — so this rides alongside a ready artifact and
+                # the client shows it without blocking the render.
+                if snap.run_id:
+                    status["runId"] = snap.run_id
+                if snap.progress is not None:
+                    status["progress"] = snap.progress
             return status
         if code in artifact_mod.BUILDABLE_ARTIFACT_CODES:
             status = {"state": artifact_mod.ARTIFACT_STATE_NEEDS_BUILD, "reason": code, "ref": ref}

--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -41,7 +41,11 @@ import StatusToast from "./workbench/StatusToast";
 import UrdfFileSheet from "./workbench/UrdfFileSheet";
 import ViewerAlertDialog from "./workbench/ViewerAlertDialog";
 import ViewerLoadingOverlay from "./workbench/ViewerLoadingOverlay";
-import { formatArtifactProgress } from "@/workbench/artifactProgress.js";
+import {
+  ARTIFACT_PROGRESS_POLL_MS,
+  formatArtifactProgress,
+  normalizeArtifactProgress
+} from "@/workbench/artifactProgress.js";
 import FloatingToolBar from "./workbench/FloatingToolBar";
 import CadWorkspaceTopBar from "./workbench/CadWorkspaceTopBar";
 import CadWorkspaceHome from "./workbench/CadWorkspaceHome";
@@ -256,7 +260,7 @@ import {
   URDF_JOINT_ANIMATION_FOLLOW_MS
 } from "cadjs/lib/urdf/jointAnimation";
 import { checkMoveIt2ServerLive, moveit2ServerEnabled, requestMoveIt2Server } from "cadjs/lib/urdf/moveit2ServerClient";
-import { readActiveCadDir } from "../workbench/cadManifestStore.js";
+import { readActiveCadDir, requestArtifactStatus } from "../workbench/cadManifestStore.js";
 import {
   FILE_STATUS_LEVELS,
   buildFileStatusItems,
@@ -1392,6 +1396,7 @@ export default function CadWorkspace({
     urdfError,
     setUrdfError,
     urdfLoadStage,
+    urdfLoadProgress,
     referenceState,
     setReferenceState,
     referenceStatus,
@@ -1485,6 +1490,13 @@ export default function CadWorkspace({
   // every loading state that is not an artifact build). Only meaningful while
   // generating — a stale frame must not outlive the build that produced it.
   const selectedArtifactProgress = selectedArtifactGenerating ? selectedArtifact.progress : null;
+  // What the loading overlay reports. A model being BUILT reports through the artifact
+  // pipeline; a robot has no build behind it at all — it is a URDF plus a pile of meshes —
+  // and its loader's own mesh count is then the only progress in existence. The two are
+  // mutually exclusive in practice, and normalizing both through one function is what keeps
+  // the overlay from having to know which subsystem it is looking at.
+  const selectedLoadProgress =
+    selectedArtifactProgress || normalizeArtifactProgress(urdfLoadProgress);
   const activeStepArtifactGenerationFiles = useMemo(
     () => (selectedArtifactGenerating && catalogSelectedEntry ? [fileKey(catalogSelectedEntry)] : []),
     [selectedArtifactGenerating, catalogSelectedEntry]
@@ -5236,11 +5248,17 @@ export default function CadWorkspace({
 
     if (selectedArtifactGenerating) {
       const frame = selectedArtifactProgress ? formatArtifactProgress(selectedArtifactProgress) : null;
+      // One number, and only a measured one: a phase's own count. An uncountable phase adds
+      // nothing here rather than a percentage of the whole build, which nothing can honestly
+      // compute. The phase name and sub-unit live in the tooltip, which is opened on purpose.
+      const chip = frame?.determinate ? frame.counts : "";
       return {
         loading: true,
-        label: frame ? `${ARTIFACT_GENERATING_LABEL} ${frame.percent}%` : ARTIFACT_GENERATING_LABEL,
+        label: chip ? `${ARTIFACT_GENERATING_LABEL} ${chip}` : ARTIFACT_GENERATING_LABEL,
         title: frame
-          ? `${frame.label}${frame.counts ? ` — ${frame.counts}` : ""}`
+          ? [frame.label, frame.ordinal && `phase ${frame.ordinal}`, frame.detail]
+              .filter(Boolean)
+              .join(" — ")
           : "Generator script is running"
       };
     }
@@ -7966,9 +7984,43 @@ export default function CadWorkspace({
     setCopyStatus("");
     setScreenshotStatus("");
     setFileAccessBusyKey(busyKey);
+    // An export re-runs the model's generator, which on a large assembly is minutes — the
+    // same work a build does, and now reported the same way. The export request itself is
+    // one long-lived call, so the position comes from polling the status route beside it:
+    // the generator holds its own lock, so the model stays readable and reports `busy`.
+    const exportLabel = exportFormatLabel(exportFormat);
+    let progressTimer = 0;
+    // Checked before every write. A poll can be mid-flight when the export resolves, and
+    // without this its late answer lands ON TOP of the "Exported ..." result.
+    let progressStopped = false;
+    const stopExportProgress = () => {
+      progressStopped = true;
+      if (progressTimer) {
+        window.clearTimeout(progressTimer);
+        progressTimer = 0;
+      }
+    };
+    const pollExportProgress = async () => {
+      try {
+        const status = await requestArtifactStatus(fileRef);
+        const frame = formatArtifactProgress(normalizeArtifactProgress(status?.progress));
+        if (frame && !progressStopped) {
+          const detail = frame.detail ? ` · ${frame.detail}` : "";
+          const counts = frame.counts ? ` ${frame.counts}` : "";
+          setCopyStatus(`Exporting ${exportLabel} — ${frame.label}${detail}${counts}`);
+        }
+      } catch {
+        // Decoration only: a failed poll must never disturb the export itself.
+      }
+      if (!progressStopped) {
+        progressTimer = window.setTimeout(pollExportProgress, ARTIFACT_PROGRESS_POLL_MS);
+      }
+    };
     try {
-      setCopyStatus(`Exporting ${exportFormatLabel(exportFormat)}...`);
+      setCopyStatus(`Exporting ${exportLabel}...`);
+      progressTimer = window.setTimeout(pollExportProgress, ARTIFACT_PROGRESS_POLL_MS);
       const payload = await requestModelExport({ file: fileRef, format: exportFormat });
+      stopExportProgress();
       if (payload?.cancelled) {
         // User dismissed the native save dialog — clear the in-progress status, no error.
         setCopyStatus("");
@@ -7987,6 +8039,7 @@ export default function CadWorkspace({
     } catch (error) {
       setCopyStatus(error instanceof Error ? error.message : "Export failed");
     } finally {
+      stopExportProgress();
       setFileAccessBusyKey((current) => (current === busyKey ? "" : current));
     }
   }, []);
@@ -8504,7 +8557,7 @@ export default function CadWorkspace({
               <ViewerLoadingOverlay
                 viewerLoading={effectiveViewerLoading}
                 previewMode={previewMode}
-                progress={selectedArtifactProgress}
+                progress={selectedLoadProgress}
               />
             </div>
 

--- a/viewer/src/client/components/ui/progress.jsx
+++ b/viewer/src/client/components/ui/progress.jsx
@@ -10,12 +10,14 @@ import { cn } from "@/ui/utils"
  * `--primary` as the fill, and a muted track. The track is deliberately thin — this sits
  * over a live 3D scene, so it reads as a status line rather than a widget.
  *
- * `value` of `null` is INDETERMINATE per the radix contract. Callers that have no real
- * denominator should still pass a number (an estimate) rather than null, so the bar always
- * moves; see `estimatedLoadingRatio` in workbench/artifactProgress.js.
+ * `value` of `null` is INDETERMINATE per the radix contract, and callers that have no
+ * denominator SHOULD pass it. A sliding bar says "working, no estimate" honestly; the
+ * alternative — inventing a number so the bar always has one — is how a ten-minute phase
+ * came to display a confident 0%.
  */
 function Progress({ className, value, ...props }) {
   const clamped = Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : null;
+  const indeterminate = clamped === null;
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -25,8 +27,14 @@ function Progress({ className, value, ...props }) {
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="h-full w-full flex-1 bg-primary transition-transform duration-200 ease-out"
-        style={{ transform: `translateX(-${100 - (clamped ?? 0)}%)` }}
+        data-indeterminate={indeterminate ? "true" : undefined}
+        className={cn(
+          "h-full bg-primary",
+          indeterminate
+            ? "w-1/3 cad-progress-indeterminate"
+            : "w-full flex-1 transition-transform duration-200 ease-out"
+        )}
+        style={indeterminate ? undefined : { transform: `translateX(-${100 - clamped}%)` }}
       />
     </ProgressPrimitive.Root>
   );

--- a/viewer/src/client/components/workbench/ViewerLoadingOverlay.js
+++ b/viewer/src/client/components/workbench/ViewerLoadingOverlay.js
@@ -1,92 +1,47 @@
-import { useEffect, useRef, useState } from "react";
-
 import { Progress } from "@/components/ui/progress";
-import {
-  ARTIFACT_PROGRESS_POLL_MS,
-  MAX_DISPLAY_PERCENT,
-  continuedLoadingRatio,
-  estimatedLoadingRatio,
-  formatArtifactProgress
-} from "@/workbench/artifactProgress.js";
+import { formatArtifactProgress } from "@/workbench/artifactProgress.js";
 
-// Two words, max. The status line names the stage; the number says how far along. Anything
-// longer starts wrapping over the 3D scene and stops being scannable at a glance.
+// Two words, max. Anything longer starts wrapping over the 3D scene and stops being
+// scannable at a glance.
 const DEFAULT_STATUS = "Loading";
 
 /**
- * The one loading indicator: a status word top-left, a percent top-right, and a bar.
+ * The one loading indicator: what is happening on the left, how far along on the right, bar.
  *
- * The bar is ALWAYS shown while loading. When the build reports real progress we use it;
- * when it does not — a plain asset read, a decode, the window before a build's first
- * event — we estimate against the clock (see `estimatedLoadingRatio`). A bar that only
- * appears for the subset of loads that happen to be instrumented is worse than one that is
- * always there, because its absence reads as "stuck" rather than "unmeasured".
+ * Two lines, never more. The status line is as SPECIFIC as the build can make it — the phase
+ * plus the sub-unit in flight, on one line ("Building geometry · airframe") — because the
+ * phase alone goes stale for minutes at a time on a big model, and a status that has not
+ * changed in twenty minutes is the failure this whole pipeline exists to fix. Putting the
+ * sub-unit on its own row instead cost a third row and made the overlay resize whenever a
+ * phase started or stopped naming things; over a live 3D scene that was worse than the
+ * information was worth.
  *
- * A load can cross from measured to unmeasured HALFWAY THROUGH: an artifact build reports
- * real phases and then stops the moment it finishes, while the package GLB still has to be
- * fetched and decoded. The measured high-water mark is therefore kept as a floor and the
- * remainder eased from there (`continuedLoadingRatio`), so the bar neither jumps backwards
- * nor freezes at the from-scratch estimate's ceiling.
+ * The phase ordinal ("2 of 4") is the one thing deliberately dropped: it answers a question
+ * nobody asks mid-build, and it competed with the count for the eye.
+ *
+ * The bar takes one of two forms, chosen by what the build can honestly say. A phase that
+ * knows its work list fills it and shows the count ("312/1127"); a phase that does not gets
+ * an INDETERMINATE bar and NO number beside it. There is no overall percentage and no clock.
+ * Both were previously required to keep one bar moving across four phases of unknowable
+ * relative cost, and both lied: a first build had no measurements to weight the phases with,
+ * so the bar sat at 0% for the whole of a ten-minute generate phase and then jumped to 46%.
+ * A sliding bar says "working, no estimate" — which is the truth — and needs no repaint timer
+ * to say it, because CSS animates it.
  */
 export default function ViewerLoadingOverlay({
   viewerLoading,
   previewMode,
   progress = null
 }) {
-  const active = viewerLoading && !previewMode;
-  const startedAtRef = useRef(0);
-  // The highest ratio this load actually MEASURED, and when the measurement stopped. The
-  // bar is monotonic within a load, so a floor is the whole mechanism: once something real
-  // is known, no later estimate may walk it back.
-  const measuredFloorRef = useRef(0);
-  const tailStartedAtRef = useRef(0);
-  const [, setTick] = useState(0);
-
-  useEffect(() => {
-    if (!active) {
-      startedAtRef.current = 0;
-      measuredFloorRef.current = 0;
-      tailStartedAtRef.current = 0;
-      return undefined;
-    }
-    startedAtRef.current = Date.now();
-    measuredFloorRef.current = 0;
-    tailStartedAtRef.current = 0;
-    // Repaint on the same cadence the artifact status is polled, so the estimated bar and
-    // a reported one advance at one rate rather than two.
-    const intervalId = window.setInterval(() => {
-      setTick((current) => current + 1);
-    }, ARTIFACT_PROGRESS_POLL_MS);
-    return () => window.clearInterval(intervalId);
-  }, [active]);
-
-  if (!active) {
+  if (!viewerLoading || previewMode) {
     return null;
   }
 
   const frame = progress ? formatArtifactProgress(progress) : null;
-  let ratio;
-  if (frame) {
-    // Measured: record the high-water mark and clear any tail clock, so a build that
-    // resumes reporting (a handoff to another run) goes back to real positions.
-    measuredFloorRef.current = Math.max(measuredFloorRef.current, frame.ratio);
-    tailStartedAtRef.current = 0;
-    ratio = measuredFloorRef.current;
-  } else if (measuredFloorRef.current > 0) {
-    // The measured phase ended but the load did not — start the tail clock at the handover
-    // (once; a re-render must not keep resetting it) and ease on from the floor.
-    if (!tailStartedAtRef.current) {
-      tailStartedAtRef.current = Date.now();
-    }
-    ratio = continuedLoadingRatio(measuredFloorRef.current, tailStartedAtRef.current);
-  } else {
-    ratio = estimatedLoadingRatio(startedAtRef.current);
-  }
-  // Derived from the ratio the bar is drawing, never from the raw frame: on a run handoff
-  // the floor can sit above what the new run reports, and a number disagreeing with the bar
-  // beside it is worse than either being slightly stale.
-  const percent = Math.min(MAX_DISPLAY_PERCENT, Math.round(ratio * 100));
   const status = frame?.label || DEFAULT_STATUS;
+  // Anything without a real fraction — an uncountable phase, or a plain asset read that
+  // reports nothing at all — renders as indeterminate.
+  const value = frame?.determinate ? frame.percent : null;
 
   return (
     <div className="pointer-events-none absolute inset-0 z-20 overflow-hidden">
@@ -104,12 +59,22 @@ export default function ViewerLoadingOverlay({
                 tailwind-merge classGroup for one call site. */}
             <span className="truncate text-[11px] uppercase tracking-wider text-muted-foreground">
               {status}
+              {/* The sub-unit rides on the SAME line as the phase, in its authored case —
+                  it is data ("airframe", "o1.7.3 nozzle_petal"), not a label, and shouting
+                  it would make a content hash even harder to read. `truncate` on the parent
+                  clips the pair from the right rather than letting it wrap over the scene. */}
+              {frame?.detail ? (
+                <span className="normal-case tracking-normal text-muted-foreground/60">
+                  {" · "}
+                  {frame.detail}
+                </span>
+              ) : null}
             </span>
-            <span className="text-[11px] tabular-nums text-muted-foreground">
-              {percent}%
+            <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+              {frame?.counts || ""}
             </span>
           </div>
-          <Progress value={percent} aria-label={status} />
+          <Progress value={value} aria-label={status} />
         </div>
       </div>
     </div>

--- a/viewer/src/client/components/workbench/hooks/useCadAssets.js
+++ b/viewer/src/client/components/workbench/hooks/useCadAssets.js
@@ -227,6 +227,11 @@ export function useCadAssets({
   const [urdfStatus, setUrdfStatus] = useState(ASSET_STATUS.PENDING);
   const [urdfError, setUrdfError] = useState("");
   const [urdfLoadStage, setUrdfLoadStage] = useState("");
+  // The same stage, as data rather than a sentence. The loader has always COUNTED the
+  // meshes it fetches; flattening that count into a string meant the one indicator the
+  // user actually watches — the overlay — could only show a generic "Loading". Both are
+  // set from the same call sites so they cannot disagree.
+  const [urdfLoadProgress, setUrdfLoadProgress] = useState(null);
   const [referenceState, setReferenceState] = useState(null);
   const [referenceStatus, setReferenceStatus] = useState(REFERENCE_STATUS.IDLE);
   const [referenceError, setReferenceError] = useState("");
@@ -407,6 +412,7 @@ export function useCadAssets({
     urdfRequestIdRef.current += 1;
     abortLoad(urdfAbortControllerRef);
     setUrdfLoadStage("");
+    setUrdfLoadProgress(null);
   }, []);
 
   const cancelReferenceLoad = useCallback(() => {
@@ -815,7 +821,9 @@ export function useCadAssets({
     urdfAbortControllerRef.current = controller;
     setUrdfStatus(ASSET_STATUS.LOADING);
     setUrdfError("");
+    const robotLabel = kind === "sdf" ? "Loading SDF" : kind === "srdf" ? "Loading SRDF" : "Loading URDF";
     setUrdfLoadStage(kind === "sdf" ? "loading SDF" : kind === "srdf" ? "loading SRDF" : "loading URDF");
+    setUrdfLoadProgress({ phase: "robot", label: robotLabel, determinate: false });
 
     try {
       const payload = kind === "srdf"
@@ -829,6 +837,13 @@ export function useCadAssets({
       const urdfData = payload.urdfData;
       const meshUrls = urdfMeshUrls(urdfData);
       setUrdfLoadStage(meshUrls.length ? "loading meshes" : "building robot");
+      setUrdfLoadProgress({
+        phase: meshUrls.length ? "meshes" : "robot",
+        label: meshUrls.length ? "Loading meshes" : "Building robot",
+        done: 0,
+        total: meshUrls.length || null,
+        determinate: meshUrls.length > 0
+      });
       // The robot is published ONCE, complete. Drawing links as they arrive was tried and
       // rejected: a half-built robot on screen with the loading card already gone gives no
       // sign whether more is coming, so it reads as a broken model rather than a loading
@@ -838,6 +853,13 @@ export function useCadAssets({
         onProgress: (completed, total) => {
           if (requestId === urdfRequestIdRef.current && total > 0) {
             setUrdfLoadStage(`loading meshes ${completed}/${total}`);
+            setUrdfLoadProgress({
+              phase: "meshes",
+              label: "Loading meshes",
+              done: completed,
+              total,
+              determinate: true
+            });
           }
         }
       });
@@ -845,6 +867,7 @@ export function useCadAssets({
         return;
       }
       setUrdfLoadStage("building robot");
+      setUrdfLoadProgress({ phase: "robot", label: "Building robot", determinate: false });
       const meshesByUrl = new Map(meshUrls.map((meshUrl, index) => [meshUrl, meshes[index]]));
       setUrdfState({
         file: entry.file,
@@ -867,6 +890,7 @@ export function useCadAssets({
       }
       if (requestId === urdfRequestIdRef.current) {
         setUrdfLoadStage("");
+        setUrdfLoadProgress(null);
       }
     }
   }, [cancelUrdfLoad, getCachedUrdfState]);
@@ -903,6 +927,7 @@ export function useCadAssets({
     urdfError,
     setUrdfError,
     urdfLoadStage,
+    urdfLoadProgress,
     referenceState,
     setReferenceState,
     referenceStatus,

--- a/viewer/src/client/styles/globals.css
+++ b/viewer/src/client/styles/globals.css
@@ -281,3 +281,26 @@
     color: var(--accent-foreground);
   }
 }
+
+/* The indeterminate progress indicator: a third-width block sliding the track, used when a
+   phase has no denominator to report. Motion here means "still working" and nothing more —
+   it deliberately carries no position, unlike a filled bar. */
+@keyframes cad-progress-slide {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(300%);
+  }
+}
+
+.cad-progress-indeterminate {
+  animation: cad-progress-slide 1.15s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cad-progress-indeterminate {
+    animation-duration: 2.4s;
+    animation-timing-function: linear;
+  }
+}

--- a/viewer/src/client/workbench/artifactProgress.js
+++ b/viewer/src/client/workbench/artifactProgress.js
@@ -1,51 +1,40 @@
-// Reading the build-progress payload the artifact-status route attaches while a model
-// is generating (written by cadgen's _internal/progress.py, served by
-// server_py/artifact.py's read_generation_progress).
+// Reading the build-progress payload the artifact-status route attaches while a model is
+// generating (written by cadgen's coordination/record.py, served by server_py/artifact.py).
 //
-// The build reports at WORK BOUNDARIES, never on a timer: OCP meshing holds Python's
-// GIL inside C for long stretches, so a heartbeat thread in the build process would
-// starve during exactly the work it was meant to report. Interpolation is therefore the
-// READER's job, and it splits cleanly in two:
+// Each phase reports ITSELF. There is no overall percentage, because a build's phases have
+// no fixed relationship to each other: measured across this repo's models, `generate` is 11%
+// of one build and 84% of another. A single bar spanning all four therefore had to be
+// weighted by a guess, and on a first build — where nothing about the model has been
+// measured — the guess had no inputs, so the bar sat at exactly 0% for ten minutes and then
+// jumped to 46% when the phase ended.
 //
-// * a determinate phase (meshing components) is shown exactly as reported -- a real
-//   done/total, never smoothed, because inventing motion between two measured counts
-//   would misreport the one stage we actually measure;
-// * an indeterminate phase (a generator running, a STEP parsing) is advanced against
-//   the wall clock inside its band, using the duration this model's PREVIOUS build
-//   recorded for that phase. Absent that, it simply sits at the band's floor.
+// So a frame says which phase is running, where it sits in the run ("1/4"), and then ONE of:
 //
-// Progress never reaches 100% here. The artifact is not ready until the build's own
-// request resolves, and a bar that sits full while the viewer still shows a spinner
-// reads as a hang.
+//   * a real fraction — `done`/`total` — rendered as a bar with its count;
+//   * a `detail` label naming the sub-unit in flight, rendered as an indeterminate bar.
+//
+// Both are true statements about the present. Nothing here extrapolates, and there are no
+// clocks: this module is a pure formatter, so a frame renders the same whenever it is read.
 
 export const ARTIFACT_PROGRESS_POLL_MS = 400;
-// The first poll runs sooner than the rest. The overlay grows by two rows the moment
-// progress first arrives, and that is the one layout shift the stacked design cannot
-// avoid — so it should happen while the loading state is still appearing, not a
-// noticeable beat later. The build reports its opening phase immediately, so there is
-// something to read this early.
+// The first poll runs sooner than the rest. The overlay grows the moment progress first
+// arrives, and that is the one layout shift the stacked design cannot avoid — so it should
+// happen while the loading state is still appearing, not a noticeable beat later. The build
+// reports its opening phase immediately, so there is something to read this early.
 export const ARTIFACT_PROGRESS_FIRST_POLL_MS = 120;
-// Progress never displays 100%: the artifact is not ready until the build's own request
-// resolves, and a bar that sits full while the viewer still shows a spinner reads as a hang.
-export const MAX_DISPLAY_PERCENT = 99;
-
-function clamp01(value) {
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric)) {
-    return 0;
-  }
-  return Math.min(1, Math.max(0, numeric));
-}
 
 function finiteNumber(value, fallback = 0) {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : fallback;
 }
 
-// Normalizes the server payload into the shape the UI reads, or null when there is
-// nothing renderable. Defensive by intent: this is a file on disk written by another
-// process, so a partial or unexpected payload must degrade to "no progress", never to a
-// broken overlay.
+function nonNegativeInt(value) {
+  return Math.max(0, Math.round(finiteNumber(value, 0)));
+}
+
+// Normalizes the server payload into the shape the UI reads, or null when there is nothing
+// renderable. Defensive by intent: this is a file on disk written by another process, so a
+// partial or unexpected payload must degrade to "no progress", never to a broken overlay.
 export function normalizeArtifactProgress(raw) {
   if (!raw || typeof raw !== "object") {
     return null;
@@ -55,107 +44,41 @@ export function normalizeArtifactProgress(raw) {
     return null;
   }
   const total = raw.total === null || raw.total === undefined ? null : finiteNumber(raw.total, 0);
-  const determinate = Boolean(raw.determinate) && Number(total) > 0;
   return {
     phase,
     label: String(raw.label || "").trim(),
     detail: String(raw.detail || "").trim(),
-    done: Math.max(0, Math.round(finiteNumber(raw.done, 0))),
+    index: nonNegativeInt(raw.index),
+    count: nonNegativeInt(raw.count),
+    done: nonNegativeInt(raw.done),
     total: total === null ? null : Math.max(0, Math.round(total)),
-    determinate,
-    ratio: clamp01(raw.ratio),
-    ratioFloor: clamp01(raw.ratioFloor),
-    ratioCeiling: clamp01(raw.ratioCeiling),
-    phaseStartedAt: finiteNumber(raw.phaseStartedAt, 0),
-    phaseExpectedMs: finiteNumber(raw.phaseExpectedMs, 0),
+    // Never trust the flag over the count: a payload claiming `determinate` without a total
+    // would render "31/null".
+    determinate: Boolean(raw.determinate) && Number(total) > 0,
     updatedAt: finiteNumber(raw.updatedAt, 0)
   };
 }
 
-export function artifactProgressRatio(progress, nowMs = Date.now()) {
-  if (!progress) {
-    return 0;
-  }
-  if (progress.determinate) {
-    return clamp01(progress.ratio);
-  }
-  if (!progress.phaseExpectedMs || !progress.phaseStartedAt) {
-    return clamp01(progress.ratio);
-  }
-  const elapsed = Math.max(0, nowMs - progress.phaseStartedAt);
-  const within = Math.min(1, elapsed / progress.phaseExpectedMs);
-  const interpolated = progress.ratioFloor + (progress.ratioCeiling - progress.ratioFloor) * within;
-  // Never below what the build itself reported: the recorded expectation can be wrong,
-  // but a measured position is not.
-  return clamp01(Math.max(progress.ratio, interpolated));
-}
-
-// The display model for one frame: a ratio, a capped percent, the phase label, and the
-// real counts when (and only when) the phase has them.
-export function formatArtifactProgress(progress, nowMs = Date.now()) {
+/**
+ * The display model for one frame.
+ *
+ * `percent` is null for a phase with no denominator — the caller renders an indeterminate
+ * bar rather than a number. It is deliberately NOT capped below 100: a phase that has
+ * finished its own work has honestly finished it, and the next phase's frame replaces this
+ * one immediately. The old cap existed because the number claimed to describe the whole
+ * build, where 100% beside a still-spinning viewer read as a hang.
+ */
+export function formatArtifactProgress(progress) {
   if (!progress) {
     return null;
   }
-  const ratio = artifactProgressRatio(progress, nowMs);
+  const determinate = progress.determinate && progress.total > 0;
   return {
-    ratio,
-    percent: Math.min(MAX_DISPLAY_PERCENT, Math.round(ratio * 100)),
     label: progress.label,
-    counts: progress.determinate && progress.total ? `${progress.done}/${progress.total}` : "",
-    determinate: progress.determinate
+    ordinal: progress.index > 0 && progress.count > 0 ? `${progress.index}/${progress.count}` : "",
+    detail: progress.detail,
+    determinate,
+    percent: determinate ? Math.round((progress.done / progress.total) * 100) : null,
+    counts: determinate ? `${progress.done}/${progress.total}` : ""
   };
-}
-
-// How long a load with no reported progress is assumed to take. Not a promise -- it only
-// sets how fast the estimate creeps.
-const ESTIMATED_LOAD_MS = 6000;
-// An estimate must never reach 100%: the bar would sit full while work continued, which
-// reads as a hang. It approaches this ceiling and stops.
-const ESTIMATED_CEILING = 0.92;
-// The ceiling for the TAIL of a load whose measured phase already finished. Higher than
-// ESTIMATED_CEILING because we know strictly more here: the build is done and only the
-// download/decode is left, so promising most of the bar is honest rather than optimistic.
-const CONTINUED_CEILING = MAX_DISPLAY_PERCENT / 100;
-
-// Eases from `floor` toward `ceiling` on an exponential curve. Deliberately NOT linear: a
-// linear estimate that outruns the real work has to jump backwards or freeze, and both
-// look broken. This moves quickly at first (when most short loads finish) and slows rather
-// than stalling at a hard stop.
-function easedEstimate(floor, ceiling, sinceMs, nowMs) {
-  const low = clamp01(floor);
-  const high = Math.max(low, clamp01(ceiling));
-  if (!Number.isFinite(sinceMs) || sinceMs <= 0) {
-    return low;
-  }
-  const elapsed = Math.max(0, nowMs - sinceMs);
-  return clamp01(low + (high - low) * (1 - Math.exp(-elapsed / ESTIMATED_LOAD_MS)));
-}
-
-/**
- * A time-based ratio for a load that has reported no progress at all.
- *
- * Most loads have no denominator -- reading a GLB off disk, decoding it in a worker -- and
- * the alternative to estimating is a bar that sits at zero, which tells the user less than
- * nothing.
- */
-export function estimatedLoadingRatio(startedAtMs, nowMs = Date.now()) {
-  return easedEstimate(0, ESTIMATED_CEILING, startedAtMs, nowMs);
-}
-
-/**
- * The estimate for the TAIL of a load whose measured phase has ended.
- *
- * An artifact build reports real progress and then stops reporting the moment it finishes
- * -- but the load is not over: the package GLB still has to be fetched and decoded, and for
- * a large implicit mesh that is the longer half. Falling back to `estimatedLoadingRatio`
- * there is wrong twice over: its clock started when the LOAD started, so after a 38s build
- * the curve has fully saturated and the bar freezes at ESTIMATED_CEILING; and because the
- * measured ratio had already climbed past that ceiling, the bar first jumps BACKWARDS.
- * That pair is exactly what reads as "stuck at 92%".
- *
- * So the tail eases from where the measurement actually left off, on a clock that starts at
- * the handover.
- */
-export function continuedLoadingRatio(floorRatio, sinceMs, nowMs = Date.now()) {
-  return easedEstimate(floorRatio, CONTINUED_CEILING, sinceMs, nowMs);
 }

--- a/viewer/src/client/workbench/artifactProgress.test.js
+++ b/viewer/src/client/workbench/artifactProgress.test.js
@@ -1,55 +1,44 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {
-  estimatedLoadingRatio,
-  artifactProgressRatio,
-  formatArtifactProgress,
-  MAX_DISPLAY_PERCENT,
-  continuedLoadingRatio,
-  normalizeArtifactProgress
-} from "./artifactProgress.js";
+import { formatArtifactProgress, normalizeArtifactProgress } from "./artifactProgress.js";
 
-function componentsPayload(overrides = {}) {
+function countingPayload(overrides = {}) {
   return {
     phase: "components",
     label: "Meshing components",
     detail: "a1b2c3",
+    index: 3,
+    count: 4,
     done: 31,
     total: 50,
     determinate: true,
-    ratio: 0.62,
-    ratioFloor: 0.46,
-    ratioCeiling: 0.96,
-    phaseStartedAt: 1_000,
-    phaseExpectedMs: 8_000,
     updatedAt: 5_000,
     ...overrides
   };
 }
 
-function indeterminatePayload(overrides = {}) {
-  return componentsPayload({
+function labelOnlyPayload(overrides = {}) {
+  return countingPayload({
     phase: "generate",
     label: "Building geometry",
+    detail: "airframe",
+    index: 1,
     determinate: false,
     total: null,
     done: 0,
-    ratio: 0,
-    ratioFloor: 0,
-    ratioCeiling: 0.4,
-    phaseStartedAt: 1_000,
-    phaseExpectedMs: 10_000,
     ...overrides
   });
 }
 
 test("normalizeArtifactProgress keeps a well-formed payload", () => {
-  const progress = normalizeArtifactProgress(componentsPayload());
+  const progress = normalizeArtifactProgress(countingPayload());
   assert.equal(progress.phase, "components");
   assert.equal(progress.label, "Meshing components");
   assert.equal(progress.done, 31);
   assert.equal(progress.total, 50);
+  assert.equal(progress.index, 3);
+  assert.equal(progress.count, 4);
   assert.equal(progress.determinate, true);
 });
 
@@ -62,115 +51,92 @@ test("normalizeArtifactProgress returns null for anything unrenderable", () => {
 test("normalizeArtifactProgress does not trust determinate without a total", () => {
   // The build never emits this, but the payload is a file another process wrote —
   // trusting the flag over the count would render "31/null".
-  const progress = normalizeArtifactProgress(componentsPayload({ total: null }));
+  const progress = normalizeArtifactProgress(countingPayload({ total: null }));
   assert.equal(progress.determinate, false);
 });
 
 test("normalizeArtifactProgress degrades non-numeric fields instead of producing NaN", () => {
   const progress = normalizeArtifactProgress(
-    componentsPayload({ ratio: "hello", done: undefined, phaseStartedAt: null })
+    countingPayload({ done: undefined, index: "hello", updatedAt: null })
   );
-  assert.equal(progress.ratio, 0);
   assert.equal(progress.done, 0);
-  assert.equal(progress.phaseStartedAt, 0);
+  assert.equal(progress.index, 0);
+  assert.equal(progress.updatedAt, 0);
 });
 
-test("a determinate phase is reported exactly, never smoothed", () => {
-  const progress = normalizeArtifactProgress(componentsPayload());
-  // Same answer however much wall-clock time passes: the count is measured, and
-  // inventing motion between two real counts would misreport the one measured stage.
-  assert.equal(artifactProgressRatio(progress, 1_000), 0.62);
-  assert.equal(artifactProgressRatio(progress, 900_000), 0.62);
-});
-
-test("an indeterminate phase advances through its band on the clock", () => {
-  const progress = normalizeArtifactProgress(indeterminatePayload());
-  assert.equal(artifactProgressRatio(progress, 1_000), 0);
-  assert.ok(Math.abs(artifactProgressRatio(progress, 6_000) - 0.2) < 1e-9);
-  // Capped at the band ceiling: overrunning the estimate must not spill into the next
-  // phase's share of the bar.
-  assert.ok(Math.abs(artifactProgressRatio(progress, 999_000) - 0.4) < 1e-9);
-});
-
-test("an indeterminate phase with no recorded expectation sits where the build reported", () => {
-  const progress = normalizeArtifactProgress(
-    indeterminatePayload({ ratio: 0.1, phaseExpectedMs: 0 })
-  );
-  assert.equal(artifactProgressRatio(progress, 500_000), 0.1);
-});
-
-test("interpolation never drops below the position the build reported", () => {
-  const progress = normalizeArtifactProgress(indeterminatePayload({ ratio: 0.35 }));
-  assert.equal(artifactProgressRatio(progress, 1_100), 0.35);
-});
-
-test("formatArtifactProgress surfaces the real counts for a determinate phase", () => {
-  const frame = formatArtifactProgress(normalizeArtifactProgress(componentsPayload()));
+test("a phase that can count reports its real fraction and count", () => {
+  const frame = formatArtifactProgress(normalizeArtifactProgress(countingPayload()));
+  assert.equal(frame.determinate, true);
   assert.equal(frame.percent, 62);
   assert.equal(frame.counts, "31/50");
   assert.equal(frame.label, "Meshing components");
 });
 
-test("formatArtifactProgress omits counts when the phase has none", () => {
-  const frame = formatArtifactProgress(normalizeArtifactProgress(indeterminatePayload()));
+test("a phase that cannot count reports no number at all", () => {
+  // The whole point of the rewrite: an uncountable phase used to be given a percentage
+  // derived from a guessed phase weighting, which on a first build was simply 0 for the
+  // entire phase. `percent: null` is the caller's signal to render an indeterminate bar.
+  const frame = formatArtifactProgress(normalizeArtifactProgress(labelOnlyPayload()));
+  assert.equal(frame.determinate, false);
+  assert.equal(frame.percent, null);
   assert.equal(frame.counts, "");
+  assert.equal(frame.detail, "airframe", "it says what it is working on instead");
 });
 
-test("formatArtifactProgress never reads 100%", () => {
-  // The artifact is not ready until the build's own request resolves; a full bar
-  // beside a still-spinning viewer reads as a hang.
-  const frame = formatArtifactProgress(
-    normalizeArtifactProgress(componentsPayload({ done: 50, ratio: 1 }))
-  );
-  assert.equal(frame.percent, 99);
+test("a frame carries the phase's position in the run", () => {
+  assert.equal(formatArtifactProgress(normalizeArtifactProgress(countingPayload())).ordinal, "3/4");
+});
+
+test("a phase the kind did not declare has no ordinal rather than a bogus one", () => {
+  const frame = formatArtifactProgress(normalizeArtifactProgress(countingPayload({ index: 0 })));
+  assert.equal(frame.ordinal, "");
+});
+
+test("formatArtifactProgress is pure — the same frame renders the same whenever it is read", () => {
+  // There are no clocks in this module. A frame is a statement about the present that the
+  // build made; re-reading it later must not invent motion the build did not report.
+  const progress = normalizeArtifactProgress(countingPayload());
+  assert.deepEqual(formatArtifactProgress(progress), formatArtifactProgress(progress));
+});
+
+test("a completed phase is allowed to read 100%", () => {
+  // The old cap existed because the number described the WHOLE build, where a full bar
+  // beside a still-spinning viewer read as a hang. Per phase, finishing is just finishing —
+  // the next phase's frame replaces this one immediately.
+  const frame = formatArtifactProgress(normalizeArtifactProgress(countingPayload({ done: 50 })));
+  assert.equal(frame.percent, 100);
 });
 
 test("formatArtifactProgress maps null progress to null, not a zeroed bar", () => {
   assert.equal(formatArtifactProgress(null), null);
 });
 
-test("estimatedLoadingRatio moves without a denominator and never reaches 100%", () => {
-  const t0 = 1_000_000;
-  assert.equal(estimatedLoadingRatio(t0, t0), 0);
-  const early = estimatedLoadingRatio(t0, t0 + 1000);
-  const later = estimatedLoadingRatio(t0, t0 + 5000);
-  assert.ok(early > 0 && early < later, "the estimate must advance with elapsed time");
-  // An estimate that hits 100% would sit full while work continued, which reads as a hang.
-  assert.ok(estimatedLoadingRatio(t0, t0 + 10 * 60 * 1000) < 1);
+// A robot has no artifact build behind it — it is a URDF plus a pile of meshes — so its
+// loader's own count is the only progress in existence. It goes through the SAME two
+// functions as a build's, which is what lets the overlay stay ignorant of which subsystem
+// produced the frame. Before this the count was formatted into a string at the source and
+// only ever reached the filename chip.
+test("a robot mesh load formats through the same path as a build", () => {
+  const frame = formatArtifactProgress(
+    normalizeArtifactProgress({
+      phase: "meshes",
+      label: "Loading meshes",
+      done: 7,
+      total: 13,
+      determinate: true
+    })
+  );
+  assert.equal(frame.label, "Loading meshes");
+  assert.equal(frame.counts, "7/13");
+  assert.equal(frame.percent, 54);
+  assert.equal(frame.ordinal, "", "a robot load has no phase sequence to place itself in");
 });
 
-test("estimatedLoadingRatio is 0 before a load has started", () => {
-  assert.equal(estimatedLoadingRatio(0), 0);
-  assert.equal(estimatedLoadingRatio(Number.NaN), 0);
-});
-
-// The "stuck at 92%" regression. An implicit build reports real phases for ~38s (its bar
-// climbing past 0.94 during `polygonize`) and then stops reporting the moment it finishes,
-// while the package GLB is still being fetched and decoded. The old code fell back to
-// estimatedLoadingRatio there, whose clock started when the LOAD started -- so it returned
-// a fully-saturated 0.92: BELOW where the measurement had already reached, and frozen.
-test("continuedLoadingRatio resumes above the measured floor instead of snapping back", () => {
-  const measuredFloor = 0.945;
-  const handover = 1_000_000;
-  // The old behaviour, for contrast: a from-scratch estimate 38s into the load is pinned at
-  // its ceiling and is LOWER than what the build already measured.
-  const staleEstimate = estimatedLoadingRatio(handover - 38_000, handover);
-  assert.ok(staleEstimate < measuredFloor, "precondition: the stale estimate is a step backwards");
-
-  assert.equal(continuedLoadingRatio(measuredFloor, handover, handover), measuredFloor);
-  const tail = continuedLoadingRatio(measuredFloor, handover, handover + 4000);
-  assert.ok(tail > measuredFloor, "the tail must keep moving after the build stops reporting");
-  assert.ok(tail < 1, "the tail must never reach 100%");
-});
-
-test("continuedLoadingRatio stays under the display cap however long the tail runs", () => {
-  const ceiling = MAX_DISPLAY_PERCENT / 100;
-  const forever = continuedLoadingRatio(0.5, 1_000_000, 1_000_000 + 60 * 60 * 1000);
-  assert.ok(forever <= ceiling, `tail ${forever} must not exceed ${ceiling}`);
-});
-
-test("continuedLoadingRatio never walks a floor backwards", () => {
-  // A floor already at/above the ceiling must hold, not be dragged down to it.
-  assert.equal(continuedLoadingRatio(1, 1_000_000, 1_000_000 + 10_000), 1);
-  assert.equal(continuedLoadingRatio(0.6, 0, 1_000_000), 0.6);
+test("a robot stage with no count still renders as a labelled indeterminate frame", () => {
+  const frame = formatArtifactProgress(
+    normalizeArtifactProgress({ phase: "robot", label: "Building robot", determinate: false })
+  );
+  assert.equal(frame.label, "Building robot");
+  assert.equal(frame.percent, null);
+  assert.equal(frame.counts, "");
 });


### PR DESCRIPTION
## The bug

Opening a fresh model showed `Building geometry` at **0%** for minutes, then a sudden jump to 46% and completion. Reproduced live on `f14d.step.py`: the generate phase ran **10m03s** of a 12-minute build and emitted exactly one progress event, at its start.

Three things compounded:

1. `gen_step()` is called with no arguments and had no way to report, so the longest phase of most builds emitted one event and then nothing.
2. With no previous build's `stageMs`, an indeterminate phase had no duration to interpolate against, so it pinned at its band floor — zero for the first phase.
3. That zero-ratio report then *suppressed* the overlay's own clock-based estimator, which exists for exactly this case.

The root cause is the overall percentage itself. Phases have no fixed relationship to each other — measured across this repo, `generate` is 11% of one model's build and 84% of another's — so one bar spanning them had to be weighted by a guess, and a first build has no inputs for that guess.

## The change

**Schema v3.** Drops `ratio`, `ratioFloor`, `ratioCeiling`, `phaseExpectedMs`, and the whole weighting apparatus (`DEFAULT_PHASE_WEIGHTS`, `phase_weights_from_stage_ms`, `MIN_PHASE_WEIGHT`, `INDETERMINATE_PHASE_CEILING`, `_bounds`, `_compute_ratio`). A phase reports its place in the run and **either** a real `done`/`total` **or** a `detail` label naming the sub-unit in flight. Uncountable phases render an indeterminate bar with no number, which also deletes the reader-side interpolation, both estimators and three ceiling constants.

**A generator can speak.** A `ContextVar` binds the lock-holding run for the duration of `generator()` — the in-process twin of `run_node_builder`, which already lets a Node child describe its work over a pipe. `cadgen.progress` exposes `track()` and `report()`; silent generators are byte-identical to before. `f14d.step.py` is the worked example.

## Also brought onto the same model

All of these reported nothing at all before:

- **Exports** — `generator_busy` yields a `BuildRun`, so `cad export` narrates the same multi-minute `gen_step()` a build runs. The viewer's export status line is live rather than a static `Exporting STL...`.
- **Robot loads** — the mesh count the loader already computed reached only the filename chip; it now drives the overlay.
- **Snapshot CLI** — `SnapshotProgress` deleted. Its per-job counter, previously formatted *into* a phase name (`rendering 3/12 model.step`), is a real `done`/`total`.
- **`inspect` and snapshot's STEP builds** — they took the lock and reported to the viewer only, so a terminal caller watched a silent process.

## CLI

Each phase becomes a durable line with its duration:

```
models/renders/f14d/f14d.step.py
  ✓ building geometry            10m03s
  ✓ collecting parts               1.1s
    meshing components  ▕█████░░░░░░░░▏  312/1127  7f3e91aa
```

Nested builds compose rather than fight: a cold snapshot paints the STEP build's four phases, then its own two.

## Notes for review

- `cadgen.cli_progress` is new. The tty painter had to leave `_internal/generation`: the snapshot CLI is pinned to import no heavy CAD modules, and reaching for a progress line dragged OCP in behind it (`test_cli_import_does_not_import_heavy_cad_modules` caught this).
- No backwards compatibility, as agreed. An older reader sees `schemaVersion != 3` and renders no bar — the same degradation as an unreadable file.
- **A count is not linear in time.** f14d's 10 systems include one airframe loft that measured 22.5 of 24.5 minutes, so `0/10` sits for a long time and then the rest tick past in ~77s. True, but coarse; finer instrumentation inside `f14_parts/body.py` is the follow-up.
- `design/artifact-generation-coordination.md` gains a "superseded in part" note; its locking and attribution rules still hold.

## Testing

Full suite green: 1,145 JS tests (viewer 294, cadjs 500, implicitjs 351) and the whole Python suite. `scripts/bundle/bundle.sh --check` clean, `npm --prefix viewer run build` clean. Verified end to end in the viewer against live cold builds for STEP, and against real status records for every phase.

Robot load progress is covered by unit tests rather than a screenshot — 11 small meshes load in well under a second, so the state could not be captured visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)