### PR TITLE
fix(viewer): open a Windows drive-letter directory instead of 403

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,9 @@ URL, and `?file=` selects one artifact within it:
 http://127.0.0.1:3245/absolute/model/root?file=path/relative/to/that/root
 ```
 
+On Windows the drive is part of that path, after the leading slash and with
+forward slashes: `D:\project\models` is `.../3245/D:/project/models`.
+
 The Viewer is not started against a directory — it opens whatever a URL names, so
 one instance serves any folder **under its own served root**. That qualifier
 matters in a worktree: an instance started from another checkout resolves paths

--- a/skills/cad-viewer/SKILL.md
+++ b/skills/cad-viewer/SKILL.md
@@ -43,6 +43,10 @@ arbitrary working directory — usually wherever the skill happens to be install
 not the model directory — so a relative path resolves against the wrong place.
 The `file=` value is relative to that directory.
 
+**On Windows the drive goes in the path, after the URL's leading slash**, with
+forward slashes: `D:\project\models` is `http://127.0.0.1:3245/D:/project/models`.
+The launcher prints this form already; build it the same way by hand.
+
 **The path is the workspace, not the file's folder.** The Viewer scans it
 recursively, so the file browser lists every model beneath it and the user can
 switch files without a new link. Pick the directory the user thinks of as their

--- a/tests/python/skills/cad/snapshot/test_cli.py
+++ b/tests/python/skills/cad/snapshot/test_cli.py
@@ -1402,9 +1402,12 @@ class SnapshotCliTests(unittest.TestCase):
             )
 
     def test_timestamp_output_path_preserves_extension(self) -> None:
+        # The helper returns a NATIVE path -- both callers resolve its result as one --
+        # so the expectation is built the same way rather than hard-coding `/`, which
+        # failed on Windows against the `\` the helper actually returns (issue #196).
         self.assertEqual(
             timestamp_output_path("snapshots/review.png", "20260527T163012Z"),
-            "snapshots/review_20260527T163012Z.png",
+            str(Path("snapshots") / "review_20260527T163012Z.png"),
         )
 
     def test_removed_daemon_flags_stay_removed(self) -> None:

--- a/viewer/server_py/backend.py
+++ b/viewer/server_py/backend.py
@@ -14,6 +14,7 @@ from urllib.parse import urlsplit, parse_qs, unquote
 
 from . import artifact as artifact_mod
 from . import cadgen_bridge
+from . import paths
 from . import scanner
 from .content_types import content_type_for_path
 from .save_dialog import pick_save_destination
@@ -50,6 +51,8 @@ def normalized_file_ref(value: str) -> str:
         return ""
     if "\0" in raw:
         raise ValueError("File path contains an invalid null byte")
+    # A ref can reach us in URL-path form (`/D:/models/part.step`) the same way ?dir= does.
+    raw = paths.filesystem_path_from_url_path(raw)
     return absolute_file_ref(raw) if os.path.isabs(raw) else raw.lstrip("/")
 
 
@@ -167,7 +170,10 @@ class LocalAssetBackend:
     kind = "local-fs"
 
     def resolve_root(self, root_dir: str = "") -> dict:
-        root_path = os.path.abspath(str(root_dir or "").strip() or os.getcwd())
+        # ?dir= is a URL path, so a Windows root arrives as `/D:/models`; abspath would
+        # read the leading slash as the current drive's root and answer `C:\D:\models`.
+        requested = paths.filesystem_path_from_url_path(str(root_dir or "").strip())
+        root_path = os.path.abspath(requested or os.getcwd())
         if "\0" in root_path:
             raise ValueError("CAD Viewer directory contains an invalid null byte")
         require_directory(root_path)

--- a/viewer/server_py/paths.py
+++ b/viewer/server_py/paths.py
@@ -1,0 +1,71 @@
+"""Translation between a Viewer URL's path and a filesystem path.
+
+A page URL's PATH is the absolute directory it opens, exactly as in a file://
+URL. On POSIX the two forms are identical -- `/Users/me/models` is already the
+filesystem path -- so this module is a no-op there. On Windows they differ: an
+absolute path carries a drive (`D:\\models`) while a URL path must begin with
+`/`, so the wire form is `/D:/models`. The client reads that straight off
+`location.pathname` and hands it back as `?dir=`.
+
+That leading slash is URL syntax, NOT part of the path, and every stdlib path
+call reads it as one:
+
+    os.path.abspath("/D:/models")        -> "C:\\D:\\models"   (slash = current drive's root)
+    os.path.join(dist_root, "D:/models") -> "D:\\models"       (drive-absolute arg drops the base)
+
+Both silently produce a path the user never asked for -- the second one made
+every Windows directory request look like a traversal escape and return 403
+(issue #211). Neither is caught by an ubuntu-only CI, which is why the seam
+lives in one module with both directions named.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Bound once so tests can swap in `ntpath` and exercise the Windows branches on a
+# POSIX host. `splitdrive` is what makes these helpers platform-correct without an
+# `os.name` check: on POSIX it never reports a drive, so every transform below
+# degrades to the identity.
+_PATH = os.path
+
+
+def filesystem_path_from_url_path(value: str) -> str:
+    """The filesystem path a Viewer URL path names.
+
+    Drops the URL's leading separator when a drive letter follows it, so
+    `/D:/models` resolves as `D:\\models` rather than `C:\\D:\\models`. A POSIX
+    path is returned unchanged -- its leading slash IS part of the path.
+    """
+    text = str(value or "")
+    if text[:1] in ("/", "\\") and _PATH.splitdrive(text[1:])[0]:
+        return text[1:]
+    return text
+
+
+def url_path_from_filesystem_path(file_path: str) -> str:
+    """The URL path that opens a directory: the inverse of the above.
+
+    `D:\\models` becomes `/D:/models`; a POSIX path is already its own URL path.
+    Returns "" for an empty input, which names no directory (the backend reads
+    that as its cwd).
+
+    Only the PLATFORM's separator is rewritten, so a backslash stays a literal
+    filename character on POSIX, where it legally is one.
+    """
+    text = str(file_path or "").replace(_PATH.sep, "/")
+    if not text:
+        return ""
+    return text if text.startswith("/") else "/" + text
+
+
+def url_path_as_relative(value: str) -> str:
+    """A URL path reduced to a RELATIVE path, safe to join onto a base directory.
+
+    Strips leading separators and any drive so `os.path.join(base, ...)` cannot
+    silently discard `base`. Traversal segments are deliberately preserved: the
+    caller still has to run its own containment check, and this must not be
+    mistaken for one.
+    """
+    stripped = str(value or "").lstrip("/\\")
+    return _PATH.splitdrive(stripped)[1].lstrip("/\\")

--- a/viewer/server_py/server.py
+++ b/viewer/server_py/server.py
@@ -34,12 +34,14 @@ if __package__ in (None, ""):
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from server_py import backend as backend_mod
     from server_py import cadgen_bridge
+    from server_py import paths
     from server_py import server_info as server_info_mod
     from server_py import encoding as enc
     from server_py.content_types import content_type_for_static_asset
 else:
     from . import backend as backend_mod
     from . import cadgen_bridge
+    from . import paths
     from . import server_info as server_info_mod
     from . import encoding as enc
     from .content_types import content_type_for_static_asset
@@ -233,6 +235,14 @@ class Handler(BaseHTTPRequestHandler):
         # index.html. That includes directory paths containing dots — `/Users/j/v0.4/models`
         # is a directory, not a missing file — which is why "has an extension" cannot be
         # the static-asset test here; only the bundle's own /assets/ prefix can be.
+        #
+        # The join must be given a RELATIVE path: a Windows directory request arrives as
+        # `/D:/models`, and os.path.join drops its base when a later component is
+        # drive-absolute, so joining that raw escaped dist_root and the containment check
+        # below rejected an ordinary directory as traversal (issue #211). Stripping the
+        # drive keeps the join inside dist_root, where no such file exists, so the request
+        # falls through to index.html like any other directory. Traversal segments survive
+        # the strip and are still caught by the check.
         dist_root = _Ctx.dist_root
         request_path = "/index.html" if path == "/" else path
         try:
@@ -240,7 +250,7 @@ class Handler(BaseHTTPRequestHandler):
         except ValueError:
             self._plain(400, "Bad request")
             return
-        file_path = os.path.abspath(os.path.join(dist_root, decoded.lstrip("/")))
+        file_path = os.path.abspath(os.path.join(dist_root, paths.url_path_as_relative(decoded)))
         if not (file_path == dist_root or file_path.startswith(dist_root + os.sep)):
             self._plain(403, "Forbidden")
             return

--- a/viewer/server_py/server_info.py
+++ b/viewer/server_py/server_info.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import os
 
+from .paths import filesystem_path_from_url_path
+
 VIEWER_SERVER_INFO_SCHEMA_VERSION = 1
 VIEWER_SERVER_APP_ID = "cad-viewer"
 DEFAULT_VIEWER_HOST = "127.0.0.1"
@@ -23,8 +25,13 @@ def normalize_viewer_port(value, fallback=DEFAULT_VIEWER_PORT) -> int:
 
 def _resolve_view_root(root_dir: str) -> dict:
     """The requested directory, absolute. Empty means the process cwd — the same
-    fallback the backend applies, since a request's URL path IS its directory."""
-    resolved = os.path.abspath(str(root_dir or "").strip() or os.getcwd())
+    fallback the backend applies, since a request's URL path IS its directory.
+
+    Routed through the URL-path reader for the same reason `LocalAssetBackend.resolve_root`
+    is:
+    a Windows directory arrives as `/D:/models`, which abspath alone turns into
+    `C:\\D:\\models`."""
+    resolved = os.path.abspath(filesystem_path_from_url_path(str(root_dir or "").strip()) or os.getcwd())
     return {"dir": resolved, "rootPath": resolved, "rootName": os.path.basename(resolved)}
 
 

--- a/viewer/server_py/start_viewer.py
+++ b/viewer/server_py/start_viewer.py
@@ -30,9 +30,11 @@ import sys
 if __package__ in (None, ""):
     sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     from server_py import cadgen_bridge
+    from server_py.paths import url_path_from_filesystem_path
     from server_py.server_info import DEFAULT_VIEWER_PORT, DEFAULT_VIEWER_HOST
 else:
     from . import cadgen_bridge
+    from .paths import url_path_from_filesystem_path
     from .server_info import DEFAULT_VIEWER_PORT, DEFAULT_VIEWER_HOST
 
 _PROBE_TIMEOUT_S = 0.35
@@ -41,8 +43,12 @@ _VIEWER_APP_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 def viewer_url(host: str, port: int, directory: str = "") -> str:
     """The Viewer URL for a directory: the absolute path IS the URL path, exactly as
-    in a file:// URL. No directory yields the bare origin, which opens the cwd."""
-    path = os.path.abspath(directory) if str(directory or "").strip() else ""
+    in a file:// URL. No directory yields the bare origin, which opens the cwd.
+
+    A Windows path is not already a URL path — pasting `D:\\models` on the end of the
+    origin yields `http://127.0.0.1:3245D:\\models`, which is not a URL at all — so the
+    absolute path is converted rather than concatenated."""
+    path = url_path_from_filesystem_path(os.path.abspath(directory)) if str(directory or "").strip() else ""
     return f"http://{host}:{port}{path or '/'}"
 
 

--- a/viewer/server_py/tests/test_windows_drive_paths.py
+++ b/viewer/server_py/tests/test_windows_drive_paths.py
@@ -1,0 +1,366 @@
+"""A Windows drive-letter directory must open, not 403 (issue #211).
+
+`http://127.0.0.1:3245/D:/some/project/models` returned `403 Forbidden` for every
+Windows user. The URL-path form of an absolute Windows path (`/D:/models`) is not
+a filesystem path, and two stdlib calls read it wrong in opposite ways:
+
+    os.path.join(dist_root, "D:/models") -> "D:\\models"      base DISCARDED -> 403
+    os.path.abspath("/D:/models")        -> "C:\\D:\\models"  leading slash = current drive
+
+The first made an ordinary directory request look like a traversal escape; fixing
+it surfaced the second in `resolve_root`, where the catalog then failed with
+`CAD Viewer directory not found: C:\\D:\\some\\project`.
+
+CI is ubuntu-only (issue #196), where `splitdrive` never reports a drive and every
+transform below is the identity -- so none of this is observable here unless the
+tests say so. They bind `paths._PATH` to `ntpath` to run the Windows branches on a
+POSIX host, and assert alongside that POSIX behaviour is genuinely unchanged.
+"""
+
+from __future__ import annotations
+
+import ntpath
+import os
+import pathlib
+import posixpath
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from server_py import backend as backend_mod  # noqa: E402
+from server_py import paths  # noqa: E402
+from server_py import server as server_mod  # noqa: E402
+from server_py import server_info  # noqa: E402
+from server_py import start_viewer  # noqa: E402
+
+
+def _as_windows():
+    """Give `paths` the path semantics of a real Windows host."""
+    return mock.patch.object(paths, "_PATH", ntpath)
+
+
+def _as_posix():
+    return mock.patch.object(paths, "_PATH", posixpath)
+
+
+class _NtPathWithOverrides:
+    """`ntpath`, with named functions replaced -- e.g. an `isdir` that says yes to a
+    drive that does not exist on the host running the test."""
+
+    def __init__(self, **overrides):
+        self._overrides = overrides
+
+    def __getattr__(self, name):
+        try:
+            return self._overrides[name]
+        except KeyError:
+            return getattr(ntpath, name)
+
+
+def _windows_os_for(module, **path_overrides):
+    """Swap one module's `os` for a Windows-semantics stand-in.
+
+    Scoped to the module under test rather than patching the global `os.path`, which
+    would redirect every other caller in the process for the duration.
+    """
+    shim = types.SimpleNamespace(
+        path=_NtPathWithOverrides(**path_overrides),
+        sep=ntpath.sep,
+        getcwd=os.getcwd,
+        getpid=os.getpid,
+    )
+    return mock.patch.object(module, "os", shim)
+
+
+class UrlPathToFilesystemPathTests(unittest.TestCase):
+    def test_a_windows_url_path_drops_the_url_leading_slash(self):
+        with _as_windows():
+            self.assertEqual("D:/some/project", paths.filesystem_path_from_url_path("/D:/some/project"))
+            self.assertEqual("C:/", paths.filesystem_path_from_url_path("/C:/"))
+            self.assertEqual("d:/lower/drive", paths.filesystem_path_from_url_path("/d:/lower/drive"))
+
+    def test_an_already_bare_windows_path_is_untouched(self):
+        with _as_windows():
+            self.assertEqual("D:/some/project", paths.filesystem_path_from_url_path("D:/some/project"))
+
+    def test_a_posix_leading_slash_is_part_of_the_path_and_is_kept(self):
+        for as_platform in (_as_posix, _as_windows):
+            with self.subTest(platform=as_platform.__name__), as_platform():
+                self.assertEqual("/Users/me/models", paths.filesystem_path_from_url_path("/Users/me/models"))
+
+    def test_a_posix_host_never_strips_a_drive_looking_path(self):
+        # A directory literally named `D:` at the root is legal on POSIX and must survive.
+        with _as_posix():
+            self.assertEqual("/D:/some/project", paths.filesystem_path_from_url_path("/D:/some/project"))
+
+    def test_empty_and_relative_inputs_pass_through(self):
+        with _as_windows():
+            self.assertEqual("", paths.filesystem_path_from_url_path(""))
+            self.assertEqual("", paths.filesystem_path_from_url_path(None))
+            self.assertEqual("models/part.step", paths.filesystem_path_from_url_path("models/part.step"))
+
+
+class FilesystemPathToUrlPathTests(unittest.TestCase):
+    def test_a_windows_path_becomes_a_url_path(self):
+        with _as_windows():
+            self.assertEqual("/D:/some/project", paths.url_path_from_filesystem_path("D:\\some\\project"))
+
+    def test_a_posix_path_is_already_its_own_url_path(self):
+        with _as_posix():
+            self.assertEqual("/Users/me/models", paths.url_path_from_filesystem_path("/Users/me/models"))
+
+    def test_a_backslash_stays_a_filename_character_on_posix(self):
+        with _as_posix():
+            self.assertEqual("/Users/me/od\\d", paths.url_path_from_filesystem_path("/Users/me/od\\d"))
+
+    def test_empty_names_no_directory(self):
+        with _as_windows():
+            self.assertEqual("", paths.url_path_from_filesystem_path(""))
+
+    def test_round_trip(self):
+        with _as_windows():
+            url_path = paths.url_path_from_filesystem_path("D:\\some\\project")
+            self.assertEqual("D:/some/project", paths.filesystem_path_from_url_path(url_path))
+
+
+class UrlPathAsRelativeTests(unittest.TestCase):
+    """What the dist join needs: a path that can never discard the base it is joined to."""
+
+    def test_a_windows_directory_request_is_reduced_to_a_relative_path(self):
+        with _as_windows():
+            self.assertEqual("some/project/models", paths.url_path_as_relative("/D:/some/project/models"))
+
+    def test_a_bundle_asset_path_keeps_everything_but_its_leading_slash(self):
+        for as_platform in (_as_posix, _as_windows):
+            with self.subTest(platform=as_platform.__name__), as_platform():
+                self.assertEqual("assets/index-abc123.js", paths.url_path_as_relative("/assets/index-abc123.js"))
+
+    def test_the_result_is_never_absolute_to_the_join_that_consumes_it(self):
+        # The invariant is per-platform: `D:/models` is absolute to ntpath.join and
+        # relative to posixpath.join, and only the host's own module does the join.
+        candidates = (
+            "/D:/some/project",
+            "//D:/some/project",
+            "\\\\D:\\some\\project",
+            "/C:/Windows/System32",
+            "/Users/me/models",
+            "/",
+            "",
+        )
+        for as_platform, path_module in ((_as_posix, posixpath), (_as_windows, ntpath)):
+            for candidate in candidates:
+                with self.subTest(platform=path_module.__name__, candidate=candidate), as_platform():
+                    result = paths.url_path_as_relative(candidate)
+                    self.assertFalse(path_module.isabs(result), result)
+                    # The point of the invariant: the base survives the join.
+                    self.assertTrue(path_module.join("base", result).startswith("base"), result)
+
+    def test_traversal_segments_survive_so_the_containment_check_still_sees_them(self):
+        # This helper is NOT a traversal guard and must not be mistaken for one.
+        with _as_windows():
+            self.assertEqual("../../etc/passwd", paths.url_path_as_relative("/../../etc/passwd"))
+
+
+class _RecordingHandler(server_mod.Handler):
+    """A Handler with the socket machinery replaced by recording stubs.
+
+    `BaseHTTPRequestHandler.__init__` would serve a request off a real socket, so it
+    is deliberately not called.
+    """
+
+    def __init__(self):  # noqa: D107 - see class docstring
+        self.command = "GET"
+        self.status = None
+        self.sent_headers = {}
+        self.body = b""
+        self.wfile = self
+
+    def send_response(self, code, message=None):
+        self.status = code
+
+    def send_header(self, key, value):
+        self.sent_headers[str(key).lower()] = value
+
+    def end_headers(self):
+        pass
+
+    def write(self, data):
+        self.body += data
+
+
+class ServeDistPosixTests(unittest.TestCase):
+    """POSIX serving is unchanged by the fix -- including the traversal guard."""
+
+    def setUp(self):
+        self._dist = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dist.cleanup)
+        dist_root = str(pathlib.Path(self._dist.name).resolve())
+        pathlib.Path(dist_root, "index.html").write_text("<!doctype html><title>cad</title>", encoding="utf-8")
+        assets = pathlib.Path(dist_root, "assets")
+        assets.mkdir()
+        (assets / "index-abc123.js").write_text("export default 1;\n", encoding="utf-8")
+
+        previous = server_mod._Ctx.dist_root
+        server_mod._Ctx.dist_root = dist_root
+        self.addCleanup(setattr, server_mod._Ctx, "dist_root", previous)
+        self.dist_root = dist_root
+
+    def _get(self, request_path):
+        handler = _RecordingHandler()
+        handler._serve_dist(request_path)
+        return handler
+
+    def test_an_absolute_directory_falls_through_to_the_spa(self):
+        handler = self._get("/Users/me/robots/models")
+        self.assertEqual(200, handler.status)
+        self.assertIn(b"<!doctype html>", handler.body)
+
+    def test_a_directory_containing_dots_is_still_a_directory(self):
+        self.assertEqual(200, self._get("/Users/j/v0.4/models").status)
+
+    def test_a_bundle_asset_is_served_from_dist(self):
+        handler = self._get("/assets/index-abc123.js")
+        self.assertEqual(200, handler.status)
+        self.assertEqual(b"export default 1;\n", handler.body)
+
+    def test_a_missing_bundle_asset_is_404_not_the_spa(self):
+        self.assertEqual(404, self._get("/assets/does-not-exist.js").status)
+
+    def test_traversal_out_of_dist_root_is_still_forbidden(self):
+        self.assertEqual(403, self._get("/../../../../etc/passwd").status)
+
+    def test_a_malformed_percent_escape_is_still_a_bad_request(self):
+        self.assertEqual(400, self._get("/models/%zz").status)
+
+
+class _RoutingHandler(_RecordingHandler):
+    """Records WHICH file `_serve_dist` chose instead of reading it.
+
+    Lets the Windows routing run against paths (`C:\\viewer\\dist\\index.html`) that
+    cannot exist on the host running the test.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.served = []
+
+    def _serve_static_file(self, file_path, content_type):
+        self.served.append(file_path)
+        self.status = 200
+        return True
+
+
+class ServeDistWindowsTests(unittest.TestCase):
+    """The 403 from issue #211, at the routing level that produced it."""
+
+    DIST_ROOT = "C:\\viewer\\dist"
+
+    def setUp(self):
+        previous = server_mod._Ctx.dist_root
+        server_mod._Ctx.dist_root = self.DIST_ROOT
+        self.addCleanup(setattr, server_mod._Ctx, "dist_root", previous)
+
+    def _get(self, request_path, **path_overrides):
+        handler = _RoutingHandler()
+        # No file exists under a fabricated dist root, so every lookup misses and the
+        # route is decided by the containment check alone -- which is the thing at issue.
+        overrides = {"isfile": lambda value: False}
+        overrides.update(path_overrides)
+        with _as_windows(), _windows_os_for(server_mod, **overrides):
+            handler._serve_dist(request_path)
+        return handler
+
+    def test_a_drive_letter_directory_serves_the_spa_instead_of_403(self):
+        handler = self._get("/D:/some/project/models")
+        self.assertEqual(200, handler.status)
+        self.assertEqual(["C:\\viewer\\dist\\index.html"], handler.served)
+
+    def test_the_drive_the_viewer_itself_lives_on_is_no_different(self):
+        self.assertEqual(200, self._get("/C:/Users/me/models").status)
+
+    def test_a_bundle_asset_is_still_looked_up_under_dist_root(self):
+        handler = self._get("/assets/index-abc123.js", isfile=lambda value: True)
+        self.assertEqual(["C:\\viewer\\dist\\assets\\index-abc123.js"], handler.served)
+
+    def test_a_missing_bundle_asset_is_still_404(self):
+        handler = self._get("/assets/does-not-exist.js")
+        self.assertEqual(404, handler.status)
+        self.assertEqual([], handler.served)
+
+    def test_traversal_out_of_dist_root_is_still_forbidden(self):
+        handler = self._get("/../../Windows/System32/drivers/etc/hosts")
+        self.assertEqual(403, handler.status)
+        self.assertEqual([], handler.served)
+
+
+class ResolveRootTests(unittest.TestCase):
+    def test_a_windows_url_path_root_is_not_prefixed_with_the_process_drive(self):
+        # The catalog failed with `CAD Viewer directory not found: C:\D:\some\project`.
+        with _as_windows(), _windows_os_for(backend_mod, isdir=lambda value: True):
+            resolved = backend_mod.LocalAssetBackend().resolve_root("/D:/some/project")
+
+        self.assertEqual("D:\\some\\project", resolved["rootPath"])
+        self.assertEqual("D:/some/project", resolved["dir"])
+        self.assertEqual("project", resolved["rootName"])
+
+    def test_a_posix_root_still_resolves_unchanged(self):
+        with tempfile.TemporaryDirectory() as directory:
+            resolved = backend_mod.LocalAssetBackend().resolve_root(str(pathlib.Path(directory).resolve()))
+            self.assertEqual(str(pathlib.Path(directory).resolve()), resolved["rootPath"])
+
+    def test_a_missing_directory_still_reports_the_path_asked_for(self):
+        with self.assertRaisesRegex(ValueError, "CAD Viewer directory not found"):
+            backend_mod.LocalAssetBackend().resolve_root("/no/such/viewer/directory")
+
+
+class NormalizedFileRefTests(unittest.TestCase):
+    def test_a_windows_url_path_ref_resolves_to_its_drive(self):
+        with _as_windows(), _windows_os_for(backend_mod):
+            self.assertEqual(
+                "D:/some/project/part.step",
+                backend_mod.normalized_file_ref("/D:/some/project/part.step"),
+            )
+
+    def test_a_relative_ref_is_still_relative(self):
+        self.assertEqual("models/part.step", backend_mod.normalized_file_ref("models/part.step"))
+
+    def test_a_posix_absolute_ref_is_unchanged(self):
+        self.assertEqual("/Users/me/models/part.step", backend_mod.normalized_file_ref("/Users/me/models/part.step"))
+
+
+class ServerInfoRootTests(unittest.TestCase):
+    def test_the_reported_root_matches_what_the_backend_resolves(self):
+        with _as_windows(), _windows_os_for(server_info):
+            info = server_info.build_viewer_server_info(root_dir="/D:/some/project")
+
+        self.assertEqual("D:\\some\\project", info["rootPath"])
+        self.assertEqual("D:\\some\\project", info["rootDir"])
+        self.assertEqual("project", info["rootName"])
+
+
+class ViewerUrlTests(unittest.TestCase):
+    def test_a_windows_directory_produces_a_usable_url(self):
+        with _as_windows(), _windows_os_for(start_viewer):
+            url = start_viewer.viewer_url("127.0.0.1", 3245, "D:\\some\\project")
+
+        # Concatenating the raw path yielded `http://127.0.0.1:3245D:\some\project`,
+        # which is not a URL at all.
+        self.assertEqual("http://127.0.0.1:3245/D:/some/project", url)
+
+    def test_a_posix_directory_is_unchanged(self):
+        with _as_posix():
+            self.assertEqual(
+                "http://127.0.0.1:3245/Users/me/models",
+                start_viewer.viewer_url("127.0.0.1", 3245, "/Users/me/models"),
+            )
+
+    def test_no_directory_still_yields_the_bare_origin(self):
+        self.assertEqual("http://127.0.0.1:3245/", start_viewer.viewer_url("127.0.0.1", 3245, ""))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

On Windows, opening the CAD Viewer against any absolute directory returned `403 Forbidden`. A Viewer page URL's path **is** the absolute directory it opens. On POSIX those two forms are identical, so nothing ever noticed they are different concepts. On Windows they diverge — an absolute path carries a drive (`D:\models`) while a URL path must start with `/` — so the wire form is `/D:/models`, and two stdlib calls read it wrong in opposite directions:

```
os.path.join(dist_root, "D:/models")  ->  "D:\models"      # base silently DISCARDED -> 403
os.path.abspath("/D:/models")         ->  "C:\D:\models"   # leading slash = current drive's root
```

The first made every Windows directory request look like a traversal escape; the second then failed the catalog with `CAD Viewer directory not found: C:\D:\some\project`.

## Approach

Both directions of the URL-path ↔ filesystem-path translation now live in one module, `viewer/server_py/paths.py`, rather than being patched at the two reported sites. `splitdrive` is what makes it platform-correct without an `os.name` check: on POSIX it never reports a drive, so **every transform degrades to the identity and existing behaviour is unchanged by construction**.

Four call sites route through it. Two were reported in #211; two are the same root cause, unreported, and would still have been broken after the reported fixes:

| Site | Symptom |
| --- | --- |
| `server.py` `_serve_dist` | the reported 403 |
| `backend.py` `resolve_root` | the reported `C:\D:\...` catalog failure |
| `server_info.py` `_resolve_view_root` | `/__cad/server` reported `C:\D:\...` as the Viewer's own root |
| `start_viewer.py` `viewer_url` | printed `http://127.0.0.1:3245D:\some\project` — not a URL at all, so a Windows user could not copy a working link out of the launcher |

`_serve_dist` is fixed by reducing the request path to a **relative** one rather than short-circuiting to `index.html` as the issue suggested. That keeps a single code path and, importantly, leaves the traversal guard doing its job: `..` segments survive the strip and are still rejected.

## Testing

CI is ubuntu-only, which is why this shipped — on Linux every one of these transforms is a no-op. `viewer/server_py/tests/test_windows_drive_paths.py` (35 tests) binds the path module to `ntpath` to run the Windows branches on a POSIX host.

I verified the tests are real by reverting the source and re-running: **6 fail against the unfixed code and pass with it**, including the reported `403 != 200` at the handler level. They also pin POSIX behaviour as unchanged — directories serve the SPA, bundle assets serve, traversal is still 403, malformed escapes are still 400.

Ran green: viewer backend 174/174, snapshot CLI 88/88, global policy 56/56, `scripts/bundle/bundle.sh --check`, `scripts/dev/setup-symlinks.sh --check`.

## Folding in the other Windows issue

Also applies the Python half of #196 — the timestamp-path helper returns a native path (both callers resolve it as one), so the expectation is built the same way instead of hard-coding `/`.

That issue's JavaScript half is **obsolete**: `packages/implicitjs/scripts/snapshot.mjs` was deleted in 5f008ddc when implicit snapshots re-pointed onto the shared Python CLI. That is also why #205 shows as conflicting — it patches a file that no longer exists on `develop`. #205 can be closed as superseded; credit to @SulimanAbdulrazzaq for the diagnosis and the platform-native approach, which is what this uses.

Closes #211. Closes #196. Supersedes #205.

## Note on the base branch

Opened against `develop`, not `main`, as the request specified: `CONTRIBUTING.md` states "`main` is publish-only: do not open PRs to `main` or push it directly", and a PR from the symlink layout to the real-copies layout on `main` would also produce a structurally wrong diff and get no CI. This should reach `main` through the normal `Release` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
