### PR TITLE
Release: publish docs from source, and trim docs/, packages/, tests/ from main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,17 +1,29 @@
 name: Deploy Docs
 
+# Deploys the docs site from a SOURCE ref, never from main.
+#
+# The docs app is a website, not something anyone installs, and it builds against
+# repo-root packages/: docs/tsconfig.json maps cadjs/* to ../packages/cadjs/src/*,
+# and packages/cadjs/src/common pulls implicitjs. Both docs/ and packages/ are
+# therefore trimmed out of the publish tree, so main cannot build this.
+#
+# Releases pass the release SOURCE commit (release-pr's source_sha), which already
+# carries the bumped VERSION and the stamped docs/package.json that the site header
+# reads. To redeploy a past release, use that release's source commit -- every
+# publish commit records it as its second parent, so `git rev-parse <tag>^2`.
+
 on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Production-layout ref to deploy, normally main or a publish commit.
+        description: Source ref to deploy — develop, or a release source commit (git rev-parse <tag>^2). Never main.
         required: true
-        default: main
+        default: develop
         type: string
   workflow_call:
     inputs:
       ref:
-        description: Production-layout ref to deploy.
+        description: Source ref to deploy.
         required: true
         type: string
 
@@ -33,6 +45,22 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
+
+      # A publish-layout ref has neither, and the failure would otherwise surface
+      # as an opaque module-resolution error deep in `next build`.
+      - name: Check this ref can build the docs site
+        run: |
+          missing=""
+          [ -d docs ] || missing="$missing docs/"
+          [ -d packages/cadjs/src ] || missing="$missing packages/cadjs/src"
+          [ -d packages/implicitjs/src ] || missing="$missing packages/implicitjs/src"
+          if [ -n "$missing" ]; then
+            echo "This ref cannot build the docs site; missing:$missing" >&2
+            echo "main is the publish branch and drops docs/ and packages/." >&2
+            echo "Deploy from a source ref instead — develop, or a release source" >&2
+            echo "commit: git rev-parse <tag>^2" >&2
+            exit 1
+          fi
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,14 +375,28 @@ jobs:
         run: scripts/test/test.sh
 
       # The plugin package is the repository root, so everything that reaches the
-      # target branch is copied into every install. models/ is fixture data;
-      # viewer/ is the SOURCE app, and what installs and runs is the dereferenced
-      # runtime the bundle already wrote to skills/cad-viewer/scripts/viewer --
-      # no skill imports repo-root viewer/. This runs after the bundle,
-      # check-builds, and the tests, so the tree they validated is untouched and
-      # only the published tree is trimmed. The standalone cad-viewer mirror
-      # syncs from the release SOURCE commit rather than from here
-      # (.github/workflows/sync-cad-viewer.yml).
+      # target branch is copied into every install. None of these is part of what
+      # installs:
+      #   models/            fixture data
+      #   viewer/            the SOURCE app -- what runs is the dereferenced
+      #                      runtime the bundle wrote to
+      #                      skills/cad-viewer/scripts/viewer, and no skill
+      #                      imports repo-root viewer/
+      #   tests/             source-only; nothing under skills/ or docs/ reads it,
+      #                      and test.yml runs on develop, never here
+      #   requirements-dev.txt  a source-checkout dev environment whose editable
+      #                      paths (packages/cadgen, viewer/moveit2_server) do not
+      #                      survive the trim anyway
+      #
+      # packages/ deliberately STAYS. The docs site deploys from this branch and
+      # builds against it: docs/tsconfig.json maps cadjs/* to
+      # ../packages/cadjs/src/*, and packages/cadjs/src/common pulls implicitjs.
+      # Removing it fails Deploy Docs in this same run.
+      #
+      # This runs after the bundle, check-builds, and the tests, so the tree they
+      # validated is untouched and only the published tree is trimmed. The
+      # standalone cad-viewer mirror syncs from the release SOURCE commit rather
+      # than from here (.github/workflows/sync-cad-viewer.yml).
       #
       # PUBLISH_TREE_REMOVED_ROOTS is the single source of truth for what was
       # dropped: the commit step below reads it both to assert the roots are
@@ -390,7 +404,7 @@ jobs:
       - name: Trim publish tree
         if: steps.gate.outputs.should_publish == 'true'
         run: |
-          removed_roots="models viewer"
+          removed_roots="models viewer tests requirements-dev.txt"
           for root in $removed_roots; do
             rm -rf "$root"
             if [ -e "$root" ]; then
@@ -401,6 +415,14 @@ jobs:
           if [ ! -f skills/cad-viewer/scripts/viewer/package.json ]; then
             echo "Refusing to publish without the bundled CAD Viewer runtime:" >&2
             echo "  skills/cad-viewer/scripts/viewer/package.json is missing." >&2
+            exit 1
+          fi
+          # Deploy Docs runs from this branch later in the same release and
+          # builds docs/ against packages/cadjs. Assert it survived, so adding
+          # packages/ to removed_roots fails here rather than in the deploy.
+          if [ ! -d packages/cadjs/src ]; then
+            echo "Refusing to publish without packages/cadjs: the docs site" >&2
+            echo "  builds against it (docs/tsconfig.json maps cadjs/* there)." >&2
             exit 1
           fi
           echo "PUBLISH_TREE_REMOVED_ROOTS=$removed_roots" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,11 +387,12 @@ jobs:
       #   requirements-dev.txt  a source-checkout dev environment whose editable
       #                      paths (packages/cadgen, viewer/moveit2_server) do not
       #                      survive the trim anyway
-      #
-      # packages/ deliberately STAYS. The docs site deploys from this branch and
-      # builds against it: docs/tsconfig.json maps cadjs/* to
-      # ../packages/cadjs/src/*, and packages/cadjs/src/common pulls implicitjs.
-      # Removing it fails Deploy Docs in this same run.
+      #   docs/              a website, not an install; Deploy Docs builds and
+      #                      deploys it from the release SOURCE commit
+      #   packages/          the shared source runtimes. Every skill already
+      #                      carries its own vendored copy, and the only other
+      #                      consumer was the docs build, which now runs from
+      #                      source too.
       #
       # This runs after the bundle, check-builds, and the tests, so the tree they
       # validated is untouched and only the published tree is trimmed. The
@@ -404,7 +405,7 @@ jobs:
       - name: Trim publish tree
         if: steps.gate.outputs.should_publish == 'true'
         run: |
-          removed_roots="models viewer tests requirements-dev.txt"
+          removed_roots="models viewer tests requirements-dev.txt docs packages"
           for root in $removed_roots; do
             rm -rf "$root"
             if [ -e "$root" ]; then
@@ -417,12 +418,12 @@ jobs:
             echo "  skills/cad-viewer/scripts/viewer/package.json is missing." >&2
             exit 1
           fi
-          # Deploy Docs runs from this branch later in the same release and
-          # builds docs/ against packages/cadjs. Assert it survived, so adding
-          # packages/ to removed_roots fails here rather than in the deploy.
-          if [ ! -d packages/cadjs/src ]; then
-            echo "Refusing to publish without packages/cadjs: the docs site" >&2
-            echo "  builds against it (docs/tsconfig.json maps cadjs/* there)." >&2
+          # Every skill vendors what it needs, so nothing published may reach
+          # repo-root packages/. A skill that does would break silently on
+          # install rather than here.
+          if grep -rIlE '\.\./\.\./\.\./packages/|["'"'"']\.\./\.\./packages/' skills 2>/dev/null | head -n 1 | grep -q .; then
+            echo "A skill references repo-root packages/, which is not published:" >&2
+            grep -rIlE '\.\./\.\./\.\./packages/|["'"'"']\.\./\.\./packages/' skills >&2
             exit 1
           fi
           echo "PUBLISH_TREE_REMOVED_ROOTS=$removed_roots" >> "$GITHUB_ENV"
@@ -570,13 +571,19 @@ jobs:
           fi
           echo "published=true" >> "$GITHUB_OUTPUT"
 
+  # Deploys from the release SOURCE commit, not the publish commit: the docs app
+  # builds against repo-root packages/, and the publish tree drops both. Still
+  # gated on the publish succeeding, so the site never moves for a release that
+  # did not ship.
   deploy-docs:
     name: Deploy Docs
-    needs: publish
+    needs:
+      - release-pr
+      - publish
     if: ${{ needs.publish.outputs.published == 'true' && inputs.target_branch == 'main' }}
     uses: ./.github/workflows/deploy-docs.yml
     with:
-      ref: ${{ needs.publish.outputs.publish_sha }}
+      ref: ${{ needs.release-pr.outputs.source_sha }}
     secrets: inherit
 
   # Mirrors from the release SOURCE commit, not the publish commit: the publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,14 @@ requested release, and pair it with `bump=none` so a rehearsal does not consume
 a version number. `bump=none` publishes `base_branch` as it stands and is also
 how you resume a failed publish; it is never a release setting.
 
-The standalone `Deploy Docs` workflow redeploys the docs site from `main`
-without running a release. The CAD Viewer is a local-filesystem app with no
-hosted deployment, but each release mirrors `viewer/` into the standalone
-`earthtojake/cad-viewer` repo through the `Sync CAD Viewer Repo` workflow, which
-`Release` calls after publishing and which can also be dispatched on its own.
+The standalone `Deploy Docs` workflow redeploys the docs site without running a
+release. It deploys a source ref (defaulting to `develop`), never `main`: the
+publish tree drops `docs/` and `packages/`, which the docs app builds against.
+The CAD Viewer is a local-filesystem app with no hosted deployment, but each
+release mirrors `viewer/` into the standalone `earthtojake/cad-viewer` repo
+through the `Sync CAD Viewer Repo` workflow, which `Release` calls after
+publishing and which can also be dispatched on its own. Both of those read the
+release SOURCE commit, because `main` carries only what installs.
 `main` is publish-only; pushing `develop` runs tests but
 never publishes. See the Releases section in `CONTRIBUTING.md` for the full
 flow, CI/CD-testing and resume options, and local/manual fallbacks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,19 +183,25 @@ preserves them verbatim, and Codex `plugin add` drops them with no error at all,
 publishing a skill whose files are simply missing at runtime.
 `scripts/github-workflows/check-builds.sh` is the gate that enforces this.
 
-Because the repository root is the plugin package, every source-only directory
-on `main` is copied into every install. The publish job therefore trims the tree
-before committing it — `models/`, `viewer/`, `tests/`, and `requirements-dev.txt`
-are removed, after the bundle and all checks have run against the untrimmed
-tree. `viewer/` in particular is source: what installs and runs is the
-dereferenced runtime under `skills/cad-viewer/scripts/viewer`, and the
-standalone cad-viewer mirror syncs from the release source commit instead.
+Because the repository root is the plugin package, every source-only path on
+`main` is copied into every install. The publish job therefore trims the tree
+before committing it, after the bundle and all checks have run against the
+untrimmed tree. `models/`, `viewer/`, `tests/`, `docs/`, `packages/`, and
+`requirements-dev.txt` are removed, leaving `main` as close to just the plugin
+package as it can be.
 
-`packages/` deliberately stays. The docs site deploys from `main` in the same
-release run and builds against it: `docs/tsconfig.json` maps `cadjs/*` to
-`../packages/cadjs/src/*`, and `packages/cadjs/src/common` pulls in
-`implicitjs`. The trim step asserts `packages/cadjs/src` survived, so adding
-`packages/` to the removal list fails the publish rather than the deploy.
+Nothing is lost, because each of those has a consumer that reads **source**
+rather than the published tree:
+
+- `viewer/` — what installs and runs is the dereferenced runtime under
+  `skills/cad-viewer/scripts/viewer`, and the standalone cad-viewer mirror syncs
+  from the release source commit.
+- `docs/` and `packages/` — `Deploy Docs` builds and deploys from the release
+  source commit. `packages/` has no other published consumer: every skill
+  vendors the runtimes it needs, and the trim step fails the publish if a skill
+  is found reaching into repo-root `packages/`.
+- `models/`, `tests/`, `requirements-dev.txt` — source-only, with no consumer
+  outside a source checkout.
 
 `main` is publish-only: do not open PRs to `main` or push it directly. The `Test`
 workflow runs on `develop` and PRs to `develop`: it starts from the symlink
@@ -314,11 +320,24 @@ missing).
 ### Redeploying the docs site
 
 The standalone `Deploy Docs` workflow redeploys the docs site to Vercel
-production without running a release. It defaults to deploying `main` and
-expects a production-layout ref:
+production without running a release. It deploys a **source** ref and defaults
+to `develop`:
 
 ```bash
-gh workflow run deploy-docs.yml -f ref=main
+gh workflow run deploy-docs.yml -f ref=develop
+```
+
+It cannot deploy `main`. The docs app builds against repo-root `packages/`
+(`docs/tsconfig.json` maps `cadjs/*` to `../packages/cadjs/src/*`), and the
+publish tree drops both `docs/` and `packages/`. The workflow checks for them up
+front and fails with that explanation rather than an opaque module-resolution
+error inside `next build`.
+
+To redeploy the site as it stood at a past release, use that release's source
+commit. Every publish commit records it as its second parent:
+
+```bash
+gh workflow run deploy-docs.yml -f ref="$(git rev-parse 0.4.6^2)"
 ```
 
 The CAD Viewer is a local-filesystem app and has no hosted deployment.
@@ -328,14 +347,18 @@ The CAD Viewer is a local-filesystem app and has no hosted deployment.
 `viewer/` is published as its own standalone repo,
 [`earthtojake/cad-viewer`](https://github.com/earthtojake/cad-viewer). The
 `Release` workflow calls `Sync CAD Viewer Repo` after publishing to `main`, so
-the mirror tracks releases rather than in-flight `develop` work. Dispatch it on
-its own for an out-of-band sync, or with `dry_run` to build and verify the
-mirror without pushing:
+the mirror tracks releases rather than in-flight `develop` work. It mirrors from
+the release **source** commit, not from `main`, which carries no `viewer/`.
+Dispatch it on its own for an out-of-band sync, or with `dry_run` to build and
+verify the mirror without pushing:
 
 ```bash
-gh workflow run sync-cad-viewer.yml -f ref=main
-gh workflow run sync-cad-viewer.yml -f ref=main -f dry_run=true
+gh workflow run sync-cad-viewer.yml -f ref=develop
+gh workflow run sync-cad-viewer.yml -f ref=develop -f dry_run=true
 ```
+
+Use a past release's source commit — `git rev-parse <tag>^2` — to re-sync the
+mirror as it stood at that release.
 
 The workflow needs a `CAD_VIEWER_SYNC_TOKEN` secret with `contents:write` on the
 mirror repo. Before pushing, it runs `npm ci`, `npm run test`, `npm run build`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,20 @@ preserves them verbatim, and Codex `plugin add` drops them with no error at all,
 publishing a skill whose files are simply missing at runtime.
 `scripts/github-workflows/check-builds.sh` is the gate that enforces this.
 
+Because the repository root is the plugin package, every source-only directory
+on `main` is copied into every install. The publish job therefore trims the tree
+before committing it — `models/`, `viewer/`, `tests/`, and `requirements-dev.txt`
+are removed, after the bundle and all checks have run against the untrimmed
+tree. `viewer/` in particular is source: what installs and runs is the
+dereferenced runtime under `skills/cad-viewer/scripts/viewer`, and the
+standalone cad-viewer mirror syncs from the release source commit instead.
+
+`packages/` deliberately stays. The docs site deploys from `main` in the same
+release run and builds against it: `docs/tsconfig.json` maps `cadjs/*` to
+`../packages/cadjs/src/*`, and `packages/cadjs/src/common` pulls in
+`implicitjs`. The trim step asserts `packages/cadjs/src` survived, so adding
+`packages/` to the removal list fails the publish rather than the deploy.
+
 `main` is publish-only: do not open PRs to `main` or push it directly. The `Test`
 workflow runs on `develop` and PRs to `develop`: it starts from the symlink
 layout, verifies that layout, checks generated outputs against their sources


### PR DESCRIPTION
Finishes the `main` trim started in #216. `main` becomes close to just the plugin package: **1,395 → ~967 files**.

The repository root *is* the plugin package, so every source-only path on `main` is copied into every install. This removes the rest of them.

## What leaves the publish tree

| | files | why it was there |
|---|---:|---|
| `packages/` | 307 | the docs build resolved `cadjs/*` from it |
| `docs/` | 36 | `Deploy Docs` ran from the publish commit |
| `tests/` | 84 | source-only, no consumer |
| `requirements-dev.txt` | 1 | source-checkout dev env |

Nothing is lost. Each one has a consumer that reads **source** rather than the published tree — the same insight that fixed the CAD Viewer mirror in #216.

## The docs decoupling

`main` carried 343 files to satisfy six imports in one hero component:

```
docs/tsconfig.json          "cadjs/*": ["../packages/cadjs/src/*"]
hero-step-render.tsx        cadjs/common/{cadScene,renderModel,source,stepModule,themeSettings}.js
check-hero-step-assets.mjs  ../../packages/cadjs/src/common/stepTopology.mjs
```

The docs site is a website, not something anyone installs. `Deploy Docs` now takes the release **source** commit, exactly like the mirror sync, and both directories become source-only.

Version correctness holds: `source_sha` is resolved *after* the release PR merges, so it already carries the bumped `VERSION` and the stamped `docs/package.json` that `site-header.tsx` reads.

## Changes

- **`deploy-docs.yml`** — takes a source ref, defaults to `develop` instead of `main`, and checks up front that `docs/`, `packages/cadjs/src`, and `packages/implicitjs/src` are present. A publish-layout ref would otherwise fail as an opaque module-resolution error deep inside `next build`.
- **`release.yml`** — `deploy-docs` gains `release-pr` as a dependency and passes `source_sha`. Still gated on the publish succeeding, so the site never moves for a release that didn't ship.
- **Trim list** — `docs` and `packages` join `PUBLISH_TREE_REMOVED_ROOTS`, which the commit step already reads for both its assertions.
- **Guard inverted** — the `packages/cadjs` *survival* assertion becomes its opposite: the publish fails if a skill is found reaching into repo-root `packages/`, since every skill is supposed to vendor what it needs. Verified passing today.

## One behavioural change to know about

**Redeploying a past release needs its source commit, not its tag.** Tags point at publish commits, which no longer carry `docs/`. Every publish commit records its source as the second parent:

```bash
gh workflow run deploy-docs.yml -f ref="$(git rev-parse 0.4.6^2)"
```

Documented in CONTRIBUTING alongside the changed default. This also fixes two `sync-cad-viewer` recipes there that still passed `ref=main`, which that workflow stopped accepting in #216.

## Verification status

- `tests/` + `requirements-dev.txt` trim rehearsed green on `build-test` ([run 31635342078](https://github.com/earthtojake/text-to-cad/actions/runs/31635342078)) — 1,310 files, `packages/` correctly retained at that point.
- Both new guards exercised locally against this checkout: pass.
- Global policy tests, YAML validation: pass.

**Not yet rehearsed:** the expanded trim (`docs` + `packages`), and the docs deploy from a source ref. `build-test` cannot cover the docs half — `deploy-docs` is gated on `target_branch == 'main'`, and a rehearsal shouldn't deploy to production. Suggested order before release:

1. Dispatch `Deploy Docs` standalone with `ref=develop` — proves the only genuinely new thing, and nothing about `main` changes if it fails.
2. Rehearse the trim on `build-test` with `bump=none`.

Both need your go-ahead; (1) deploys the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
