### PR TITLE
cadgen: treat --user installed dependencies as third party (#215)

### DIFF
--- a/packages/cadgen/src/cadgen/_internal/source_hash.py
+++ b/packages/cadgen/src/cadgen/_internal/source_hash.py
@@ -190,14 +190,44 @@ def _interpreter_roots() -> tuple[Path, ...]:
     records is identical regardless of which directory the build was launched from.
     """
     roots: set[Path] = set()
-    paths = sysconfig.get_paths()
+
+    def add(value: object) -> None:
+        if not value:
+            return
+        with contextlib.suppress(OSError, TypeError, ValueError):
+            roots.add(Path(str(value)).resolve())
+
+    # sysconfig.get_paths() answers for the DEFAULT scheme only, which is prefix-based
+    # ("posix_prefix"/"nt"). It therefore never names the per-user scheme, so a
+    # ``pip install --user`` tree — the normal layout on a machine whose system
+    # site-packages needs admin rights — was absent from these roots. build123d, OCP and
+    # numpy installed that way were classified as MODEL code and evicted from sys.modules
+    # before every build; numpy cannot survive re-import while its C extension is loaded,
+    # so every build died with "module 'numpy.dtypes' has no attribute 'BoolDType'".
     for key in ("stdlib", "platstdlib", "purelib", "platlib"):
-        value = paths.get(key)
-        if value:
-            roots.add(Path(value).resolve())
+        add(sysconfig.get_paths().get(key))
+    #
+    # Only the package-installation directories, never a whole user tree: the user BASE
+    # (``site.getuserbase()``, ``~/.local`` on posix) holds bin/ and share/ as well, and
+    # excluding it would classify a model kept anywhere beneath it as third-party — which
+    # drops it from the recorded closure and silently disables staleness detection for that
+    # model. Nothing importable lives in the user tree outside its site-packages anyway.
+    with contextlib.suppress(Exception):
+        user_paths = sysconfig.get_paths(sysconfig.get_preferred_scheme("user"))
+        for key in ("purelib", "platlib"):
+            add(user_paths.get(key))
+    # site's answers rather than only sysconfig's: they cover layouts sysconfig does not
+    # describe (Debian's dist-packages, some relocated venvs) and are the canonical source
+    # for the user tree. Guarded because site's helpers raise when Python runs with a
+    # trimmed or embedded site module.
+    with contextlib.suppress(Exception):
+        import site
+
+        add(site.getusersitepackages())
+        for entry in site.getsitepackages():
+            add(entry)
     for prefix in (sys.prefix, sys.base_prefix, sys.exec_prefix, sys.base_exec_prefix):
-        if prefix:
-            roots.add(Path(prefix).resolve())
+        add(prefix)
     return tuple(roots)
 
 
@@ -298,10 +328,41 @@ def evict_first_party_modules() -> tuple[str, ...]:
     previous build failed partway, or what the generator unloads mid-run. Runtime
     and third-party modules (cadgen, build123d, OCP, ...) are never touched: they
     cannot reload safely and are not freshness inputs."""
-    evicted = tuple(repo_local_loaded_modules(set(sys.modules)))
+    protected = _packages_owning_loaded_extensions()
+    evicted = tuple(
+        name
+        for name in repo_local_loaded_modules(set(sys.modules))
+        if name.partition(".")[0] not in protected
+    )
     for name in evicted:
         sys.modules.pop(name, None)
     return evicted
+
+
+def _packages_owning_loaded_extensions() -> frozenset[str]:
+    """Top-level package names that already have a compiled extension module loaded.
+
+    A backstop for the root lists above, which are a denylist and will keep missing
+    layouts (``pip install --target``, conda, PYTHONPATH trees, relocated installs). A
+    package whose C extension is already initialised cannot be re-imported: dropping the
+    Python half from ``sys.modules`` leaves the extension registered, and re-executing the
+    Python half then fails on half-initialised state — which is how a numpy misclassified
+    as model code took down every build with "module 'numpy.dtypes' has no attribute
+    'BoolDType'" rather than merely recording a wrong closure.
+
+    Model code does not ship C extensions, so refusing to evict these costs nothing real:
+    the worst case is that a genuinely first-party package with a compiled sibling is not
+    re-executed, and that package could not have been re-imported safely anyway.
+    """
+    protected: set[str] = set()
+    for name, module in list(sys.modules.items()):
+        file_name = getattr(module, "__file__", None)
+        if not file_name or file_name.endswith(".py"):
+            continue
+        # .so / .pyd / .dylib — anything the import system loaded that is not Python source.
+        if os.path.splitext(file_name)[1]:
+            protected.add(name.partition(".")[0])
+    return frozenset(protected)
 
 
 _ACTIVE_EXECUTION_CAPTURE: set[Path] | None = None

--- a/tests/python/skills/cad/cadgen/test_source_closure_and_cache.py
+++ b/tests/python/skills/cad/cadgen/test_source_closure_and_cache.py
@@ -198,3 +198,120 @@ class ImportStepCachedTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class UserSiteIsNotModelCodeTest(unittest.TestCase):
+    """Dependencies installed with ``pip install --user`` are third party, not model code.
+
+    Regression for #215. ``sysconfig.get_paths()`` answers for the DEFAULT (prefix-based)
+    scheme only, so it never names the per-user scheme. build123d/OCP/numpy installed with
+    ``pip install --user`` — the normal layout on a machine whose system site-packages needs
+    admin rights — were therefore classified as model code and evicted from ``sys.modules``
+    before every build. numpy cannot survive re-import while its C extension is loaded, so
+    every build died with "module 'numpy.dtypes' has no attribute 'BoolDType'", including a
+    five-line Box generator.
+    """
+
+    def setUp(self) -> None:
+        cad_source_hash._interpreter_roots.cache_clear()
+        cad_source_hash._excluded_roots.cache_clear()
+        cad_source_hash.is_first_party_source_file.cache_clear()
+
+    tearDown = setUp
+
+    def test_user_site_packages_is_excluded(self) -> None:
+        import site
+
+        user_site = Path(site.getusersitepackages())
+        self.assertFalse(
+            cad_source_hash.is_first_party_source_file(user_site / "numpy" / "__init__.py"),
+            "a --user installed dependency must not be treated as model code",
+        )
+        self.assertFalse(
+            cad_source_hash.is_first_party_source_file(
+                user_site / "build123d" / "geometry.py"
+            )
+        )
+
+    def test_the_user_scheme_purelib_is_excluded(self) -> None:
+        # The path sysconfig itself reports for the per-user scheme, which is what the
+        # default-scheme lookup was missing.
+        import sysconfig
+
+        user_paths = sysconfig.get_paths(sysconfig.get_preferred_scheme("user"))
+        purelib = user_paths.get("purelib")
+        self.assertTrue(purelib, "the platform must describe a per-user purelib")
+        self.assertFalse(
+            cad_source_hash.is_first_party_source_file(Path(purelib) / "pkg" / "mod.py")
+        )
+
+    def test_the_user_base_itself_is_not_excluded(self) -> None:
+        # Deliberately narrower than the fix suggested in the issue: the user BASE holds
+        # bin/ and share/ too, and excluding all of it would classify a model kept anywhere
+        # beneath it as third party — dropping it from the closure and silently disabling
+        # staleness detection for that model.
+        import site
+
+        user_base = Path(site.getuserbase())
+        model = user_base / "projects" / "widget" / "widget.step.py"
+        self.assertTrue(
+            cad_source_hash.is_first_party_source_file(model),
+            "a model under the user base must stay first party",
+        )
+
+    def test_a_model_beside_the_repo_is_still_first_party(self) -> None:
+        with temporary_directory(prefix="closure-model") as root:
+            model = Path(root) / "widget.step.py"
+            model.write_text("from build123d import Box\n")
+            self.assertTrue(cad_source_hash.is_first_party_source_file(model))
+
+
+class ExtensionOwningPackagesSurviveEvictionTest(unittest.TestCase):
+    """A package with a loaded C extension is never evicted, whatever the install layout.
+
+    The root lists are a denylist and will keep missing layouts (``pip install --target``,
+    conda, PYTHONPATH trees). This backstop turns "wrong closure" into the worst case
+    instead of "every build crashes", because a half-evicted extension package cannot be
+    re-imported.
+    """
+
+    def test_numpy_is_never_evicted_even_if_misclassified(self) -> None:
+        import numpy
+
+        with mock.patch.object(
+            cad_source_hash,
+            "repo_local_loaded_modules",
+            return_value={"numpy": Path(numpy.__file__)},
+        ):
+            evicted = cad_source_hash.evict_first_party_modules()
+
+        self.assertNotIn("numpy", evicted)
+        self.assertIn("numpy", sys.modules, "evicting numpy breaks every later import")
+
+    def test_a_pure_python_module_is_still_evicted(self) -> None:
+        module_name = "cadgen_test_pure_python_module"
+        module = type(sys)(module_name)
+        module.__file__ = "/tmp/does-not-matter/widget.step.py"
+        sys.modules[module_name] = module
+        self.addCleanup(sys.modules.pop, module_name, None)
+
+        with mock.patch.object(
+            cad_source_hash,
+            "repo_local_loaded_modules",
+            return_value={module_name: Path(module.__file__)},
+        ):
+            evicted = cad_source_hash.evict_first_party_modules()
+
+        self.assertIn(module_name, evicted)
+        self.assertNotIn(module_name, sys.modules)
+
+    def test_extension_owners_are_detected_by_suffix_not_by_name(self) -> None:
+        protected = cad_source_hash._packages_owning_loaded_extensions()
+        # Whatever compiled packages this interpreter has loaded, numpy is one of them.
+        import numpy  # noqa: F401
+
+        self.assertIn("numpy", protected)
+        # A stdlib pure-Python package must not be swept into the protected set.
+        import json  # noqa: F401
+
+        self.assertNotIn("json", protected)


### PR DESCRIPTION
Closes #215. The report's diagnosis is correct; this fixes it, narrower in one place and broader in another, both explained below.

## Confirmed

`sysconfig.get_paths()` answers for the **default** scheme only — prefix-based (`posix_prefix`/`nt`) — so it never names the per-user scheme. Reproduced on a plain venv machine, no `--user` install required:

```python
from pathlib import Path
import site
from cadgen._internal.source_hash import is_first_party_source_file
is_first_party_source_file(Path(site.getusersitepackages()) / "numpy" / "__init__.py")
# -> True, expected False
```

So on a machine whose system site-packages needs admin rights, build123d/OCP/numpy installed with `pip install --user` fell outside every excluded root, were classified as **model** code, and were evicted from `sys.modules` before every build. numpy cannot survive re-import while its C extension is loaded, hence `AttributeError: module 'numpy.dtypes' has no attribute 'BoolDType'` on a five-line `Box` generator.

## The fix

`_interpreter_roots()` now also takes:

- the **per-user scheme's** `purelib`/`platlib` (`sysconfig.get_paths(sysconfig.get_preferred_scheme("user"))`) — the path the default lookup was missing
- `site.getusersitepackages()` and `site.getsitepackages()` — `site` describes layouts `sysconfig` does not (Debian's `dist-packages`, relocated venvs)

**Narrower than suggested in one place:** the issue also proposed excluding `site.getuserbase()`. I left that out. The base (`~/.local` on posix) holds `bin/` and `share/` too, so excluding all of it would classify a model kept anywhere beneath it as third party — dropping it from the recorded closure and **silently disabling staleness detection** for that model. Nothing importable lives in the user tree outside its site-packages, so the base buys nothing and costs that. There's a test pinning it.

**Broader in another:** root lists are a denylist and will keep missing layouts (`pip install --target`, conda, PYTHONPATH trees), so eviction now also refuses any package that already has a compiled extension loaded — the issue's own suggested backstop. A half-evicted extension package cannot be re-imported at all, so this turns the failure mode from *every build crashes* into *at worst a wrong closure*. Model code does not ship C extensions, so it costs nothing real.

## Verification

The 7 new tests fail 4 ways on `develop` and pass with the fix.

Beyond unit tests, the thing over-excluding would have silently broken — closure capture and staleness — checked end to end with a generator importing a sibling helper:

| | |
|---|---|
| recorded closure | `["helper.py", "widget.step.py"]` — helper captured |
| rebuild, nothing changed | `widget is current; skipped recompose` |
| rebuild after editing **only** `helper.py` | rebuilt, not skipped |

- `scripts/test/test-python.sh` — pass
- `scripts/test/test-global.sh` — 63 pass
- `scripts/bundle/bundle.sh --check` — current; dev symlink layout restored

## What I could not verify

I have no Windows machine with a `pip install --user` layout, so the actual reported environment is untested. What I can say is that the misclassification reproduces here and no longer does, and the C-extension backstop makes the crash unreachable even on a layout neither of us has enumerated. @M-Stege — if you can run against this branch, that would close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
