### PR TITLE
js: fix the implicitjs Node floor and make the viewer bundler follow the committed lockfile (#201)

### DIFF
--- a/packages/implicitjs/scripts/run-tests.mjs
+++ b/packages/implicitjs/scripts/run-tests.mjs
@@ -30,12 +30,26 @@ if (!tests.length) {
   process.exit(1);
 }
 
+// This suite writes temporary `.implicit.js` fixtures -- bare .js files whose body is
+// `export default { ... }`, in a temp dir with no package.json -- and imports them, both
+// in-process and through the spawned export CLI. Only Node 22+ reads module syntax out of
+// an ambiguous .js, so the floor is a property of the fixtures, not a preference.
+//
+// This used to pass `--experimental-default-type=module` on every Node below 22, which was
+// wrong at both ends: Node 18 has no such flag and died with `bad option: ...` before
+// running a single test, and on Node 20/21 the flag reached only THIS process, so the tests
+// that spawn the CLI failed anyway. Say the version out loud instead of half-fixing it.
 const nodeMajor = Number(process.versions.node.split(".")[0] || 0);
-const extraFlags = nodeMajor > 0 && nodeMajor < 22 ? ["--experimental-default-type=module"] : [];
+if (nodeMajor > 0 && nodeMajor < 22) {
+  console.error(
+    `implicitjs tests require Node 22 or newer (running ${process.versions.node}): the .implicit.js `
+    + "fixtures are plain .js files with module syntax, which older Node reads as CommonJS."
+  );
+  process.exit(1);
+}
 
 const result = spawnSync(process.execPath, [
   "--test",
-  ...extraFlags,
   ...tests,
 ], {
   cwd: packageRoot,

--- a/packages/implicitjs/src/lib/implicitCad/export.js
+++ b/packages/implicitjs/src/lib/implicitCad/export.js
@@ -3,6 +3,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { normalizeImplicitCadModel } from "./model.js";
+import { unsupportedNodeVersionMessage } from "./nodeModuleSupport.js";
 import {
   exportImplicitCadAnimatedGlb,
   exportImplicitCadModel,
@@ -75,7 +76,18 @@ export async function loadImplicitCadModelFromPath(inputPath, {
   }
   const inputUrl = pathToFileURL(resolvedInput);
   inputUrl.searchParams.set("mtime", String(Number(stats.mtimeMs)));
-  const moduleValue = await import(inputUrl.href);
+  let moduleValue;
+  try {
+    moduleValue = await import(inputUrl.href);
+  } catch (error) {
+    // Blame the interpreter when the interpreter is at fault: on Node < 22 a plain `.js`
+    // model file fails with "Unexpected token 'export'", which reads as a broken model.
+    const unsupported = unsupportedNodeVersionMessage(error, { inputPath: resolvedInput });
+    if (unsupported) {
+      throw new Error(unsupported, { cause: error });
+    }
+    throw error;
+  }
   const defaultModel = normalizeImplicitCadModel(moduleValue, { sourceUrl: inputUrl.href });
   const nextParams = isObject(params) ? params : isObject(parameterValues) ? parameterValues : null;
   if (nextParams || animationState) {

--- a/packages/implicitjs/src/lib/implicitCad/nodeModuleSupport.js
+++ b/packages/implicitjs/src/lib/implicitCad/nodeModuleSupport.js
@@ -1,0 +1,59 @@
+/** Why a `.implicit.js` model fails to import on an older Node, said out loud.
+ *
+ * An implicit model is a bare `.js` file whose body is `export default { ... }`, and it
+ * normally sits in a model folder with no `package.json` above it -- so nothing tells Node
+ * it is a module. Node 22 works that out by DETECTING module syntax in an ambiguous `.js`.
+ * Earlier versions compile it as CommonJS and throw `SyntaxError: Unexpected token 'export'`,
+ * which reads as "your model file is broken" when the model is fine and the interpreter is
+ * the problem.
+ *
+ * Node 20 and 21 have `--experimental-default-type=module`, which fixes the import in the
+ * process that passes it -- and nothing else. It does not reach a child process, so a CLI
+ * spawned by that process fails anyway; and Node 18 does not have the flag at all, where
+ * passing it kills the process with `bad option`. That is the whole reason this is reported
+ * rather than worked around.
+ */
+
+/** The first Node major that reads module syntax out of an extensionless-intent `.js`. */
+export const IMPLICIT_JS_MIN_NODE_MAJOR = 22;
+
+export function nodeMajorVersion(version = process.versions.node) {
+  const major = Number.parseInt(String(version || "").split(".")[0], 10);
+  return Number.isFinite(major) ? major : 0;
+}
+
+/** True when ``error`` is Node refusing to read module syntax out of a plain `.js`. */
+export function isAmbiguousModuleSyntaxError(error) {
+  if (!error || error.name !== "SyntaxError") {
+    return false;
+  }
+  const message = String(error.message || "");
+  return (
+    message.includes("Unexpected token 'export'")
+    || message.includes("Cannot use import statement outside a module")
+  );
+}
+
+/** The message to raise instead of the SyntaxError, or null to let the original stand.
+ *
+ * Null for a `.mjs` input, or on a Node that supports the syntax: there the SyntaxError is
+ * about the model's own code and replacing it would hide a real authoring mistake. */
+export function unsupportedNodeVersionMessage(error, {
+  inputPath,
+  version = process.versions.node,
+} = {}) {
+  if (!isAmbiguousModuleSyntaxError(error)) {
+    return null;
+  }
+  if (/\.mjs$/i.test(String(inputPath || ""))) {
+    return null;
+  }
+  if (nodeMajorVersion(version) >= IMPLICIT_JS_MIN_NODE_MAJOR) {
+    return null;
+  }
+  return (
+    `Node ${version} cannot load a .implicit.js model: reading module syntax out of a plain `
+    + `.js file needs Node ${IMPLICIT_JS_MIN_NODE_MAJOR} or newer. Upgrade Node, or rename `
+    + `the model to .implicit.mjs. (${inputPath})`
+  );
+}

--- a/packages/implicitjs/src/lib/implicitCad/nodeModuleSupport.test.js
+++ b/packages/implicitjs/src/lib/implicitCad/nodeModuleSupport.test.js
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { loadImplicitCadModelFromPath } from "./export.js";
+import {
+  IMPLICIT_JS_MIN_NODE_MAJOR,
+  isAmbiguousModuleSyntaxError,
+  nodeMajorVersion,
+  unsupportedNodeVersionMessage
+} from "./nodeModuleSupport.js";
+
+function ambiguousSyntaxError() {
+  const error = new SyntaxError("Unexpected token 'export'");
+  return error;
+}
+
+test("an old Node is named as the cause instead of the model file", () => {
+  const message = unsupportedNodeVersionMessage(ambiguousSyntaxError(), {
+    inputPath: "/models/orb.implicit.js",
+    version: "20.10.0"
+  });
+  assert.match(message, /Node 20\.10\.0 cannot load a \.implicit\.js model/u);
+  assert.match(message, new RegExp(`Node ${IMPLICIT_JS_MIN_NODE_MAJOR} or newer`, "u"));
+  assert.match(message, /orb\.implicit\.js/u);
+});
+
+test("Node 18, which has no flag to offer, gets the same answer", () => {
+  // The runner used to pass --experimental-default-type=module here and die with
+  // `bad option`, so this version is the one that most needs a sentence.
+  assert.ok(unsupportedNodeVersionMessage(ambiguousSyntaxError(), {
+    inputPath: "/models/orb.implicit.js",
+    version: "18.17.0"
+  }));
+});
+
+test("a supported Node keeps the model's own syntax error", () => {
+  // The whole value of the message is that it is TRUE. On a Node that can read the
+  // syntax, an "Unexpected token 'export'" really is the model's problem, and relabelling
+  // it would send the author looking at their interpreter instead of their code.
+  assert.equal(
+    unsupportedNodeVersionMessage(ambiguousSyntaxError(), {
+      inputPath: "/models/orb.implicit.js",
+      version: `${IMPLICIT_JS_MIN_NODE_MAJOR}.0.0`
+    }),
+    null
+  );
+});
+
+test("a .mjs model is unambiguous to every Node, so nothing is claimed about it", () => {
+  assert.equal(
+    unsupportedNodeVersionMessage(ambiguousSyntaxError(), {
+      inputPath: "/models/orb.implicit.mjs",
+      version: "20.10.0"
+    }),
+    null
+  );
+});
+
+test("only the two ambiguous-module errors are recognized", () => {
+  assert.equal(isAmbiguousModuleSyntaxError(ambiguousSyntaxError()), true);
+  assert.equal(
+    isAmbiguousModuleSyntaxError(new SyntaxError("Cannot use import statement outside a module")),
+    true
+  );
+  assert.equal(isAmbiguousModuleSyntaxError(new SyntaxError("Unexpected end of input")), false);
+  assert.equal(isAmbiguousModuleSyntaxError(new TypeError("not a syntax error")), false);
+  assert.equal(isAmbiguousModuleSyntaxError(null), false);
+});
+
+test("an unparseable version reads as unsupported rather than as newest", () => {
+  assert.equal(nodeMajorVersion("not-a-version"), 0);
+});
+
+test("loading a genuinely broken model still reports the model's syntax error", async () => {
+  // Wiring: the guard sits around the dynamic import, so it must not swallow the errors it
+  // does not explain. This runs on a supported Node, where the error IS the model's.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "implicit-syntax-"));
+  const modelPath = path.join(dir, "broken.implicit.js");
+  fs.writeFileSync(modelPath, "export default { schema: 'implicit.js/0.1.0',\n", "utf-8");
+  await assert.rejects(
+    loadImplicitCadModelFromPath(modelPath),
+    (error) => error.name === "SyntaxError" && !/cannot load a \.implicit\.js model/u.test(error.message)
+  );
+});

--- a/scripts/bundle/skills/bundle-cad-viewer.sh
+++ b/scripts/bundle/skills/bundle-cad-viewer.sh
@@ -97,9 +97,26 @@ require_command() {
   fi
 }
 
+# The COMMITTED lockfile decides, not what happens to be installed on this machine. The
+# repository commits viewer/package-lock.json, so preferring pnpm merely because it is on
+# PATH made the release build depend on the builder's laptop: pnpm and npm lay out
+# node_modules differently (which is why resolve_esbuild_bin has to search .pnpm at all),
+# so the same source revision could be bundled against a different tree. The committed npm
+# lockfile is checked first on purpose: a stray local `pnpm install` leaves an untracked
+# pnpm-lock.yaml behind, and that must not be able to flip a release build either. An explicit
+# CAD_VIEWER_PACKAGE_MANAGER still wins -- someone deliberately switching should not have to
+# delete a lockfile to do it.
 resolve_viewer_package_manager() {
   if [ -n "$VIEWER_PACKAGE_MANAGER" ]; then
     echo "$VIEWER_PACKAGE_MANAGER"
+    return
+  fi
+  if [ -f "$VIEWER_DIR/package-lock.json" ]; then
+    echo "npm"
+    return
+  fi
+  if [ -f "$VIEWER_DIR/pnpm-lock.yaml" ]; then
+    echo "pnpm"
     return
   fi
   if command -v pnpm >/dev/null 2>&1; then

--- a/tests/python/global/test_js_runtime_reproducibility.py
+++ b/tests/python/global/test_js_runtime_reproducibility.py
@@ -1,0 +1,185 @@
+"""The JS side must build and test the same way on every machine and every Node.
+
+Two independent ways that stopped being true, both reported in #201:
+
+* the Viewer bundler picked its package manager from what was INSTALLED, so a release
+  built on a laptop with pnpm on PATH was bundled against a different node_modules layout
+  than the committed lockfile describes;
+* the JS test runners passed ``--experimental-default-type=module``, a flag that current
+  Node rejects outright -- so the suites refused to start rather than failing a test.
+
+Both are the kind of thing nobody notices until a specific machine or a specific Node,
+which is why they are pinned here rather than left to whoever runs the build next.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+VIEWER_DIR = REPO_ROOT / "viewer"
+VIEWER_BUNDLER = REPO_ROOT / "scripts" / "bundle" / "skills" / "bundle-cad-viewer.sh"
+IMPLICITJS_RUNNER = REPO_ROOT / "packages" / "implicitjs" / "scripts" / "run-tests.mjs"
+NODE_MODULE_SUPPORT = (
+    REPO_ROOT / "packages" / "implicitjs" / "src" / "lib" / "implicitCad" / "nodeModuleSupport.js"
+)
+TEST_RUNNERS = (
+    REPO_ROOT / "packages" / "cadjs" / "scripts" / "run-tests.mjs",
+    IMPLICITJS_RUNNER,
+    REPO_ROOT / "viewer" / "scripts" / "run-tests.mjs",
+)
+
+
+def resolved_viewer_package_manager(*lockfiles: str, override: str = "") -> str:
+    """Run the bundler's own resolver against a synthetic viewer dir.
+
+    The function is extracted from the script and executed rather than pattern-matched, so
+    the test asserts on BEHAVIOUR -- including the fallback order -- instead of on the text
+    of a shell if-chain. Both package managers are stubbed onto PATH so "installed" is never
+    what decides the answer.
+    """
+    bundler = VIEWER_BUNDLER.read_text(encoding="utf-8")
+    match = re.search(
+        r"^resolve_viewer_package_manager\(\) \{.*?^\}\n",
+        bundler,
+        re.DOTALL | re.MULTILINE,
+    )
+    if match is None:
+        raise AssertionError("resolve_viewer_package_manager is gone from the Viewer bundler")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        bin_dir = root / "bin"
+        viewer_dir = root / "viewer"
+        bin_dir.mkdir()
+        viewer_dir.mkdir()
+        for command in ("npm", "pnpm"):
+            executable = bin_dir / command
+            executable.write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+            executable.chmod(0o755)
+        for lockfile in lockfiles:
+            (viewer_dir / lockfile).touch()
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+                "VIEWER_DIR": str(viewer_dir),
+                "VIEWER_PACKAGE_MANAGER": override,
+            }
+        )
+        result = subprocess.run(
+            ["bash", "-c", f"set -euo pipefail\n{match.group(0)}\nresolve_viewer_package_manager"],
+            check=True,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+        return result.stdout.strip()
+
+
+class ViewerPackageManagerIsDecidedByTheLockfileTest(unittest.TestCase):
+    def test_the_repository_commits_exactly_one_viewer_lockfile(self) -> None:
+        # The premise of every case below: there is one committed answer to appeal to.
+        self.assertTrue((VIEWER_DIR / "package-lock.json").is_file())
+        self.assertFalse(
+            (VIEWER_DIR / "pnpm-lock.yaml").exists(),
+            "two committed lockfiles would make the build's package manager ambiguous again",
+        )
+
+    def test_a_committed_npm_lockfile_wins_over_an_installed_pnpm(self) -> None:
+        self.assertEqual("npm", resolved_viewer_package_manager("package-lock.json"))
+
+    def test_a_pnpm_lockfile_selects_pnpm(self) -> None:
+        self.assertEqual("pnpm", resolved_viewer_package_manager("pnpm-lock.yaml"))
+
+    def test_a_stray_local_pnpm_lockfile_cannot_flip_a_committed_npm_build(self) -> None:
+        # `pnpm install` in viewer/ leaves an untracked pnpm-lock.yaml behind; a release
+        # build must not change shape because someone ran it once.
+        self.assertEqual(
+            "npm",
+            resolved_viewer_package_manager("package-lock.json", "pnpm-lock.yaml"),
+        )
+
+    def test_an_explicit_override_still_wins(self) -> None:
+        self.assertEqual(
+            "pnpm",
+            resolved_viewer_package_manager("package-lock.json", override="pnpm"),
+        )
+
+    def test_with_no_lockfile_at_all_it_still_answers(self) -> None:
+        self.assertIn(resolved_viewer_package_manager(), {"npm", "pnpm"})
+
+
+class TestRunnersStartOnCurrentNodeTest(unittest.TestCase):
+    def test_no_runner_passes_a_flag_current_node_rejects(self) -> None:
+        # Node 24 removed --experimental-default-type, and an unknown flag is not a failed
+        # test: the interpreter exits before the runner reports anything at all. Comments are
+        # stripped first -- a runner is free to explain WHY it no longer passes the flag.
+        for runner in TEST_RUNNERS:
+            with self.subTest(runner=runner.name):
+                code = re.sub(r"//[^\n]*", "", runner.read_text(encoding="utf-8"))
+                self.assertNotIn(
+                    "--experimental-default-type",
+                    code,
+                    f"{runner.relative_to(REPO_ROOT)} passes a flag current Node rejects",
+                )
+
+    def test_the_implicitjs_node_floor_is_one_number(self) -> None:
+        # The runner refuses below the floor and the loader explains the same limit to a
+        # user; a hand-copied second number is how the two drift.
+        declared = re.search(
+            r"IMPLICIT_JS_MIN_NODE_MAJOR = (\d+)",
+            NODE_MODULE_SUPPORT.read_text(encoding="utf-8"),
+        )
+        self.assertIsNotNone(declared, "implicitjs must declare IMPLICIT_JS_MIN_NODE_MAJOR")
+        runner = IMPLICITJS_RUNNER.read_text(encoding="utf-8")
+        floors = set(re.findall(r"nodeMajor < (\d+)", runner))
+        self.assertEqual(
+            {declared.group(1)},
+            floors,
+            "the implicitjs runner's Node floor disagrees with IMPLICIT_JS_MIN_NODE_MAJOR",
+        )
+        self.assertIn(f"Node {declared.group(1)} or newer", runner)
+
+    def test_the_ci_node_version_satisfies_that_floor(self) -> None:
+        declared = int(
+            re.search(
+                r"IMPLICIT_JS_MIN_NODE_MAJOR = (\d+)",
+                NODE_MODULE_SUPPORT.read_text(encoding="utf-8"),
+            ).group(1)
+        )
+        workflow = (REPO_ROOT / ".github" / "workflows" / "test.yml").read_text(encoding="utf-8")
+        versions = [int(value) for value in re.findall(r'node-version:\s*"(\d+)"', workflow)]
+        self.assertTrue(versions, "test.yml must pin a Node version")
+        for version in versions:
+            self.assertGreaterEqual(
+                version,
+                declared,
+                "CI runs a Node the implicitjs suite refuses to start on",
+            )
+
+    def test_viewer_declares_the_module_type_its_tests_rely_on(self) -> None:
+        # The flag existed to force module semantics; the durable answer is that every
+        # package that owns .js tests declares itself a module package.
+        for package_json in (
+            REPO_ROOT / "packages" / "cadjs" / "package.json",
+            REPO_ROOT / "packages" / "implicitjs" / "package.json",
+            VIEWER_DIR / "package.json",
+        ):
+            with self.subTest(package=package_json.parent.name):
+                self.assertEqual(
+                    "module",
+                    json.loads(package_json.read_text(encoding="utf-8")).get("type"),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/pnpm-workspace.yaml
+++ b/viewer/pnpm-workspace.yaml
@@ -1,0 +1,15 @@
+# Which dependencies may run install scripts, for contributors who install with pnpm.
+# pnpm 10 blocks them by default and prints "Ignored build scripts: esbuild@0.27.7".
+#
+# `allowBuilds` IS the key pnpm reads -- verified against a bogus-key control on pnpm
+# 10.30.0: with a nonsense top-level key the warning stays and the postinstall is skipped;
+# with this file, `.../esbuild/postinstall: Done`. Do not delete it as cargo cult, which is
+# easy to assume because pnpm also documents `onlyBuiltDependencies`.
+#
+# Not load-bearing for the build itself: esbuild 0.27 ships its platform binary as an
+# optional dependency, so `esbuild --version` works even with the postinstall skipped. This
+# is here so a pnpm install is quiet and its script policy is stated rather than implied.
+# The bundler builds with npm anyway, following the committed package-lock.json.
+allowBuilds:
+  esbuild: true
+  fsevents: false


### PR DESCRIPTION
Lands the findings from #201 (thanks @823608044-droid) that are still real on `develop`. That branch predates the 0.4.x viewer and can't be rebased, so each item was re-verified here one at a time.

## Already fixed — kept from regressing

`cadjs` and `viewer` stopped passing `--experimental-default-type=module` some time after #201 was cut. Both suites run on Node 18 → 24 today (575 and 346 tests). A policy test keeps the flag from coming back: an unrecognized flag isn't a failing test, the interpreter exits before the runner reports anything, which is why the original report read as "reproducibility" rather than "one bad argument".

## Still broken, and worse than reported — implicitjs

`implicitjs` kept the flag behind `nodeMajor < 22`, which is wrong at **both ends** of the range it claims to serve. Measured per version, before this PR:

| Node | | |
|---|---|---|
| 18.17 | `rc=9` | `bad option: --experimental-default-type=module` — 0 tests run |
| 20.10 | `rc=1` | 349 pass / 2 fail (the two that spawn the export CLI) |
| 22.22 | `rc=0` | 351 pass |
| 24.19 | `rc=0` | 351 pass |

Node 18 has no such flag. And on Node 20 the flag reaches only the runner process, so the spawned-CLI tests fail regardless.

The flag was never the fix: the real constraint is a property of the fixtures. The suite writes temporary `.implicit.js` files whose body is `export default { ... }` into a temp dir with no `package.json`, and only Node 22+ reads module syntax out of an ambiguous `.js`. The runner now states that floor and exits 1 below it.

**That floor is user-facing, not test-only** — which #201 didn't reach. A real `.implicit.js` model hits the same wall, and Node reports it as `SyntaxError: Unexpected token 'export'` pointing *into the user's model*. The model is fine; the interpreter is too old. `loadImplicitCadModelFromPath` now says so and offers the two real remedies (upgrade Node, or name the model `.implicit.mjs`). It relabels that error **only** below the floor and only for a `.js` input — on a supported Node, `Unexpected token 'export'` really is the model's own bug, and hiding it would send an author to check their Node instead of their code. A test pins that boundary in both directions.

## Still broken — the viewer bundler's package manager

`resolve_viewer_package_manager` chose by what was **installed**, so `pnpm` merely being on `PATH` switched a release build away from the committed `viewer/package-lock.json`. npm and pnpm lay out `node_modules` differently — `resolve_esbuild_bin` has to search `.pnpm` precisely because of it — so one source revision could be bundled against a different tree depending on the builder's laptop.

The committed lockfile decides now, `package-lock.json` first so a stray local `pnpm install` (which leaves an untracked `pnpm-lock.yaml` behind) can't flip a release either. An explicit `CAD_VIEWER_PACKAGE_MANAGER` still wins. The test extracts the shell function and **runs** it with both managers stubbed onto `PATH`, so it asserts the resolution order rather than the text of an if-chain. Two of its cases fail against the old resolver.

## Landed after a correction — `viewer/pnpm-workspace.yaml`

I first wrote this off as inert, on the grounds that pnpm's key is `onlyBuiltDependencies`. **That was wrong**, and the last commit corrects it. `allowBuilds` is the key pnpm reads — verified against a bogus-key control on pnpm 10.30.0:

| `pnpm-workspace.yaml` | result |
|---|---|
| absent | `Ignored build scripts: esbuild@0.27.7` |
| a nonsense top-level key | `Ignored build scripts: esbuild@0.27.7` |
| `allowBuilds: {esbuild: true}` | `.../esbuild/postinstall: Done` |

So #201 was right about the key and it lands as proposed, with that control written into the file — "this looks cargo-culted" is exactly the wrong conclusion I reached about it.

Scope, measured rather than assumed: it does **not** fix a broken build. esbuild 0.27 ships its platform binary as an optional dependency, so `esbuild --version` works with the postinstall skipped. What it does is make a pnpm install quiet and state the policy explicitly. The bundler builds with npm regardless, per the committed lockfile.

## Not landed, deliberately

- **`--preserve-symlinks` on the viewer runner.** Nothing needs it — the viewer suite passes on 18/20/22/24 without it — and it changes module resolution for the symlinked dev layout, where `cadjs` and `implicitjs` are symlinks. A flag that alters how the code under test is loaded needs a failure to justify it.
- **`allowScripts` in `package.json`.** This one really is inert here: it is read only by `@lavamoat/allow-scripts`, which is not a dependency. #201 also added a test asserting the field exists, which would have pinned two inert strings in place and read as an npm install-script policy the repo does not have.

## Gate

implicitjs 358 (1 opt-in GPU skip), cadjs 575, viewer 346, viewer build, `test-global.sh` 73, `bundle.sh --check` all current, symlink layout valid. Runner behaviour re-measured on Node 18/20/22/24 after the change: a clear one-line refusal below 22, full green on 22 and 24.

Closes #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
