### PR TITLE
dxf: fix scripts/gen on Windows when the Python path contains a space (#245)

### DIFF
--- a/skills/dxf/scripts/artifact/__main__.py
+++ b/skills/dxf/scripts/artifact/__main__.py
@@ -6,10 +6,21 @@ from pathlib import Path
 
 # Drawing packages are content-addressed (drawing.json dxfHash) and must be
 # byte-deterministic. ezdxf's object-section creation order depends on Python
-# hash randomization, so pin the seed and re-exec once before any ezdxf import.
+# hash randomization, so pin the seed and re-run once before any ezdxf import.
+#
+# subprocess rather than os.execv: on Windows execv hands the argument vector to the C
+# runtime, which re-joins it into a command line WITHOUT quoting, so an interpreter path
+# containing a space -- C:\Program Files\Python311\python.exe, which is where the
+# python.org all-users installer puts it -- arrives as two arguments and the child tries to
+# run "Files\Python311\python.exe" as a script relative to the working directory. subprocess
+# applies Windows quoting rules. Nothing is lost on POSIX either: os.execv never replaced the
+# process on Windows, so the parent lingered there regardless, and the child's exit code is
+# passed straight through here.
 if os.environ.get("PYTHONHASHSEED") != "0":
+    import subprocess
+
     os.environ["PYTHONHASHSEED"] = "0"
-    os.execv(sys.executable, [sys.executable, *sys.argv])
+    raise SystemExit(subprocess.run([sys.executable, *sys.argv], check=False).returncode)
 
 # Prefer the skill's bundled cadgen over any pip-installed copy, exactly as
 # skills/dxf/scripts/gen/__main__.py does.

--- a/skills/dxf/scripts/gen/__main__.py
+++ b/skills/dxf/scripts/gen/__main__.py
@@ -6,10 +6,21 @@ from pathlib import Path
 
 # Drawing packages are content-addressed (drawing.json dxfHash) and must be
 # byte-deterministic. ezdxf's object-section creation order depends on Python
-# hash randomization, so pin the seed and re-exec once before any ezdxf import.
+# hash randomization, so pin the seed and re-run once before any ezdxf import.
+#
+# subprocess rather than os.execv: on Windows execv hands the argument vector to the C
+# runtime, which re-joins it into a command line WITHOUT quoting, so an interpreter path
+# containing a space -- C:\Program Files\Python311\python.exe, which is where the
+# python.org all-users installer puts it -- arrives as two arguments and the child tries to
+# run "Files\Python311\python.exe" as a script relative to the working directory. subprocess
+# applies Windows quoting rules. Nothing is lost on POSIX either: os.execv never replaced the
+# process on Windows, so the parent lingered there regardless, and the child's exit code is
+# passed straight through here.
 if os.environ.get("PYTHONHASHSEED") != "0":
+    import subprocess
+
     os.environ["PYTHONHASHSEED"] = "0"
-    os.execv(sys.executable, [sys.executable, *sys.argv])
+    raise SystemExit(subprocess.run([sys.executable, *sys.argv], check=False).returncode)
 
 # Prefer the skill's bundled cadgen over any pip-installed copy, exactly as
 # skills/cad/scripts/gen/__main__.py and skills/implicit-cad/scripts/gen/__main__.py do.

--- a/tests/python/global/test_launcher_reexec.py
+++ b/tests/python/global/test_launcher_reexec.py
@@ -1,0 +1,75 @@
+"""A launcher that re-runs itself must survive an interpreter path with a space in it.
+
+``skills/dxf/scripts/{gen,artifact}`` pin ``PYTHONHASHSEED`` before importing ezdxf, because a
+drawing package is content-addressed and ezdxf's object order depends on hash randomization. The
+re-run used ``os.execv``, which on Windows hands the argument vector to the C runtime; the
+runtime re-joins it into a command line WITHOUT quoting, so the default all-users interpreter
+path ``C:\\Program Files\\Python311\\python.exe`` arrived as two arguments and the child tried to
+run ``Files\\Python311\\python.exe`` as a script (issue #245).
+
+The bug is Windows-only and CI is Linux, so the guard here is the policy: no launcher re-runs
+itself through ``os.execv``. ``subprocess`` quotes correctly on every platform, and on Windows
+``os.execv`` never replaced the process anyway, so nothing was gained by it.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SKILLS_DIR = REPO_ROOT / "skills"
+
+
+def launcher_sources() -> list[Path]:
+    return sorted(
+        path
+        for path in SKILLS_DIR.glob("*/scripts/*/__main__.py")
+        if "__pycache__" not in path.parts
+    )
+
+
+class LauncherReExecTest(unittest.TestCase):
+    def test_there_are_launchers_to_check(self) -> None:
+        self.assertGreater(len(launcher_sources()), 4, "the glob stopped finding launchers")
+
+    def test_no_launcher_re_runs_itself_through_os_execv(self) -> None:
+        # Comments are stripped first: a launcher is free to explain why it does NOT use execv.
+        offenders = [
+            str(path.relative_to(REPO_ROOT))
+            for path in launcher_sources()
+            if re.search(
+                r"\bos\.execv",
+                re.sub(r"#[^\n]*", "", path.read_text(encoding="utf-8")),
+            )
+        ]
+        self.assertEqual(
+            [],
+            offenders,
+            "os.execv does not quote on Windows: an interpreter path containing a space "
+            "arrives as two arguments. Re-run through subprocess and exit with its return code.",
+        )
+
+    def test_the_hash_seed_re_run_passes_the_exit_code_through(self) -> None:
+        # A re-run that swallowed the child's status would turn every generator failure into a
+        # success, which is worse than the crash it replaced.
+        for path in launcher_sources():
+            source = path.read_text(encoding="utf-8")
+            if "PYTHONHASHSEED" not in source:
+                continue
+            with self.subTest(launcher=str(path.relative_to(REPO_ROOT))):
+                self.assertRegex(
+                    source,
+                    r"SystemExit\(\s*subprocess\.run\(",
+                    "the re-run must exit with the child's return code",
+                )
+                self.assertIn(
+                    "sys.executable",
+                    source,
+                    "the re-run must use the same interpreter",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #245.

`skills/dxf/scripts/gen` died on Windows whenever the interpreter path contained a space — `C:\Program Files\Python311\python.exe`, where the python.org all-users installer puts it:

```
C:\Program: can' open file "C:\some\working\dir\Files\Python311\python.exe"
```

## Cause

The launcher pins `PYTHONHASHSEED` before importing ezdxf, because a drawing package is content-addressed and ezdxf object order depends on hash randomization. It did that by re-execing itself. On Windows `os.execv` hands the argument **vector** to the C runtime, which re-joins it into a command line without quoting — so the interpreter path arrived as two arguments and the child tried to run `Files\Python311\python.exe` as a script relative to the working directory. That is the odd path in the error above.

## Fix

`subprocess` applies Windows quoting rules, and the exit code passes straight through. Nothing is lost on POSIX: `os.execv` never replaced the process on Windows anyway, so the parent lingered there regardless.

Both of the skill launchers that re-exec had the same line, as the reporter noted — `scripts/gen` and `scripts/artifact`. `skills/cad/scripts/gen` does not re-exec and was unaffected.

## Verification

The bug is Windows-only and CI is Linux, so the regression guard is a policy test: no skill launcher re-runs itself through `os.execv`, and a launcher that pins the hash seed exits with its child return code (a re-run that swallowed the status would turn every generator failure into a success). Both cases fail against the old code. Also checked by hand on macOS through an interpreter path containing a space, which is as close as this platform gets to the reported case.

Reported by @M-Stege, who diagnosed both the cause and the fix in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)