### PR TITLE
cadgen: apply #244's SMB rename retry to all seven artifact renames (#241)

### DIFF
--- a/packages/cadgen/src/cadgen/_internal/atomic_replace.py
+++ b/packages/cadgen/src/cadgen/_internal/atomic_replace.py
@@ -1,0 +1,62 @@
+"""The one atomic rename every artifact writer uses.
+
+Every cached artifact is written to a temp file and renamed into place, so a reader never sees
+a half-written payload. On a Windows SMB share that rename is not reliably atomic-and-instant:
+the redirector can still hold the handle Python just closed, and the rename loses with
+``WinError 32`` (ERROR_SHARING_VIOLATION, "file is being used by another process"). Under a
+parallel component build it happens reliably -- see issue #241, where 8 workers failed every
+time on a NAS and ``CADGEN_COMPONENT_WORKERS=1`` succeeded.
+
+The remedy is a short bounded retry, and the reason it lives here rather than at each writer is
+that there are seven of these renames in a build's write path. Hardening one moves the failure
+to the next: the reporter's traceback caught the GLB writer's inner rename, with the outer
+component rename one frame away.
+
+Deliberately narrow:
+
+* only ``WinError 32`` retries. A denial (5) or a missing directory is a real error and must
+  surface at once, not 350 ms later.
+* the attribute does not exist off Windows, so this is exactly ``os.replace`` on POSIX.
+* four attempts over 350 ms, then the original error propagates. A rename that cannot win in
+  that window is not a deferred close, and a build that hangs retrying is worse than one that
+  says what happened.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+# ERROR_SHARING_VIOLATION: the file is open in another process -- or, on SMB, was open a moment
+# ago and the server has not caught up.
+WINDOWS_SHARING_VIOLATION = 32
+RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2)
+
+
+def replace_atomic(temp_path: Path | str, target_path: Path | str) -> None:
+    """``os.replace`` with a bounded retry for the SMB sharing violation."""
+    for delay in (*RETRY_DELAYS_SECONDS, None):
+        try:
+            os.replace(temp_path, target_path)
+            return
+        except OSError as error:
+            if getattr(error, "winerror", None) != WINDOWS_SHARING_VIOLATION or delay is None:
+                raise
+            time.sleep(delay)
+
+
+def write_bytes_atomic(target_path: Path, payload: bytes) -> None:
+    """Write ``payload`` to ``target_path`` through a temp file in the same directory.
+
+    Same directory on purpose: a rename across filesystems is not atomic, and a temp dir on
+    another volume would silently turn this into a copy.
+    """
+    resolved = Path(target_path)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = resolved.with_name(f"{resolved.name}.{os.getpid()}.{time.time_ns()}.tmp")
+    try:
+        temp_path.write_bytes(payload)
+        replace_atomic(temp_path, resolved)
+    finally:
+        temp_path.unlink(missing_ok=True)

--- a/packages/cadgen/src/cadgen/_internal/component_package.py
+++ b/packages/cadgen/src/cadgen/_internal/component_package.py
@@ -19,6 +19,7 @@ import os
 from pathlib import Path
 from typing import Any, Mapping
 
+from cadgen._internal.atomic_replace import replace_atomic
 from cadgen.catalog import render_package_dir
 from cadgen._internal.generation import (
     DEFAULT_MESH_ANGULAR_TOLERANCE,
@@ -392,7 +393,7 @@ def _write_component_glb_atomic(
             linear_deflection=linear_deflection,
             angular_deflection=angular_deflection,
         )
-        os.replace(temp_path, out_glb)
+        replace_atomic(temp_path, out_glb)
     finally:
         temp_path.unlink(missing_ok=True)
     return out_glb
@@ -766,7 +767,7 @@ def build_package_from_compound(
     # and report the package unreadable.
     _descriptor_tmp = package_dir / f".{DESCRIPTOR_NAME}.tmp{os.getpid()}"
     _descriptor_tmp.write_text(json.dumps(descriptor))
-    os.replace(_descriptor_tmp, package_dir / DESCRIPTOR_NAME)
+    replace_atomic(_descriptor_tmp, package_dir / DESCRIPTOR_NAME)
     # The lazy whole-assembly topology sidecar was extracted against the
     # previous descriptor's provenance; a rewritten package makes it stale by
     # definition, so drop it and let the next selector query rebuild it.

--- a/packages/cadgen/src/cadgen/_internal/drawing_package.py
+++ b/packages/cadgen/src/cadgen/_internal/drawing_package.py
@@ -38,6 +38,7 @@ import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 
+from cadgen._internal.atomic_replace import replace_atomic
 from cadgen._internal.file_metadata import text_to_cad_identity_metadata, write_dxf_text_to_cad_metadata
 from cadgen._internal.node_runtime import node_builder_script, run_node_builder
 from cadgen._internal.package_freshness import (
@@ -278,7 +279,7 @@ def _write_descriptor(package_dir: Path, descriptor: dict[str, object]) -> dict[
     with temp_path.open("w", encoding="utf-8") as handle:
         json.dump(descriptor, handle, indent=2, sort_keys=True)
         handle.write("\n")
-    os.replace(temp_path, descriptor_path)
+    replace_atomic(temp_path, descriptor_path)
     return descriptor
 
 

--- a/packages/cadgen/src/cadgen/_internal/glb.py
+++ b/packages/cadgen/src/cadgen/_internal/glb.py
@@ -9,6 +9,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from cadgen._internal.atomic_replace import write_bytes_atomic
 from cadgen._internal.glb_mesh_payload import (
     CAD_TO_GLB_SCALE,
     DEFAULT_MATERIAL,
@@ -138,22 +139,9 @@ def write_empty_glb(target_path: Path) -> Path:
 
 
 def _atomic_write_bytes(target_path: Path, payload: bytes) -> None:
-    target_path.parent.mkdir(parents=True, exist_ok=True)
-    temp_path = target_path.with_name(f"{target_path.name}.{os.getpid()}.{time.time_ns()}.tmp")
-    try:
-        temp_path.write_bytes(payload)
-        # Windows SMB servers can briefly retain the freshly closed temp file.
-        # Retry only that sharing violation; every other replace error is final.
-        for delay in (0.05, 0.1, 0.2, None):
-            try:
-                temp_path.replace(target_path)
-                break
-            except OSError as exc:
-                if getattr(exc, "winerror", None) != 32 or delay is None:
-                    raise
-                time.sleep(delay)
-    finally:
-        temp_path.unlink(missing_ok=True)
+    # The SMB retry that used to be inline here now covers every artifact rename -- see
+    # cadgen._internal.atomic_replace, and issue #241.
+    write_bytes_atomic(target_path, payload)
 
 
 def build_step_topology_index_manifest(

--- a/packages/cadgen/src/cadgen/_internal/implicit_package.py
+++ b/packages/cadgen/src/cadgen/_internal/implicit_package.py
@@ -36,6 +36,7 @@ import os
 from datetime import datetime, timezone
 from pathlib import Path
 
+from cadgen._internal.atomic_replace import replace_atomic
 from cadgen._internal.node_runtime import node_builder_script, run_node_builder
 from cadgen._internal.package_freshness import (
     bake_hash_matches,
@@ -221,7 +222,7 @@ def _write_descriptor(package_dir: Path, descriptor: dict[str, object]) -> dict[
     with temp_path.open("w", encoding="utf-8") as handle:
         json.dump(descriptor, handle, indent=2, sort_keys=True)
         handle.write("\n")
-    os.replace(temp_path, descriptor_path)
+    replace_atomic(temp_path, descriptor_path)
     return descriptor
 
 

--- a/packages/cadgen/src/cadgen/coordination/record.py
+++ b/packages/cadgen/src/cadgen/coordination/record.py
@@ -38,6 +38,9 @@ import time
 from pathlib import Path
 from typing import Any, Mapping
 
+# Stdlib-only, like everything this module touches: the viewer's server imports it.
+from cadgen._internal.atomic_replace import replace_atomic
+
 SCHEMA_VERSION = 3
 
 OUTCOME_RUNNING = None
@@ -100,7 +103,7 @@ def write_record(path: Path | str, record: Mapping[str, Any]) -> bool:
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
         temp_path.write_text(json.dumps(record, separators=(",", ":")), encoding="utf-8")
-        os.replace(temp_path, target)
+        replace_atomic(temp_path, target)
         return True
     except OSError:
         with contextlib.suppress(OSError):

--- a/packages/cadgen/src/cadgen/step_artifacts.py
+++ b/packages/cadgen/src/cadgen/step_artifacts.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Iterator
 
+from cadgen._internal.atomic_replace import replace_atomic
 from cadgen.catalog import source_from_path
 from cadgen.cli_logging import CliLogger
 from cadgen.coordination import (
@@ -440,7 +441,7 @@ def _write_topology_sidecar(
             angular_deflection=options.angular_deflection,
             selector_bundle=bundle,
         )
-        os.replace(temp_path, target)
+        replace_atomic(temp_path, target)
     except Exception as exc:  # noqa: BLE001 - cache write is advisory
         if logger is not None:
             logger.debug(f"topology.glb cache write skipped for {spec.cad_ref}: {exc}")

--- a/tests/python/packages/cadgen/test_atomic_replace.py
+++ b/tests/python/packages/cadgen/test_atomic_replace.py
@@ -1,0 +1,141 @@
+"""Every artifact rename retries the one Windows error that is worth retrying.
+
+A cached artifact is written to a temp file and renamed into place. On a Windows SMB share that
+rename can lose to ``WinError 32`` -- the redirector still holds the handle Python just closed --
+which under a parallel component build fails reliably (issue #241: 8 workers failed every time
+on a NAS, one worker succeeded). PR #244 fixed the rename inside the GLB writer; this pins the
+policy for all of them, because there are seven in a build's write path and hardening one moves
+the failure to the next.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tests.python.support.paths import REPO_ROOT, add_repo_path
+
+add_repo_path("packages/cadgen/src")
+
+from cadgen._internal import atomic_replace
+
+CADGEN_SRC = REPO_ROOT / "packages" / "cadgen" / "src" / "cadgen"
+
+
+def sharing_violation() -> PermissionError:
+    error = PermissionError(13, "file is being used by another process")
+    error.winerror = atomic_replace.WINDOWS_SHARING_VIOLATION
+    return error
+
+
+class ReplaceAtomicTest(unittest.TestCase):
+    def test_a_sharing_violation_is_retried_until_it_wins(self) -> None:
+        attempts = []
+
+        def flaky(source, target):
+            attempts.append((source, target))
+            if len(attempts) < 3:
+                raise sharing_violation()
+
+        with mock.patch.object(atomic_replace.os, "replace", side_effect=flaky), \
+             mock.patch.object(atomic_replace.time, "sleep") as sleep:
+            atomic_replace.replace_atomic("from.tmp", "to.glb")
+
+        self.assertEqual(3, len(attempts))
+        self.assertEqual(
+            [(0.05,), (0.1,)],
+            [call.args for call in sleep.call_args_list],
+            "the backoff must grow, and must not sleep after the winning attempt",
+        )
+
+    def test_it_gives_up_rather_than_hanging(self) -> None:
+        # A rename that cannot win in 350 ms is not a deferred close. Failing beats a build that
+        # retries forever.
+        error = sharing_violation()
+        with mock.patch.object(atomic_replace.os, "replace", side_effect=error), \
+             mock.patch.object(atomic_replace.time, "sleep") as sleep:
+            with self.assertRaises(PermissionError) as raised:
+                atomic_replace.replace_atomic("from.tmp", "to.glb")
+        self.assertIs(error, raised.exception, "the original error must survive the retries")
+        self.assertEqual(len(atomic_replace.RETRY_DELAYS_SECONDS), sleep.call_count)
+
+    def test_every_other_error_surfaces_at_once(self) -> None:
+        for winerror in (5, 2, None):
+            error = PermissionError(13, "denied")
+            if winerror is not None:
+                error.winerror = winerror
+            with self.subTest(winerror=winerror):
+                with mock.patch.object(atomic_replace.os, "replace", side_effect=error), \
+                     mock.patch.object(atomic_replace.time, "sleep") as sleep:
+                    with self.assertRaises(PermissionError):
+                        atomic_replace.replace_atomic("from.tmp", "to.glb")
+                sleep.assert_not_called()
+
+    def test_the_happy_path_does_not_sleep(self) -> None:
+        with mock.patch.object(atomic_replace.os, "replace") as replace, \
+             mock.patch.object(atomic_replace.time, "sleep") as sleep:
+            atomic_replace.replace_atomic("from.tmp", "to.glb")
+        replace.assert_called_once_with("from.tmp", "to.glb")
+        sleep.assert_not_called()
+
+
+class WriteBytesAtomicTest(unittest.TestCase):
+    def test_it_writes_through_a_temp_file_in_the_SAME_directory(self) -> None:
+        # A temp file on another volume would turn the rename into a copy, which is not atomic.
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="cad-atomic-") as temp_dir:
+            target = Path(temp_dir) / "nested" / "artifact.glb"
+            seen = {}
+
+            real_replace = os.replace
+
+            def record(source, destination):
+                seen["source_parent"] = Path(source).parent
+                real_replace(source, destination)
+
+            with mock.patch.object(atomic_replace.os, "replace", side_effect=record):
+                atomic_replace.write_bytes_atomic(target, b"glTF")
+
+            self.assertEqual(b"glTF", target.read_bytes())
+            self.assertEqual(target.parent, seen["source_parent"])
+
+    def test_the_temp_file_does_not_survive_a_failure(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="cad-atomic-") as temp_dir:
+            target = Path(temp_dir) / "artifact.glb"
+            with mock.patch.object(atomic_replace.os, "replace", side_effect=OSError("nope")):
+                with self.assertRaises(OSError):
+                    atomic_replace.write_bytes_atomic(target, b"glTF")
+            self.assertEqual([], list(Path(temp_dir).iterdir()), "a temp file was left behind")
+
+
+class EveryRenameGoesThroughTheHelperTest(unittest.TestCase):
+    """The point of the helper: one policy, not one per writer.
+
+    Hardening a single rename is what left the reporter's next build to fail somewhere else, so
+    a direct ``os.replace`` in cadgen is the regression this test exists to catch.
+    """
+
+    def test_no_cadgen_module_renames_directly(self) -> None:
+        offenders = []
+        for path in sorted(CADGEN_SRC.rglob("*.py")):
+            if path.name == "atomic_replace.py" or "__pycache__" in path.parts:
+                continue
+            source = re.sub(r"#[^\n]*", "", path.read_text(encoding="utf-8"))
+            if re.search(r"\bos\.replace\(|\.replace\(\s*target", source):
+                offenders.append(str(path.relative_to(REPO_ROOT)))
+        self.assertEqual(
+            [],
+            offenders,
+            "use cadgen._internal.atomic_replace.replace_atomic: a bare os.replace loses to "
+            "WinError 32 on an SMB share (issue #241)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/skills/cad/cadgen/test_glb.py
+++ b/tests/python/skills/cad/cadgen/test_glb.py
@@ -94,35 +94,44 @@ def _read_glb_json(path: Path) -> dict[str, object]:
 
 
 class AtomicGlbWriteTests(unittest.TestCase):
-    def test_retries_transient_windows_file_in_use_error(self) -> None:
+    """The GLB writer inherits the SMB retry rather than implementing one.
+
+    These started as PR #244's tests against an inline retry loop here. The loop moved to
+    cadgen._internal.atomic_replace when the other six artifact renames needed the same policy
+    (issue #241 fails on whichever rename loses first), so what is worth asserting here is the
+    delegation -- the policy itself is pinned in tests/python/packages/cadgen/test_atomic_replace.py.
+    """
+
+    def test_the_writer_renames_through_the_shared_helper(self) -> None:
         with temporary_directory(prefix="cad-glb-atomic-") as temp_dir:
-            target = Path(temp_dir) / "component.glb.tmp1234"
-            locked = PermissionError(13, "file is in use", str(target))
-            locked.winerror = 32
-            with (
-                mock.patch.object(Path, "replace", side_effect=[locked, None]) as replace,
-                mock.patch.object(glb_module.time, "sleep") as sleep,
-            ):
+            target = Path(temp_dir) / "component.glb"
+            with mock.patch.object(
+                glb_module, "write_bytes_atomic", wraps=glb_module.write_bytes_atomic
+            ) as write:
                 glb_module._atomic_write_bytes(target, b"glTF")
+            write.assert_called_once_with(target, b"glTF")
+            self.assertEqual(b"glTF", target.read_bytes())
 
-            self.assertEqual(2, replace.call_count)
-            sleep.assert_called_once_with(0.05)
+    def test_a_windows_sharing_violation_still_retries_through_that_helper(self) -> None:
+        from cadgen._internal import atomic_replace
 
-    def test_does_not_retry_other_replace_errors(self) -> None:
+        locked = PermissionError(13, "file is in use")
+        locked.winerror = atomic_replace.WINDOWS_SHARING_VIOLATION
+        real_replace = atomic_replace.os.replace
+        attempts = []
+
+        def flaky(source, destination):
+            attempts.append(source)
+            if len(attempts) < 2:
+                raise locked
+            real_replace(source, destination)
+
         with temporary_directory(prefix="cad-glb-atomic-") as temp_dir:
-            target = Path(temp_dir) / "component.glb.tmp1234"
-            denied = PermissionError(13, "access denied", str(target))
-            denied.winerror = 5
-            with (
-                mock.patch.object(Path, "replace", side_effect=denied) as replace,
-                mock.patch.object(glb_module.time, "sleep") as sleep,
-            ):
-                with self.assertRaises(PermissionError) as raised:
-                    glb_module._atomic_write_bytes(target, b"glTF")
-
-            self.assertIs(denied, raised.exception)
-            self.assertEqual(1, replace.call_count)
-            sleep.assert_not_called()
+            target = Path(temp_dir) / "component.glb"
+            with mock.patch.object(atomic_replace.os, "replace", side_effect=flaky), \
+                 mock.patch.object(atomic_replace.time, "sleep"):
+                glb_module._atomic_write_bytes(target, b"glTF")
+        self.assertEqual(2, len(attempts))
 
 
 class GlbExportTests(unittest.TestCase):


### PR DESCRIPTION
Follow-up to #244 (merged), which fixed the rename inside the GLB writer. Same share, same build: there are **seven** of these renames in the write path, so hardening one moves the failure to the next.

| rename | covered before |
|---|---|
| `_internal/glb.py` — inner GLB write | #244 |
| `_internal/component_package.py` — outer component GLB, one per component | no |
| `_internal/component_package.py` — `assembly.json` | no |
| `_internal/drawing_package.py` — drawing descriptor | no |
| `_internal/implicit_package.py` — implicit descriptor | no |
| `step_artifacts.py` — STEP artifact | no |
| `coordination/record.py` — progress record, many times per build | no |

The reporter's traceback in #241 has the inner and outer component renames one frame apart, so the outer one was next in line.

## Policy, unchanged from #244

Retry **only** `WinError 32` (ERROR_SHARING_VIOLATION — an SMB deferred close), backoff 50/100/200 ms, then let the original error through. A denial or a missing directory still surfaces immediately rather than 350 ms later, and off Windows there is no `winerror` attribute, so this is exactly `os.replace` on POSIX.

## Notes

- `replace_atomic` lives in `cadgen._internal.atomic_replace`, which is stdlib-only because `coordination/record.py` uses it and the viewer's server imports `coordination` without any CAD runtime (pinned by `test_coordination_is_stdlib_only`).
- `write_bytes_atomic` keeps the temp file in the **target's** directory: a temp dir on another volume would silently turn the rename into a copy, which is not atomic.
- A test fails if any cadgen module renames directly — the regression that would otherwise reappear one writer at a time.
- #244's two tests mocked `Path.replace` on the inline loop, so this refactor stopped them intercepting anything. Rewritten at the new seam (the writer delegates; a sharing violation still retries through the helper), with the policy assertions living once in `test_atomic_replace.py`.

Reported by @M-Stege (#241, with a clean A/B: 8 workers failed every time on a NAS, `CADGEN_COMPONENT_WORKERS=1` succeeded and was faster). Retry policy by @NgoQuocViet2001 in #244.

Gate: `test-python.sh` green (cadgen 255, cad 364, viewer backend 174, …), `test-global.sh` 73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)