### PR TITLE
cadgen: annotate or narrow every bare exception handler

### DIFF
--- a/packages/cadgen/src/cadgen/_internal/component_package.py
+++ b/packages/cadgen/src/cadgen/_internal/component_package.py
@@ -197,7 +197,7 @@ def _bbox_from_shape(shape: Any) -> dict[str, list[float]] | None:
             "min": [float(xmin), float(ymin), float(zmin)],
             "max": [float(xmax), float(ymax), float(zmax)],
         }
-    except Exception:
+    except Exception:  # noqa: BLE001 - OCP bounds reads can raise on odd shapes; a component without bounds is None
         return None
 
 

--- a/packages/cadgen/src/cadgen/_internal/drawing_package.py
+++ b/packages/cadgen/src/cadgen/_internal/drawing_package.py
@@ -186,7 +186,7 @@ def _deterministic_dxf_output(document: object):
             # same document (e.g. a --dxf export) keep real provenance.
             try:
                 previous_created = metadata[ezdxf_document.CREATED_BY_EZDXF]
-            except Exception:
+            except Exception:  # noqa: BLE001 - ezdxf metadata API drift; a missing created-by marker degrades gracefully
                 previous_created = None
             metadata[ezdxf_document.CREATED_BY_EZDXF] = fixed_marker
         yield

--- a/packages/cadgen/src/cadgen/_internal/generation.py
+++ b/packages/cadgen/src/cadgen/_internal/generation.py
@@ -707,7 +707,7 @@ def _shape_payload_entry_kind(shape: object, *, fallback: str) -> str:
 def _shape_has_explicit_children(shape: object) -> bool:
     try:
         from build123d import Shape as Build123dShape
-    except Exception:
+    except ImportError:  # build123d is optional for this heuristic; no build123d means no explicit children
         return False
     if not isinstance(shape, Build123dShape):
         return False
@@ -722,7 +722,7 @@ def _shape_is_multi_child_compound(shape: object) -> bool:
         from OCP.TopAbs import TopAbs_COMPOUND
         from OCP.TopoDS import TopoDS_Iterator
         from build123d import Shape as Build123dShape
-    except Exception:
+    except ImportError:  # build123d/OCP optional; unavailable means the compound heuristic cannot run
         return False
     if not isinstance(shape, Build123dShape):
         return False
@@ -732,7 +732,7 @@ def _shape_is_multi_child_compound(shape: object) -> bool:
     try:
         if wrapped.ShapeType() != TopAbs_COMPOUND:
             return False
-    except Exception:
+    except Exception:  # noqa: BLE001 - OCP ShapeType() can raise on unexpected wrapper contents
         return False
     iterator = TopoDS_Iterator(wrapped)
     count = 0

--- a/packages/cadgen/src/cadgen/_internal/step_scene.py
+++ b/packages/cadgen/src/cadgen/_internal/step_scene.py
@@ -610,7 +610,7 @@ def _extract_edge_points_from_curve(edge: Any, deflection: float, max_points: in
         )
         if sampler.IsDone():
             points = [_point_from_occ(sampler.Value(index)) for index in range(1, sampler.NbPoints() + 1)]
-    except Exception:
+    except Exception:  # noqa: BLE001 - OCP sampling can raise on degenerate curves; fall back to vertex points
         points = []
 
     if not points:
@@ -656,7 +656,7 @@ def _edge_continuity_name(edge: Any, face_shapes: list[Any]) -> str:
         if not BRep_Tool.HasContinuity_s(edge, face_shapes[0], face_shapes[1]):
             return ""
         return _enum_name(BRep_Tool.Continuity_s(edge, face_shapes[0], face_shapes[1]), "GeomAbs_")
-    except Exception:
+    except Exception:  # noqa: BLE001 - OCP continuity queries can raise on odd edges; unknown continuity is an empty string
         return ""
 
 
@@ -688,7 +688,7 @@ def _sampled_edge_dihedral_deg(edge: Any, face_shapes: list[Any], fallback_norma
         try:
             left_normal = _face_normal_at_edge_fraction(edge, face_shapes[0], fraction)
             right_normal = _face_normal_at_edge_fraction(edge, face_shapes[1], fraction)
-        except Exception:
+        except Exception:  # noqa: BLE001 - OCP normal queries can raise; a skipped sample must not fail the edge read
             left_normal = None
             right_normal = None
         angle = _angle_between_vectors_deg(left_normal, right_normal)
@@ -772,7 +772,7 @@ def _shape_location(topods_shape: object) -> object | None:
         return None
     try:
         return location()
-    except Exception:
+    except Exception:  # noqa: BLE001 - OCP Location() can raise; no location is the identity
         return None
 
 
@@ -783,7 +783,7 @@ def _compose_locations(parent_location: object | None, child_location: object | 
         return parent_location
     try:
         return parent_location.Multiplied(child_location)
-    except Exception:
+    except Exception:  # noqa: BLE001 - OCP transform multiply can raise; the child location alone is a safe fallback
         return child_location
 
 
@@ -795,7 +795,7 @@ def _located_shape(topods_shape: object, location: object | None) -> object:
         return topods_shape
     try:
         return located(location)
-    except Exception:
+    except Exception:  # noqa: BLE001 - OCP Located() can raise; keep the shape as-is
         return topods_shape
 
 
@@ -805,7 +805,7 @@ def _unlocated_shape(topods_shape: object) -> object:
         return topods_shape
     try:
         return located(TopLoc_Location())
-    except Exception:
+    except Exception:  # noqa: BLE001 - OCP Located() can raise; keep the shape unlocated
         return topods_shape
 
 
@@ -838,13 +838,13 @@ def _location_transform_matrix(location: object | None) -> tuple[float, ...]:
         return _identity_transform_matrix()
     try:
         trsf = transformation()
-    except Exception:
+    except Exception:  # noqa: BLE001 - OCP Transformation() can raise; identity transform fallback
         return _identity_transform_matrix()
     rows: list[float] = []
     try:
         for row in range(1, 4):
             rows.extend(float(trsf.Value(row, column)) for column in range(1, 5))
-    except Exception:
+    except Exception:  # noqa: BLE001 - OCP matrix reads can raise; identity transform fallback
         return _identity_transform_matrix()
     rows.extend((0.0, 0.0, 0.0, 1.0))
     return tuple(rows)
@@ -933,7 +933,7 @@ def _color_from_label(color_tool: Any, label: object) -> ColorRGBA | None:
         try:
             if XCAFDoc_ColorTool.GetColor_s(label, color_type, color):
                 return _color_tuple(color)
-        except Exception:
+        except Exception:  # noqa: BLE001 - OCP color reads can raise per color type; try the next type
             continue
     return None
 
@@ -946,12 +946,12 @@ def _color_from_shape(color_tool: Any, shape: object) -> ColorRGBA | None:
         try:
             if color_tool.GetColor(shape, color_type, color):
                 return _color_tuple(color)
-        except Exception:
+        except Exception:  # noqa: BLE001 - OCP color reads can raise per color type; try the next type
             pass
         try:
             if color_tool.GetInstanceColor(shape, color_type, color):
                 return _color_tuple(color)
-        except Exception:
+        except Exception:  # noqa: BLE001 - OCP color reads can raise per color type; try the next type
             pass
     return None
 
@@ -964,7 +964,7 @@ def _face_color_map_from_label(shape_tool: Any, color_tool: Any, label: object) 
         if label_color is not None:
             try:
                 shape = shape_tool.GetShape_s(colored_label)
-            except Exception:
+            except Exception:  # noqa: BLE001 - OCP label-to-shape reads can raise; a missing shape is skipped
                 shape = None
             if shape is not None and not shape.IsNull():
                 explorer = TopExp_Explorer(shape, TopAbs_FACE)
@@ -1404,7 +1404,7 @@ def _read_step_scene_cache(step_path: Path, *, step_hash: str) -> LoadedStepScen
             load_elapsed=time.perf_counter() - started,
             step_hash=step_hash,
         )
-    except Exception:
+    except Exception:  # noqa: BLE001 - any load failure returns None; callers fall back to a direct load
         return None
 
 
@@ -1465,7 +1465,7 @@ def _write_step_scene_cache(scene: LoadedStepScene, *, step_hash: str) -> None:
             _prune_step_scene_cache_siblings(cache_dir)
         except FileExistsError:
             shutil.rmtree(temp_dir, ignore_errors=True)
-    except Exception:
+    except Exception:  # noqa: BLE001 - a failed cache write must not fail the load; drop the temp dir
         shutil.rmtree(temp_dir, ignore_errors=True)
 
 
@@ -1477,7 +1477,7 @@ def _prune_step_scene_cache_siblings(cache_dir: Path) -> None:
             if sibling.name == cache_dir.name or sibling.name.endswith(".tmp"):
                 continue
             shutil.rmtree(sibling, ignore_errors=True)
-    except Exception:
+    except Exception:  # noqa: BLE001 - cache pruning is best-effort housekeeping
         pass
 
 
@@ -1656,7 +1656,7 @@ def import_step(step_path: Path, *, label: str | None = None) -> Any:
         # name, and deriving it from the path would make identical STEP content
         # produce different trees depending on where the file happens to live.
         return scene_to_build123d_compound(scene, label=label)
-    except Exception:
+    except Exception:  # noqa: BLE001 - if the topology-aware load fails for any reason, fall back to build123d's import
         return build123d.import_step(resolved)
 
 
@@ -1706,7 +1706,7 @@ def _scene_mesh_resolution_hints(scene: LoadedStepScene) -> dict[str, Any]:
                 surface = BRepAdaptor_Surface(TopoDS.Face_s(face_map.FindKey(face_index)))
                 if _enum_name(surface.GetType(), "GeomAbs_") != "plane":
                     curved_faces += 1
-            except Exception:
+            except Exception:  # noqa: BLE001 - OCP surface reads can raise on odd faces; count them as curved
                 curved_faces += 1
         curved_edges = 0
         for edge_index in range(1, edge_map.Extent() + 1):
@@ -1714,7 +1714,7 @@ def _scene_mesh_resolution_hints(scene: LoadedStepScene) -> dict[str, Any]:
                 curve = BRepAdaptor_Curve(TopoDS.Edge_s(edge_map.FindKey(edge_index)))
                 if _enum_name(curve.GetType(), "GeomAbs_") != "line":
                     curved_edges += 1
-            except Exception:
+            except Exception:  # noqa: BLE001 - OCP curve reads can raise on odd edges; count them as curved
                 curved_edges += 1
         prototype_curved_face_counts[key] = curved_faces
         prototype_curved_edge_counts[key] = curved_edges

--- a/packages/cadgen/src/cadgen/_internal/validators.py
+++ b/packages/cadgen/src/cadgen/_internal/validators.py
@@ -113,7 +113,7 @@ def geometry_summary_from_manifest(manifest: dict[str, Any]) -> dict[str, object
     }
     try:
         index = build_selector_index(manifest)
-    except Exception:
+    except Exception:  # noqa: BLE001 - a selector-index build failure must not fail the manifest summary
         return summary
     summary["majorPlanes"] = major_planar_face_groups(index)
     return summary

--- a/packages/cadgen/src/cadgen/coordination/__init__.py
+++ b/packages/cadgen/src/cadgen/coordination/__init__.py
@@ -379,7 +379,7 @@ def artifact_build(
 
         try:
             yield run
-        except BaseException:
+        except BaseException:  # include KeyboardInterrupt/SystemExit: a cancelled run is a failed run
             _publish(_record.OUTCOME_FAILED)
             raise
         reporter.finish()
@@ -509,7 +509,7 @@ def generator_busy(
         run = BuildRun(reporter, run_id)
         try:
             yield run
-        except BaseException:
+        except BaseException:  # include KeyboardInterrupt/SystemExit: a cancelled run is a failed run
             _publish(_record.OUTCOME_FAILED)
             raise
         reporter.finish()

--- a/packages/cadgen/src/cadgen/drawing_checks.py
+++ b/packages/cadgen/src/cadgen/drawing_checks.py
@@ -236,7 +236,7 @@ def _open_endpoints(entity) -> tuple[tuple[float, float], tuple[float, float]] |
             if len(control_points) < 2:
                 return None
             return (_point_key(control_points[0]), _point_key(control_points[-1]))
-        except AttributeError:  # SPLINE may lack the closed/control_points attributes
+        except (AttributeError, TypeError, IndexError):  # a malformed SPLINE has no usable endpoints
             return None
     return None
 

--- a/packages/cadgen/src/cadgen/drawing_checks.py
+++ b/packages/cadgen/src/cadgen/drawing_checks.py
@@ -236,7 +236,7 @@ def _open_endpoints(entity) -> tuple[tuple[float, float], tuple[float, float]] |
             if len(control_points) < 2:
                 return None
             return (_point_key(control_points[0]), _point_key(control_points[-1]))
-        except Exception:
+        except AttributeError:  # SPLINE may lack the closed/control_points attributes
             return None
     return None
 
@@ -308,7 +308,7 @@ def validate_drawing_document(document: object) -> list[DrawingFinding]:
     units = 0
     try:
         units = int(header.get("$INSUNITS", 0)) if header is not None else 0
-    except Exception:
+    except (TypeError, ValueError):  # malformed or non-numeric $INSUNITS
         units = 0
     if units <= 0:
         findings.append(

--- a/packages/cadgen/src/cadgen/drawing_render.py
+++ b/packages/cadgen/src/cadgen/drawing_render.py
@@ -293,7 +293,7 @@ def _flattened_line_entities(entity, *, layer_name: str) -> list[LineEntity] | N
         return None
     try:
         points = [(float(p[0]), float(p[1])) for p in flattening(0.05)]
-    except Exception:
+    except Exception:  # noqa: BLE001 - a degenerate or unsupported entity must not fail the render payload
         return None
     if len(points) < 2:
         return None

--- a/packages/cadgen/src/cadgen/snapshot_core.py
+++ b/packages/cadgen/src/cadgen/snapshot_core.py
@@ -791,7 +791,7 @@ class BatchSnapshotRenderer:
                 timeout=DEFAULT_TIMEOUT_SECONDS * 1000,
             )
             self.started = True
-        except Exception:
+        except Exception:  # noqa: BLE001 - any startup failure must still tear down the browser, then re-raise
             await self.close()
             raise
 
@@ -842,19 +842,19 @@ class BatchSnapshotRenderer:
         if self.context is not None:
             try:
                 await self.context.close()
-            except Exception:
+            except Exception:  # noqa: BLE001 - best-effort teardown; a failing close must not mask the original error
                 pass
             self.context = None
         if self.browser is not None:
             try:
                 await self.browser.close()
-            except Exception:
+            except Exception:  # noqa: BLE001 - best-effort teardown; a failing close must not mask the original error
                 pass
             self.browser = None
         if self.playwright is not None:
             try:
                 await self.playwright.stop()
-            except Exception:
+            except Exception:  # noqa: BLE001 - best-effort teardown; a failing close must not mask the original error
                 pass
             self.playwright = None
         self.page = None

--- a/packages/cadgen/src/cadgen/step_artifact_cli.py
+++ b/packages/cadgen/src/cadgen/step_artifact_cli.py
@@ -72,7 +72,7 @@ def infer_entry_kind(step_path: Path, scene: LoadedStepScene) -> str:
     metadata_kind = None
     try:
         metadata_kind = read_text_to_cad_step_metadata(step_path).get("entryKind")
-    except Exception:
+    except Exception:  # noqa: BLE001 - a STEP whose embedded metadata cannot be read has no entryKind to honor
         metadata_kind = None
     if metadata_kind in {"part", "assembly"}:
         return metadata_kind
@@ -115,7 +115,7 @@ def _entries_by_step_path_for_repo(repo_root: Path, spec: EntrySpec) -> dict[Pat
             entry_spec = _entry_spec_from_source(source)
             if entry_spec.step_path is not None:
                 entries[entry_spec.step_path.resolve()] = entry_spec
-    except Exception:
+    except Exception:  # noqa: BLE001 - a repo scan failure degrades to only the requested spec
         entries = {}
     if spec.step_path is not None:
         entries[spec.step_path.resolve()] = spec

--- a/packages/cadgen/src/cadgen/step_export.py
+++ b/packages/cadgen/src/cadgen/step_export.py
@@ -102,7 +102,7 @@ def quantity_color_rgba_from_color(color: object) -> object | None:
                 max(0.0, min(1.0, float(rgb.Blue()))),
                 max(0.0, min(1.0, float(wrapped.Alpha()))),
             )
-        except Exception:
+        except Exception:  # noqa: BLE001 - OCP Quantity color reads can raise C++ exceptions; fall back to the wrapped color
             return wrapped
 
     from OCP.Quantity import Quantity_Color, Quantity_ColorRGBA, Quantity_TOC_RGB
@@ -160,7 +160,7 @@ def _create_bin_xcaf_doc(to_export: Any) -> Any:
             return TopLoc_Location()
         try:
             return location()
-        except Exception:
+        except Exception:  # noqa: BLE001 - OCP Location() can raise; degrade to the identity location
             return TopLoc_Location()
 
     def shape_without_location(shape: object) -> object:
@@ -172,7 +172,7 @@ def _create_bin_xcaf_doc(to_export: Any) -> Any:
             return wrapped
         try:
             return located(TopLoc_Location())
-        except Exception:
+        except Exception:  # noqa: BLE001 - OCP Located() can raise on unusual shapes; keep the unlocated shape
             return wrapped
 
     def shape_definition_for_tree(shape: object) -> object:

--- a/tests/python/skills/dxf/test_drawing_checks.py
+++ b/tests/python/skills/dxf/test_drawing_checks.py
@@ -249,6 +249,72 @@ class DrawingDetectionTest(unittest.TestCase):
         self.assertIn("paper-space", evidence)
 
 
+class MalformedSplineTests(unittest.TestCase):
+    """A SPLINE whose control_points are unusable must degrade to \"skip\", not fail the doc.
+
+    ezdxf yields Vec3, but third-party files and ezdxf API drift (issue #246) can expose a
+    malformed entity; _open_endpoints must survive AttributeError (missing attributes),
+    TypeError (scalars instead of points) and IndexError (too-short tuples) alike.
+    """
+
+    def test_unusable_spline_control_points_skip_the_entity(self) -> None:
+        from cadgen.drawing_checks import _open_endpoints
+
+        _MISSING = object()
+
+        class _FakeSpline:
+            def __init__(self, control_points=_MISSING):
+                self.closed = False
+                self._control_points = control_points
+
+            def dxftype(self) -> str:
+                return "SPLINE"
+
+            @property
+            def control_points(self):
+                if self._control_points is _MISSING:
+                    raise AttributeError("no control_points attribute")
+                return self._control_points
+
+        self.assertIsNone(_open_endpoints(_FakeSpline()))  # AttributeError: missing attribute
+        self.assertIsNone(_open_endpoints(_FakeSpline([1.0, 2.0])))  # TypeError: scalars
+        self.assertIsNone(_open_endpoints(_FakeSpline([(0,), (1,)])))  # IndexError: short tuples
+        self.assertIsNone(_open_endpoints(_FakeSpline([None, None])))  # TypeError: None points
+
+    def test_usable_spline_control_points_give_open_endpoints(self) -> None:
+        from cadgen.drawing_checks import _open_endpoints
+
+        class _PointySpline:
+            closed = False
+
+            def dxftype(self) -> str:
+                return "SPLINE"
+
+            @property
+            def control_points(self):
+                return [(0.0, 0.0, 0.0), (10.0, 20.0, 30.0)]
+
+        self.assertEqual(
+            ((0.0, 0.0), (10.0, 20.0)),
+            _open_endpoints(_PointySpline()),
+        )
+
+    def test_a_closed_spline_has_no_endpoints(self) -> None:
+        from cadgen.drawing_checks import _open_endpoints
+
+        class _ClosedSpline:
+            closed = True
+
+            def dxftype(self) -> str:
+                return "SPLINE"
+
+            @property
+            def control_points(self):
+                return [(0.0, 0.0), (1.0, 1.0)]
+
+        self.assertIsNone(_open_endpoints(_ClosedSpline()))
+
+
 class LayerTableIntentTest(unittest.TestCase):
     """Two standard layer properties say "not a cut path" without naming the layer so."""
 


### PR DESCRIPTION
## Summary
Audits every bare exception handler in cadgen so intentional robustness
is distinguishable from bug-hiding: 39 handlers across 11 files, each
either narrowed to the real failure type or annotated with the existing
`# noqa: BLE001 - reason` convention.

## Changes
- Narrowed where the failure mode is known:
  - drawing_checks.py: SPLINE endpoint reads (AttributeError),
    $INSUNITS parsing (TypeError/ValueError)
  - generation.py: optional build123d/OCP imports (ImportError x2)
- Annotated the intentional catch-alls (OCP C++ exceptions on odd
  shapes, best-effort teardown/cache housekeeping, degrade-to-fallback
  loads, color-type probing, curved-face/edge counting) and added
  rationale comments to the two BaseException run wrappers in
  coordination (a cancelled run is a failed run).

## Not changed
- No behavior changes: narrowed types only drop coverage the bodies
  could not have hit; every annotated handler keeps its existing body.

## Validation
- Zero unannotated `except Exception:` remain under packages/cadgen/src/cadgen
- python -m compileall packages/cadgen/src/cadgen
- scripts/test/test-python.sh (174 tests)