### PR TITLE
Add skill-level tests for sendcutsend, step-parts, and implicit-cad

### DIFF
--- a/tests/python/skills/implicit-cad/test_schema_reference.py
+++ b/tests/python/skills/implicit-cad/test_schema_reference.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import unittest
+
+from tests.python.support.paths import repo_path
+
+SCHEMA_PATH_REFERENCE = "scripts/packages/implicitjs/src/lib/implicitCad/schema.js"
+HELPER_REEXPORT = "scripts/lib/implicit-cad.mjs"
+SCHEMA_MARKER = "implicit.js/0.1.0"
+
+
+class ImplicitCadSchemaReferenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill_root = repo_path("skills", "implicit-cad")
+
+    def test_skill_md_names_the_schema_source_of_truth(self) -> None:
+        source = (self.skill_root / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn(SCHEMA_PATH_REFERENCE, source)
+
+    def test_schema_path_reference_resolves(self) -> None:
+        schema = self.skill_root / SCHEMA_PATH_REFERENCE
+        self.assertTrue(schema.is_file(), f"{SCHEMA_PATH_REFERENCE} must resolve to a file")
+        self.assertGreater(schema.read_text(encoding="utf-8").strip(), "")
+        self.assertIn(SCHEMA_MARKER, schema.read_text(encoding="utf-8"))
+
+    def test_skill_reexport_module_resolves(self) -> None:
+        helper = self.skill_root / HELPER_REEXPORT
+        self.assertTrue(helper.is_file(), f"{HELPER_REEXPORT} must resolve to a file")

--- a/tests/python/skills/implicit-cad/test_skill_structure.py
+++ b/tests/python/skills/implicit-cad/test_skill_structure.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unittest
+
+from tests.python.support.paths import repo_path
+
+EXPECTED_SCRIPT_ENTRIES = ("gen", "export.mjs", "snapshot", "lib/implicit-cad.mjs")
+
+
+class ImplicitCadSkillStructureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill_root = repo_path("skills", "implicit-cad")
+
+    def test_skill_md_exists_with_required_frontmatter(self) -> None:
+        source = (self.skill_root / "SKILL.md").read_text(encoding="utf-8")
+        head = source.split("---", 2)
+        self.assertEqual(3, len(head), "SKILL.md must open with YAML frontmatter")
+        self.assertIn("name: implicit-cad", head[1])
+        self.assertRegex(head[1], r"description:\s*\S", "description frontmatter must be non-empty")
+
+    def test_agents_openai_yaml_exists(self) -> None:
+        agent_file = self.skill_root / "agents" / "openai.yaml"
+        self.assertTrue(agent_file.is_file(), "agents/openai.yaml must exist")
+        self.assertGreater(agent_file.read_text(encoding="utf-8").strip(), "")
+
+    def test_expected_script_entry_points_exist(self) -> None:
+        for rel in EXPECTED_SCRIPT_ENTRIES:
+            with self.subTest(entry=rel):
+                self.assertTrue(
+                    (self.skill_root / "scripts" / rel).exists(),
+                    f"scripts/{rel} must exist",
+                )
+
+    def test_gen_package_is_runnable_as_a_module(self) -> None:
+        gen_dir = self.skill_root / "scripts" / "gen"
+        self.assertTrue((gen_dir / "__main__.py").is_file())
+        self.assertTrue((gen_dir / "cli.py").is_file())

--- a/tests/python/skills/sendcutsend/test_report_template.py
+++ b/tests/python/skills/sendcutsend/test_report_template.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import unittest
+
+from tests.python.support.paths import repo_path
+
+REQUIRED_SECTIONS = (
+    "Context",
+    "Sources Checked",
+    "Geometry Facts",
+    "Findings",
+    "Verdict",
+)
+
+
+class SendCutSendReportTemplateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.template = (
+            repo_path("skills", "sendcutsend", "references", "report-template.md")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        )
+
+    def test_template_has_a_document_title(self) -> None:
+        self.assertTrue(self.template[0].startswith("# "), "template must open with a title")
+
+    def test_required_sections_appear_in_order(self) -> None:
+        heading_lines = [line.strip() for line in self.template if line.strip().startswith("## ")]
+        self.assertGreaterEqual(len(heading_lines), len(REQUIRED_SECTIONS))
+        headings = [line[3:].strip() for line in heading_lines]
+        position = 0
+        for section in REQUIRED_SECTIONS:
+            with self.subTest(section=section):
+                self.assertIn(section, headings[position:], f"section {section!r} missing or out of order")
+                position = position + 1 + headings[position:].index(section)
+
+    def test_findings_table_has_the_standard_columns(self) -> None:
+        header = [line for line in self.template if line.strip().startswith("| Status | Check | Evidence |")]
+        self.assertEqual(1, len(header), "findings table must carry the standard header row")
+        self.assertIn("Rule source", header[0])
+        self.assertIn("Recommendation", header[0])

--- a/tests/python/skills/sendcutsend/test_skill_structure.py
+++ b/tests/python/skills/sendcutsend/test_skill_structure.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from tests.python.support.paths import repo_path
+
+
+class SendCutSendSkillStructureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill_root = repo_path("skills", "sendcutsend")
+
+    def test_skill_md_exists_with_required_frontmatter(self) -> None:
+        source = (self.skill_root / "SKILL.md").read_text(encoding="utf-8")
+        head = source.split("---", 2)
+        self.assertEqual(3, len(head), "SKILL.md must open with YAML frontmatter")
+        self.assertIn("name: sendcutsend", head[1])
+        self.assertRegex(head[1], r"description:\s*\S", "description frontmatter must be non-empty")
+
+    def test_agents_openai_yaml_exists(self) -> None:
+        agent_file = self.skill_root / "agents" / "openai.yaml"
+        self.assertTrue(agent_file.is_file(), "agents/openai.yaml must exist")
+        self.assertGreater(agent_file.read_text(encoding="utf-8").strip(), "")
+
+    def test_references_exist(self) -> None:
+        for rel in ("official-sources.md", "report-template.md"):
+            ref = self.skill_root / "references" / rel
+            with self.subTest(reference=rel):
+                self.assertTrue(ref.is_file(), f"references/{rel} must exist")
+                self.assertGreater(ref.read_text(encoding="utf-8").strip(), "")

--- a/tests/python/skills/step-parts/test_search_cli.py
+++ b/tests/python/skills/step-parts/test_search_cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+
+from tests.python.support.paths import repo_path
+
+
+class StepPartsSearchCliTests(unittest.TestCase):
+    """Smoke-test the search/download CLI without touching the network."""
+
+    def test_help_exits_zero_and_documents_network_flags(self) -> None:
+        script = repo_path("skills", "step-parts", "scripts", "download_step_part.py")
+        proc = subprocess.run(
+            [sys.executable, str(script), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(0, proc.returncode, proc.stderr)
+        self.assertIn("usage:", proc.stdout)
+        for flag in ("--origin", "--download", "--out-dir", "--limit"):
+            with self.subTest(flag=flag):
+                self.assertIn(flag, proc.stdout)
+
+    def test_invalid_flag_exits_nonzero(self) -> None:
+        script = repo_path("skills", "step-parts", "scripts", "download_step_part.py")
+        proc = subprocess.run(
+            [sys.executable, str(script), "--definitely-not-a-flag"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertNotEqual(0, proc.returncode)

--- a/tests/python/skills/step-parts/test_skill_structure.py
+++ b/tests/python/skills/step-parts/test_skill_structure.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from tests.python.support.paths import repo_path
+
+
+class StepPartsSkillStructureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill_root = repo_path("skills", "step-parts")
+
+    def test_skill_md_exists_with_required_frontmatter(self) -> None:
+        source = (self.skill_root / "SKILL.md").read_text(encoding="utf-8")
+        head = source.split("---", 2)
+        self.assertEqual(3, len(head), "SKILL.md must open with YAML frontmatter")
+        self.assertIn("name: step-parts", head[1])
+        self.assertRegex(head[1], r"description:\s*\S", "description frontmatter must be non-empty")
+
+    def test_agents_openai_yaml_exists(self) -> None:
+        agent_file = self.skill_root / "agents" / "openai.yaml"
+        self.assertTrue(agent_file.is_file(), "agents/openai.yaml must exist")
+        self.assertGreater(agent_file.read_text(encoding="utf-8").strip(), "")
+
+    def test_reference_and_cli_script_exist(self) -> None:
+        self.assertTrue((self.skill_root / "references" / "step-parts-api.md").is_file())
+        script = self.skill_root / "scripts" / "download_step_part.py"
+        self.assertTrue(script.is_file(), "scripts/download_step_part.py must exist")
+
+    def test_cli_script_stays_stdlib_only(self) -> None:
+        script = self.skill_root / "scripts" / "download_step_part.py"
+        source = script.read_text(encoding="utf-8")
+        imports = []
+        for line in source.splitlines():
+            line = line.strip()
+            if line.startswith("import "):
+                imports.append(line[len("import ") :].split(".")[0].split()[0])
+            elif line.startswith("from "):
+                imports.append(line[len("from ") :].split(".")[0].split()[0])
+        self.assertEqual([], sorted(set(imports) - _STDLIB))
+        self.assertTrue(source.lstrip().startswith("#!/usr/bin/env python3"))
+
+
+_STDLIB = {
+    "__future__",
+    "argparse",
+    "hashlib",
+    "json",
+    "pathlib",
+    "sys",
+    "tempfile",
+    "typing",
+    "urllib",
+}


### PR DESCRIPTION
## Why

Every other skill (`cad`, `dxf`, `gcode`, `bambu-labs`, `urdf`, `srdf`, `sdf`) has a Python skill-level test suite; these three had none, so nothing in CI pins their SKILL.md frontmatter, references, agents, or script entry points.

## What changed

Six new test files under `tests/python/skills/<skill-dir>/` (19 tests total):

- **`sendcutsend/`** — structure tests (frontmatter, `agents/openai.yaml`, `references/official-sources.md` + `report-template.md`) and a report-template validator (required sections in order: Context → Sources Checked → Geometry Facts → Findings → Verdict; standard findings-table columns)
- **`step-parts/`** — structure tests plus a network-free CLI smoke test (`--help` exits 0, flags documented; bad flag exits non-zero) and a stdlib-only import guard on `download_step_part.py`
- **`implicit-cad/`** — structure tests (frontmatter, agents, script entry points `gen`/`export.mjs`/`snapshot`/`lib/implicit-cad.mjs`, `gen` runnable as a module) and schema-reference tests pinning that the SKILL.md `schema.js` path resolves and carries the `implicit.js/0.1.0` marker

One deviation from the scan plan: test dirs use the skills/ directory names (`step-parts`, `implicit-cad` — hyphens) rather than the planned underscores, because `scripts/test/test-python.sh` keys discovery off `list-skills.sh` basenames; underscored dirs would be silently skipped.

## Verification

- `scripts/test/test-python.sh` full suite green: `sendcutsend` 6, `step-parts` 6, `implicit-cad` 7, and all pre-existing suites unchanged
- No `__init__.py` added, matching the convention of the existing six skill suites