### PR TITLE
Add Windows msvcrt fallback to the coordination lock

### DIFF
--- a/packages/cadgen/src/cadgen/coordination/lock.py
+++ b/packages/cadgen/src/cadgen/coordination/lock.py
@@ -25,6 +25,16 @@ Readers probe with ``LOCK_SH``, writers take ``LOCK_EX``. That asymmetry matters
 conflicts per open file description, not per process, so two concurrent ``LOCK_EX`` probes
 of an UNHELD sentinel conflict with each other and one of them wrongly reports a build in
 flight. Measured at ~6% false positives with four threads before this was fixed.
+
+On Windows there is no ``fcntl``; :mod:`msvcrt` provides byte-range locks (``locking``)
+instead. Kernel-ownership on close behaves the same, but the model differs in two ways
+that matter: ``msvcrt.locking`` locks a byte region at the CURRENT file position (not the
+whole descriptor), and it has no shared mode -- every operation, probes included, takes an
+exclusive region lock. A sentinel therefore must hold a byte before it can be locked at
+all, and two concurrent Windows probes of the same sentinel can false-positive "held"
+(the very race the POSIX shared-probe asymmetry exists to avoid). Locking past EOF is an
+error on Windows, so an EMPTY sentinel is reported as degraded rather than held -- a
+crash between ``open()`` and stamping must not wedge every later build forever.
 """
 
 from __future__ import annotations
@@ -38,10 +48,19 @@ import uuid
 from pathlib import Path
 from typing import Callable, Iterator, NamedTuple
 
-try:  # POSIX only; on a platform without fcntl every operation degrades to a no-op.
+try:  # POSIX only; on a platform without fcntl every operation uses the windows backend
+    # or degrades to a no-op.
     import fcntl
 except ImportError:  # pragma: no cover - not reachable on darwin/linux CI
     fcntl = None  # type: ignore[assignment]
+
+try:  # Windows only; msvcrt.locking is a byte-range lock, not a whole-descriptor lock.
+    import msvcrt
+except ImportError:  # pragma: no cover - not reachable on darwin/linux CI
+    msvcrt = None  # type: ignore[assignment]
+
+
+_BUSY_ERRNOS = (errno.EWOULDBLOCK, errno.EAGAIN, errno.EACCES)
 
 
 _HELD = threading.local()
@@ -66,14 +85,36 @@ class Contended(RuntimeError):
 
 class ProbeResult(NamedTuple):
     """``held`` -- a peer holds the lock right now. ``degraded`` -- we could not tell,
-    because locking is unavailable here (no ``fcntl``, or a filesystem that refuses it)."""
+    because locking is unavailable here (no ``fcntl``/``msvcrt``, or a filesystem that
+    refuses it)."""
 
     held: bool
     degraded: bool
 
 
 def locking_available() -> bool:
-    return fcntl is not None
+    return fcntl is not None or msvcrt is not None
+
+
+def _unlock(handle) -> None:
+    """Release whatever backend lock ``handle`` holds; the caller owns error policy."""
+    if fcntl is not None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    else:
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def _pad_sentinel(handle) -> None:
+    """Ensure the sentinel holds at least one byte, so a Windows region lock is legal.
+
+    Locking past EOF is an error on Windows, and a brand-new sentinel is 0 bytes.
+    Sentinels are never unlinked, so this pad happens at most once in the file's life and
+    writes nothing visible to ``read_run_id`` (which strips whitespace)."""
+    if handle.seek(0, os.SEEK_END) == 0:
+        handle.write(b"\x00")
+        handle.flush()
+    handle.seek(0)
 
 
 def new_run_id() -> str:
@@ -87,7 +128,7 @@ def probe(lock_path: Path | str) -> ProbeResult:
     sentinel under ``__cadgen__`` for a model that had never been built, as a side effect
     of a status GET. A missing sentinel means no run has ever held it, which is idle.
     """
-    if fcntl is None:
+    if fcntl is None and msvcrt is None:
         return ProbeResult(held=False, degraded=True)
     path = Path(lock_path)
     try:
@@ -98,16 +139,33 @@ def probe(lock_path: Path | str) -> ProbeResult:
         # Unreadable sentinel: we cannot tell, and must not claim a build is running.
         return ProbeResult(held=False, degraded=True)
     try:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
-    except OSError as exc:
-        if exc.errno in (errno.EWOULDBLOCK, errno.EAGAIN):
-            return ProbeResult(held=True, degraded=False)
-        # ENOLCK / EOPNOTSUPP -- the filesystem does not do advisory locks (NFS, SMB,
-        # some bind mounts). Report degraded rather than inventing a state.
-        return ProbeResult(held=False, degraded=True)
-    else:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-        return ProbeResult(held=False, degraded=False)
+        if fcntl is not None:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
+            except OSError as exc:
+                if exc.errno in _BUSY_ERRNOS:
+                    return ProbeResult(held=True, degraded=False)
+                # ENOLCK / EOPNOTSUPP -- the filesystem does not do advisory locks (NFS,
+                # SMB, some bind mounts). Report degraded rather than inventing a state.
+                return ProbeResult(held=False, degraded=True)
+            else:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                return ProbeResult(held=False, degraded=False)
+        # Windows backend: a 1-byte EXCLUSIVE region lock (msvcrt has no shared mode).
+        # An empty sentinel cannot be locked at all (lock-past-EOF is an error), and it
+        # must read as UNKNOWN, never held: see the module docstring.
+        if handle.seek(0, os.SEEK_END) == 0:
+            return ProbeResult(held=False, degraded=True)
+        handle.seek(0)
+        try:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError as exc:
+            if exc.errno in _BUSY_ERRNOS:
+                return ProbeResult(held=True, degraded=False)
+            return ProbeResult(held=False, degraded=True)
+        else:
+            _unlock(handle)
+            return ProbeResult(held=False, degraded=False)
     finally:
         handle.close()
 
@@ -148,10 +206,10 @@ def exclusive(
 
     ``None`` (a producer with no coordinated output dir) is a no-op, and so is every
     failure to lock: an unwritable ``__cadgen__``, a filesystem without advisory locks, or
-    a platform without ``fcntl`` degrades to "no coordination" and yields None. A build
-    must never fail because a lock was unavailable.
+    a platform without ``fcntl`` or ``msvcrt`` degrades to "no coordination" and yields
+    None. A build must never fail because a lock was unavailable.
     """
-    if lock_path is None or fcntl is None:
+    if lock_path is None or (fcntl is None and msvcrt is None):
         yield None
         return
 
@@ -192,7 +250,7 @@ def exclusive(
             yield recorded
         finally:
             with contextlib.suppress(OSError):
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                _unlock(handle)
     finally:
         held.discard(key)
         with contextlib.suppress(OSError):
@@ -206,29 +264,36 @@ def _acquire(
     deadline_ms: float | None,
     on_wait: Callable[[float], None] | None,
 ) -> None:
-    """Take ``LOCK_EX``, honouring an optional deadline and an optional wait notice.
+    """Take the exclusive lock, honouring an optional deadline and an optional wait notice.
 
-    With neither, this is a plain blocking ``flock`` -- the kernel queues us and the hot
-    path costs one syscall. With either, the wait has to POLL: ``flock`` has no timeout,
-    and alarm-based interruption is not thread-safe, so there is no way to bound the wait
-    or to get control back periodically while blocked inside it. The interval is short
-    enough to be imperceptible against a wait long enough to be worth reporting.
+    POSIX, with neither: a plain blocking ``flock`` -- the kernel queues us and the hot
+    path costs one syscall. Every other case POLLS: ``flock`` has no timeout and
+    alarm-based interruption is not thread-safe, and ``msvcrt.LK_LOCK`` (the Windows
+    blocking mode) retries only ten times at one-second intervals before raising, so it
+    would turn a genuinely long wait into a spurious degradation. Polling gives the
+    deadline and the wait notice meaning on both backends. The interval is short enough
+    to be imperceptible against a wait long enough to be worth reporting.
 
     Raises :class:`Contended` when ``deadline_ms`` elapses with a peer still holding it.
     """
-    if deadline_ms is None and on_wait is None:
+    if fcntl is not None and deadline_ms is None and on_wait is None:
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         return
 
+    _pad_sentinel(handle)
     started = time.monotonic()
     deadline = None if deadline_ms is None else started + (max(0.0, deadline_ms) / 1000.0)
     next_notice_at = _WAIT_NOTICE_GRACE_S
     while True:
         try:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            else:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
             return
         except OSError as exc:
-            if exc.errno not in (errno.EWOULDBLOCK, errno.EAGAIN):
+            if exc.errno not in _BUSY_ERRNOS:
                 raise
         now = time.monotonic()
         if deadline is not None and now >= deadline:

--- a/packages/cadgen/src/cadgen/coordination/lock.py
+++ b/packages/cadgen/src/cadgen/coordination/lock.py
@@ -60,7 +60,12 @@ except ImportError:  # pragma: no cover - not reachable on darwin/linux CI
     msvcrt = None  # type: ignore[assignment]
 
 
-_BUSY_ERRNOS = (errno.EWOULDBLOCK, errno.EAGAIN, errno.EACCES)
+# errnos that mean "a peer holds the lock right now", per backend. POSIX flock raises
+# EWOULDBLOCK/EAGAIN for a contended LOCK_NB; Windows msvcrt raises EACCES instead. Folding
+# EACCES into the POSIX set would misread one of flock's "the filesystem refused this"
+# errors as contention, so the sets stay separate.
+_FCNTL_BUSY_ERRNOS = (errno.EWOULDBLOCK, errno.EAGAIN)
+_MSVCRT_BUSY_ERRNOS = (errno.EWOULDBLOCK, errno.EAGAIN, errno.EACCES)
 
 
 _HELD = threading.local()
@@ -112,7 +117,7 @@ def _pad_sentinel(handle) -> None:
     Sentinels are never unlinked, so this pad happens at most once in the file's life and
     writes nothing visible to ``read_run_id`` (which strips whitespace)."""
     if handle.seek(0, os.SEEK_END) == 0:
-        handle.write(b"\x00")
+        handle.write(b" ")
         handle.flush()
     handle.seek(0)
 
@@ -143,7 +148,7 @@ def probe(lock_path: Path | str) -> ProbeResult:
             try:
                 fcntl.flock(handle.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
             except OSError as exc:
-                if exc.errno in _BUSY_ERRNOS:
+                if exc.errno in _FCNTL_BUSY_ERRNOS:
                     return ProbeResult(held=True, degraded=False)
                 # ENOLCK / EOPNOTSUPP -- the filesystem does not do advisory locks (NFS,
                 # SMB, some bind mounts). Report degraded rather than inventing a state.
@@ -160,7 +165,7 @@ def probe(lock_path: Path | str) -> ProbeResult:
         try:
             msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
         except OSError as exc:
-            if exc.errno in _BUSY_ERRNOS:
+            if exc.errno in _MSVCRT_BUSY_ERRNOS:
                 return ProbeResult(held=True, degraded=False)
             return ProbeResult(held=False, degraded=True)
         else:
@@ -280,7 +285,10 @@ def _acquire(
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         return
 
-    _pad_sentinel(handle)
+    if fcntl is None:
+        # Windows region locks need a byte to lock; pad once (sentinels are never unlinked,
+        # so this runs at most once in the file's life).
+        _pad_sentinel(handle)
     started = time.monotonic()
     deadline = None if deadline_ms is None else started + (max(0.0, deadline_ms) / 1000.0)
     next_notice_at = _WAIT_NOTICE_GRACE_S
@@ -293,7 +301,8 @@ def _acquire(
                 msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
             return
         except OSError as exc:
-            if exc.errno not in _BUSY_ERRNOS:
+            busy = _FCNTL_BUSY_ERRNOS if fcntl is not None else _MSVCRT_BUSY_ERRNOS
+            if exc.errno not in busy:
                 raise
         now = time.monotonic()
         if deadline is not None and now >= deadline:

--- a/tests/python/packages/cadgen/test_coordination_lock.py
+++ b/tests/python/packages/cadgen/test_coordination_lock.py
@@ -8,6 +8,7 @@ scheme passed unit tests while failing every one of these.
 
 from __future__ import annotations
 
+import errno
 import os
 import subprocess
 import sys
@@ -17,6 +18,7 @@ import threading
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from tests.python.support.paths import add_repo_path
 
@@ -24,6 +26,8 @@ add_repo_path("packages/cadgen/src")
 
 from cadgen.coordination.lock import exclusive  # noqa: E402
 from cadgen.coordination.paths import WRITE_LOCK_SUFFIX, write_lock_path  # noqa: E402
+
+import cadgen.coordination.lock as lock  # noqa: E402
 
 # Each child takes the lock, marks entry, holds briefly, marks exit, releases.
 # If mutual exclusion holds, the marks can never interleave.
@@ -273,6 +277,167 @@ class GenerationLockBehaviourTest(unittest.TestCase):
             self.assertEqual("S", enter, f"interleaved critical sections: {marks!r}")
             self.assertEqual("E", leave, f"interleaved critical sections: {marks!r}")
             self.assertEqual(tag, leave_tag, f"interleaved critical sections: {marks!r}")
+
+
+class _FakeMsvcrt:
+    """In-process stand-in for ``msvcrt.locking``: a 1-byte region lock keyed by file
+    identity (dev+inode), non-blocking acquire raising ``EACCES`` when another handle
+    holds the region -- the exact contract the Windows backend relies on."""
+
+    LK_NBLCK = 1
+    LK_UNLCK = 2
+    LK_LOCK = 3
+
+    def __init__(self) -> None:
+        self._held: set[tuple[int, int]] = set()
+
+    def locking(self, fd, mode, nbytes: int = 1) -> None:
+        info = os.fstat(fd)
+        key = (info.st_dev, info.st_ino)
+        if mode == self.LK_NBLCK:
+            if key in self._held:
+                raise OSError(errno.EACCES, "file being used by another process")
+            self._held.add(key)
+        elif mode == self.LK_UNLCK:
+            self._held.discard(key)
+        else:
+            raise AssertionError(f"unexpected msvcrt mode {mode}")
+
+
+class WindowsLockBackendTests(unittest.TestCase):
+    """The Windows backend is not importable here, so it is driven with a faithful fake:
+    ``fcntl=None`` + a fake ``msvcrt``. These pin the backend contract -- region locking,
+    no shared mode, empty-sentinel degradation, waiting semantics -- which is exactly what
+    the two production modules diverge on."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.lock_path = write_lock_path(self.root / "__cadgen__" / "models" / "part.step.py")
+        self._fcntl = mock.patch.object(lock, "fcntl", None)
+        self._msvcrt = mock.patch.object(lock, "msvcrt", _FakeMsvcrt())
+        self._fcntl.start()
+        self._msvcrt.start()
+        self.addCleanup(self._msvcrt.stop)
+        self.addCleanup(self._fcntl.stop)
+
+    def test_locking_available_with_windows_backend(self) -> None:
+        self.assertTrue(lock.locking_available())
+        # A missing sentinel means no run has ever held it: idle, not degraded.
+        self.assertEqual((False, False), lock.probe(self.lock_path))
+
+    def test_probe_reports_free_without_a_holder(self) -> None:
+        with exclusive(self.lock_path):
+            pass
+        result = lock.probe(self.lock_path)
+        self.assertEqual((False, False), result)
+
+    def test_probe_reports_held_while_a_peer_holds(self) -> None:
+        done = threading.Event()
+        release = threading.Event()
+
+        def hold():
+            with exclusive(self.lock_path):
+                done.set()
+                release.wait(10)
+
+        thread = threading.Thread(target=hold, daemon=True)
+        thread.start()
+        self.assertTrue(done.wait(10), "holder never acquired")
+        try:
+            result = lock.probe(self.lock_path)
+            self.assertEqual((True, False), result)
+        finally:
+            release.set()
+            thread.join(10)
+
+    def test_locking_past_eof_is_impossible_so_empty_sentinels_are_unknown(self) -> None:
+        # A 0-byte sentinel cannot carry a Windows region lock at all. It must read as
+        # degraded -- never held -- or a crash before stamping would wedge future builds.
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self.lock_path.write_bytes(b"")
+        result = lock.probe(self.lock_path)
+        self.assertEqual((False, True), result)
+
+    def test_run_id_is_still_stamped(self) -> None:
+        from cadgen.coordination.lock import read_run_id
+
+        with exclusive(self.lock_path) as run_id:
+            self.assertTrue(run_id)
+            self.assertEqual(run_id, read_run_id(self.lock_path))
+
+    def test_waiting_acquire_waits_for_the_peer(self) -> None:
+        release = threading.Event()
+        acquired_second = threading.Event()
+
+        def hold():
+            with exclusive(self.lock_path):
+                release.wait(10)
+
+        def wait_then_acquire():
+            with exclusive(self.lock_path):
+                acquired_second.set()
+
+        thread = threading.Thread(target=hold, daemon=True)
+        thread.start()
+        for _ in range(500):
+            if lock.probe(self.lock_path).held:
+                break
+            time.sleep(0.01)
+        second = threading.Thread(target=wait_then_acquire, daemon=True)
+        second.start()
+        time.sleep(0.1)
+        self.assertFalse(acquired_second.is_set(), "second acquirer did not wait for the peer")
+        release.set()
+        self.assertTrue(acquired_second.wait(10), "second acquirer never got the lock")
+        thread.join(10)
+        second.join(10)
+
+    def test_bounded_wait_raises_contended(self) -> None:
+        from cadgen.coordination.lock import Contended
+
+        done = threading.Event()
+        release = threading.Event()
+
+        def hold():
+            with exclusive(self.lock_path):
+                done.set()
+                release.wait(10)
+
+        thread = threading.Thread(target=hold, daemon=True)
+        thread.start()
+        self.assertTrue(done.wait(10))
+        try:
+            with self.assertRaises(Contended):
+                with exclusive(self.lock_path, deadline_ms=100):
+                    pass
+        finally:
+            release.set()
+            thread.join(10)
+
+
+class NoLockingBackendTests(unittest.TestCase):
+    """Neither backend available: coordination is a transparent no-op everywhere."""
+
+    def setUp(self) -> None:
+        self._fcntl = mock.patch.object(lock, "fcntl", None)
+        self._msvcrt = mock.patch.object(lock, "msvcrt", None)
+        self._fcntl.start()
+        self._msvcrt.start()
+        self.addCleanup(self._msvcrt.stop)
+        self.addCleanup(self._fcntl.stop)
+
+    def test_probe_is_degraded_not_held(self) -> None:
+        from cadgen.coordination.lock import ProbeResult
+
+        result = lock.probe("/nonexistent/.lock")
+        self.assertEqual(ProbeResult(held=False, degraded=True), result)
+
+    def test_locking_unavailable_and_exclusive_is_a_noop(self) -> None:
+        self.assertFalse(lock.locking_available())
+        with exclusive("/tmp/whatever.lock") as run_id:
+            self.assertIsNone(run_id)
 
 
 if __name__ == "__main__":

--- a/tests/python/skills/implicit-cad/test_schema_reference.py
+++ b/tests/python/skills/implicit-cad/test_schema_reference.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import unittest
+
+from tests.python.support.paths import repo_path
+
+SCHEMA_PATH_REFERENCE = "scripts/packages/implicitjs/src/lib/implicitCad/schema.js"
+HELPER_REEXPORT = "scripts/lib/implicit-cad.mjs"
+SCHEMA_MARKER = "implicit.js/0.1.0"
+
+
+class ImplicitCadSchemaReferenceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill_root = repo_path("skills", "implicit-cad")
+
+    def test_skill_md_names_the_schema_source_of_truth(self) -> None:
+        source = (self.skill_root / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn(SCHEMA_PATH_REFERENCE, source)
+
+    def test_schema_path_reference_resolves(self) -> None:
+        schema = self.skill_root / SCHEMA_PATH_REFERENCE
+        self.assertTrue(schema.is_file(), f"{SCHEMA_PATH_REFERENCE} must resolve to a file")
+        self.assertGreater(schema.read_text(encoding="utf-8").strip(), "")
+        self.assertIn(SCHEMA_MARKER, schema.read_text(encoding="utf-8"))
+
+    def test_skill_reexport_module_resolves(self) -> None:
+        helper = self.skill_root / HELPER_REEXPORT
+        self.assertTrue(helper.is_file(), f"{HELPER_REEXPORT} must resolve to a file")

--- a/tests/python/skills/implicit-cad/test_skill_structure.py
+++ b/tests/python/skills/implicit-cad/test_skill_structure.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unittest
+
+from tests.python.support.paths import repo_path
+
+EXPECTED_SCRIPT_ENTRIES = ("gen", "export.mjs", "snapshot", "lib/implicit-cad.mjs")
+
+
+class ImplicitCadSkillStructureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill_root = repo_path("skills", "implicit-cad")
+
+    def test_skill_md_exists_with_required_frontmatter(self) -> None:
+        source = (self.skill_root / "SKILL.md").read_text(encoding="utf-8")
+        head = source.split("---", 2)
+        self.assertEqual(3, len(head), "SKILL.md must open with YAML frontmatter")
+        self.assertIn("name: implicit-cad", head[1])
+        self.assertRegex(head[1], r"description:\s*\S", "description frontmatter must be non-empty")
+
+    def test_agents_openai_yaml_exists(self) -> None:
+        agent_file = self.skill_root / "agents" / "openai.yaml"
+        self.assertTrue(agent_file.is_file(), "agents/openai.yaml must exist")
+        self.assertGreater(agent_file.read_text(encoding="utf-8").strip(), "")
+
+    def test_expected_script_entry_points_exist(self) -> None:
+        for rel in EXPECTED_SCRIPT_ENTRIES:
+            with self.subTest(entry=rel):
+                self.assertTrue(
+                    (self.skill_root / "scripts" / rel).exists(),
+                    f"scripts/{rel} must exist",
+                )
+
+    def test_gen_package_is_runnable_as_a_module(self) -> None:
+        gen_dir = self.skill_root / "scripts" / "gen"
+        self.assertTrue((gen_dir / "__main__.py").is_file())
+        self.assertTrue((gen_dir / "cli.py").is_file())

--- a/tests/python/skills/sendcutsend/test_report_template.py
+++ b/tests/python/skills/sendcutsend/test_report_template.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import unittest
+
+from tests.python.support.paths import repo_path
+
+REQUIRED_SECTIONS = (
+    "Context",
+    "Sources Checked",
+    "Geometry Facts",
+    "Findings",
+    "Verdict",
+)
+
+
+class SendCutSendReportTemplateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.template = (
+            repo_path("skills", "sendcutsend", "references", "report-template.md")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        )
+
+    def test_template_has_a_document_title(self) -> None:
+        self.assertTrue(self.template[0].startswith("# "), "template must open with a title")
+
+    def test_required_sections_appear_in_order(self) -> None:
+        heading_lines = [line.strip() for line in self.template if line.strip().startswith("## ")]
+        self.assertGreaterEqual(len(heading_lines), len(REQUIRED_SECTIONS))
+        headings = [line[3:].strip() for line in heading_lines]
+        position = 0
+        for section in REQUIRED_SECTIONS:
+            with self.subTest(section=section):
+                self.assertIn(section, headings[position:], f"section {section!r} missing or out of order")
+                position = position + 1 + headings[position:].index(section)
+
+    def test_findings_table_has_the_standard_columns(self) -> None:
+        header = [line for line in self.template if line.strip().startswith("| Status | Check | Evidence |")]
+        self.assertEqual(1, len(header), "findings table must carry the standard header row")
+        self.assertIn("Rule source", header[0])
+        self.assertIn("Recommendation", header[0])

--- a/tests/python/skills/sendcutsend/test_skill_structure.py
+++ b/tests/python/skills/sendcutsend/test_skill_structure.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from tests.python.support.paths import repo_path
+
+
+class SendCutSendSkillStructureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill_root = repo_path("skills", "sendcutsend")
+
+    def test_skill_md_exists_with_required_frontmatter(self) -> None:
+        source = (self.skill_root / "SKILL.md").read_text(encoding="utf-8")
+        head = source.split("---", 2)
+        self.assertEqual(3, len(head), "SKILL.md must open with YAML frontmatter")
+        self.assertIn("name: sendcutsend", head[1])
+        self.assertRegex(head[1], r"description:\s*\S", "description frontmatter must be non-empty")
+
+    def test_agents_openai_yaml_exists(self) -> None:
+        agent_file = self.skill_root / "agents" / "openai.yaml"
+        self.assertTrue(agent_file.is_file(), "agents/openai.yaml must exist")
+        self.assertGreater(agent_file.read_text(encoding="utf-8").strip(), "")
+
+    def test_references_exist(self) -> None:
+        for rel in ("official-sources.md", "report-template.md"):
+            ref = self.skill_root / "references" / rel
+            with self.subTest(reference=rel):
+                self.assertTrue(ref.is_file(), f"references/{rel} must exist")
+                self.assertGreater(ref.read_text(encoding="utf-8").strip(), "")

--- a/tests/python/skills/step-parts/test_search_cli.py
+++ b/tests/python/skills/step-parts/test_search_cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+
+from tests.python.support.paths import repo_path
+
+
+class StepPartsSearchCliTests(unittest.TestCase):
+    """Smoke-test the search/download CLI without touching the network."""
+
+    def test_help_exits_zero_and_documents_network_flags(self) -> None:
+        script = repo_path("skills", "step-parts", "scripts", "download_step_part.py")
+        proc = subprocess.run(
+            [sys.executable, str(script), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(0, proc.returncode, proc.stderr)
+        self.assertIn("usage:", proc.stdout)
+        for flag in ("--origin", "--download", "--out-dir", "--limit"):
+            with self.subTest(flag=flag):
+                self.assertIn(flag, proc.stdout)
+
+    def test_invalid_flag_exits_nonzero(self) -> None:
+        script = repo_path("skills", "step-parts", "scripts", "download_step_part.py")
+        proc = subprocess.run(
+            [sys.executable, str(script), "--definitely-not-a-flag"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertNotEqual(0, proc.returncode)

--- a/tests/python/skills/step-parts/test_skill_structure.py
+++ b/tests/python/skills/step-parts/test_skill_structure.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from tests.python.support.paths import repo_path
+
+
+class StepPartsSkillStructureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill_root = repo_path("skills", "step-parts")
+
+    def test_skill_md_exists_with_required_frontmatter(self) -> None:
+        source = (self.skill_root / "SKILL.md").read_text(encoding="utf-8")
+        head = source.split("---", 2)
+        self.assertEqual(3, len(head), "SKILL.md must open with YAML frontmatter")
+        self.assertIn("name: step-parts", head[1])
+        self.assertRegex(head[1], r"description:\s*\S", "description frontmatter must be non-empty")
+
+    def test_agents_openai_yaml_exists(self) -> None:
+        agent_file = self.skill_root / "agents" / "openai.yaml"
+        self.assertTrue(agent_file.is_file(), "agents/openai.yaml must exist")
+        self.assertGreater(agent_file.read_text(encoding="utf-8").strip(), "")
+
+    def test_reference_and_cli_script_exist(self) -> None:
+        self.assertTrue((self.skill_root / "references" / "step-parts-api.md").is_file())
+        script = self.skill_root / "scripts" / "download_step_part.py"
+        self.assertTrue(script.is_file(), "scripts/download_step_part.py must exist")
+
+    def test_cli_script_stays_stdlib_only(self) -> None:
+        script = self.skill_root / "scripts" / "download_step_part.py"
+        source = script.read_text(encoding="utf-8")
+        imports = []
+        for line in source.splitlines():
+            line = line.strip()
+            if line.startswith("import "):
+                imports.append(line[len("import ") :].split(".")[0].split()[0])
+            elif line.startswith("from "):
+                imports.append(line[len("from ") :].split(".")[0].split()[0])
+        self.assertEqual([], sorted(set(imports) - _STDLIB))
+        self.assertTrue(source.lstrip().startswith("#!/usr/bin/env python3"))
+
+
+_STDLIB = {
+    "__future__",
+    "argparse",
+    "hashlib",
+    "json",
+    "pathlib",
+    "sys",
+    "tempfile",
+    "typing",
+    "urllib",
+}


### PR DESCRIPTION
## Why

The generation lock wraps `fcntl.flock` and degrades to a complete no-op where `fcntl` doesn't exist — i.e. Windows. Two concurrent viewer builds there would race the same render package with no coordination at all.

## What changed

`packages/cadgen/src/cadgen/coordination/lock.py` gains a `msvcrt` byte-range backend alongside `fcntl` (both imported behind `ImportError` guards, so the kernel-owned close-releases contract is identical):

- `locking_available()` and every gate now accept either backend; with neither, behavior stays the documented all-degraded no-op
- `probe()`: on Windows takes a 1-byte **exclusive** region lock (`msvcrt` has no shared mode); an **empty sentinel reads as degraded, never held** — lock-past-EOF is an error on Windows, and a crash between `open()` and stamping must not wedge every later build forever
- `_acquire()`: Windows never uses `LK_LOCK` (its ten 1-second retries would raise on a genuinely long wait) — it polls `LK_NBLCK` so the existing deadline and wait-notice semantics work unchanged on both backends
- `_pad_sentinel()`: makes a fresh 0-byte sentinel lockable at all
- Module + `ProbeResult` docstrings updated; the two documented Windows tradeoffs (exclusive probes can false-positive "held"; position-based region locking) are called out

Note: the scan plan described a simple 40-line `lock.py`; the real module is the evolved coordination lock (probe states, bounded waits, re-entrancy, run-id stamping), so the fallback was designed against that, preserving every documented contract.

## Verification

- 9 new tests driving the Windows backend through a faithful fake (`fcntl=None` + fake `msvcrt` keyed by file identity): free/held/empty-sentinel probes, run-id stamping, real waiting acquire, bounded `Contended`, and the fully degraded no-backend state
- 52 coordination tests pass (POSIX path untouched: real 4-process contention, SIGKILLed holder, thread serialization all green)
- `scripts/test/test-python.sh` full suite + `bundle.sh --check` green