### PR TITLE
release: stop a symlinked mirror reverting the version stamp

### DIFF
--- a/scripts/release/sync-version.mjs
+++ b/scripts/release/sync-version.mjs
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, realpathSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "../..");
 const canonicalVersionPath = "VERSION";
 const semverPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
-const jsonTargets = [
+export const jsonTargets = [
   { path: "docs/package.json", fields: [["version"]] },
   { path: "docs/package-lock.json", fields: [["version"], ["packages", "", "version"]] },
   { path: "packages/cadjs/package.json", fields: [["version"]] },
@@ -34,11 +34,15 @@ const jsonTargets = [
   { path: ".codex-plugin/plugin.json", fields: [["version"]] },
   { path: ".claude-plugin/marketplace.json", fields: [["version"]], pluginEntries: ["cad"] },
   { path: "viewer/packages/cadjs/package.json", fields: [["version"]], required: false },
-  { path: "viewer/packages/cadjs/package-lock.json", fields: [["version"], ["packages", "", "version"]], required: false },
+  {
+    path: "viewer/packages/cadjs/package-lock.json",
+    fields: [["version"], ["packages", "", "version"], ["packages", "../implicitjs", "version"]],
+    required: false,
+  },
   { path: "skills/cad-viewer/scripts/viewer/packages/cadjs/package.json", fields: [["version"]], required: false },
   {
     path: "skills/cad-viewer/scripts/viewer/packages/cadjs/package-lock.json",
-    fields: [["version"], ["packages", "", "version"]],
+    fields: [["version"], ["packages", "", "version"], ["packages", "../implicitjs", "version"]],
     required: false,
   },
   { path: "viewer/packages/implicitjs/package.json", fields: [["version"]], required: false },
@@ -224,12 +228,57 @@ function syncTomlTarget(relativePath, version) {
   };
 }
 
+/** Merge targets that are the SAME FILE into one, unioning their fields.
+ *
+ * The mirrored viewer/skill paths are symlinks to the canonical package in the development
+ * layout, so several targets can name one file. Every target reads that file BEFORE any write
+ * happens, so two of them stamping it means the last write wins -- and when the mirror declares
+ * FEWER fields than the canonical target, the field only the canonical one knows about is
+ * silently reverted. That is how the 0.4.10 release gate came to reject its own bump:
+ * `packages/cadjs/package-lock.json` was stamped with the implicitjs version and then
+ * overwritten through its own symlink, which did not carry that field.
+ */
+export function mergeTargetsByRealPath(targets) {
+  const merged = [];
+  const byRealPath = new Map();
+  const sameField = (a, b) => a.length === b.length && a.every((part, index) => part === b[index]);
+  for (const target of targets) {
+    let key = target.path;
+    try {
+      key = realpathSync(repoPath(target.path));
+    } catch {
+      // Absent: an optional mirror in a layout that does not have it. Keep it distinct and let
+      // syncJsonTarget apply its own required/optional policy.
+    }
+    const existing = byRealPath.get(key);
+    if (!existing) {
+      const copy = { ...target, fields: target.fields.map((field) => [...field]) };
+      byRealPath.set(key, copy);
+      merged.push(copy);
+      continue;
+    }
+    for (const field of target.fields) {
+      if (!existing.fields.some((known) => sameField(known, field))) {
+        existing.fields.push([...field]);
+      }
+    }
+    if (target.pluginEntries?.length) {
+      existing.pluginEntries = [...new Set([...(existing.pluginEntries ?? []), ...target.pluginEntries])];
+    }
+    // One required target makes the file required, however optional its mirrors are.
+    if (target.required !== false) {
+      existing.required = true;
+    }
+  }
+  return merged;
+}
+
 function main() {
   const options = parseArgs(process.argv.slice(2));
   const version = canonicalVersion();
   const changes = [];
 
-  for (const target of jsonTargets) {
+  for (const target of mergeTargetsByRealPath(jsonTargets)) {
     const change = syncJsonTarget(target, version);
     if (change) {
       changes.push(change);
@@ -267,9 +316,11 @@ function main() {
   }
 }
 
-try {
-  main();
-} catch (error) {
-  console.error(`error: ${error.message}`);
-  process.exit(1);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`error: ${error.message}`);
+    process.exit(1);
+  }
 }

--- a/tests/python/global/test_release_version_sync.py
+++ b/tests/python/global/test_release_version_sync.py
@@ -1,0 +1,103 @@
+"""The release version stamp has to survive the development symlink layout.
+
+`scripts/release/sync-version.mjs` names several paths that are the SAME FILE here: the
+mirrored `viewer/packages/...` and `skills/.../packages/...` entries are symlinks to the
+canonical package. Each target reads its file before any write happens, so two targets
+stamping one file means the last write wins -- and a mirror declaring fewer fields than the
+canonical target silently reverts the field only the canonical one knows about.
+
+That is not hypothetical: adding the implicitjs version to `packages/cadjs/package-lock.json`
+without adding it to that file's two symlinked mirrors made the 0.4.10 release fail its own
+version gate, after the bump and before anything was published.
+"""
+
+from __future__ import annotations
+
+import json
+
+import subprocess
+import unittest
+from pathlib import Path
+
+from tests.python.support.paths import repo_path
+
+SYNC_SCRIPT = repo_path("scripts", "release", "sync-version.mjs")
+
+
+def _node(script: str, cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd else None,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"node failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+class VersionSyncMirrorTests(unittest.TestCase):
+    def test_targets_naming_one_file_are_merged_into_one_write(self) -> None:
+        """Two targets on the same real file become one target holding both field sets."""
+        if not repo_path("viewer", "packages", "cadjs").is_symlink():
+            self.skipTest("not in the development symlink layout")
+        # The script resolves target paths against the repo root, so the pair below has to be
+        # real repo paths: the canonical lockfile and the mirror that symlinks to it.
+        script = (
+            "const { mergeTargetsByRealPath } = await import(%s);\n"
+            "const merged = mergeTargetsByRealPath([\n"
+            '  { path: "packages/cadjs/package-lock.json",'
+            ' fields: [["version"], ["packages", "../implicitjs", "version"]] },\n'
+            '  { path: "viewer/packages/cadjs/package-lock.json", fields: [["version"]], required: false },\n'
+            "]);\n"
+            "console.log(JSON.stringify({ count: merged.length, fields: merged[0].fields,"
+            " treatedAsRequired: merged[0].required !== false }));"
+            % json.dumps(SYNC_SCRIPT.as_uri())
+        )
+        payload = json.loads(_node(script))
+        self.assertEqual(1, payload["count"], "a symlinked mirror must not get its own write")
+        self.assertIn(
+            ["packages", "../implicitjs", "version"],
+            payload["fields"],
+            "the merged target must keep the field only the canonical target declared",
+        )
+        self.assertTrue(payload["treatedAsRequired"], "a required target keeps the file required")
+
+    def test_every_cadjs_lockfile_target_stamps_the_implicitjs_version(self) -> None:
+        """The field that broke 0.4.10, asserted across every copy of that lockfile.
+
+        cadjs's lockfile embeds implicitjs as a linked workspace package, so every target
+        naming a `cadjs/package-lock.json` has to stamp it -- including the vendored copies
+        that ship inside skills, which are real files rather than symlinks.
+        """
+        targets = json.loads(
+            _node(
+                "const { jsonTargets } = await import(%s);\n"
+                "console.log(JSON.stringify(jsonTargets));" % json.dumps(SYNC_SCRIPT.as_uri())
+            )
+        )
+        lockfiles = [t for t in targets if t["path"].endswith("cadjs/package-lock.json")]
+        self.assertGreaterEqual(len(lockfiles), 2, "expected the canonical lockfile and its mirrors")
+        for target in lockfiles:
+            with self.subTest(path=target["path"]):
+                self.assertIn(
+                    ["packages", "../implicitjs", "version"],
+                    target["fields"],
+                    f"{target['path']} would ship a stale implicitjs version",
+                )
+
+    def test_derived_metadata_is_synced_at_the_current_version(self) -> None:
+        """The gate the Release workflow runs, at the version in VERSION."""
+        result = subprocess.run(
+            ["node", str(SYNC_SCRIPT), "--check"],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_path()),
+            timeout=120,
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The 0.4.10 release failed its own gate, after the bump and before anything was published:

```
Derived version metadata is stale for 0.4.10:
- packages/cadjs/package-lock.json (packages.../implicitjs.version)
```

#254 added the implicitjs version to that lockfile's target, and to the vendored copies that ship inside skills. What it could not know is that two of those "copies" are **the same file** here — `viewer/packages/cadjs` and `skills/cad-viewer/scripts/viewer/packages/cadjs` are symlinks to `packages/cadjs` in the development layout. Every target reads its file before any write happens, so the canonical target stamped all three fields, and then the mirror — declaring only two — wrote back the text it had read earlier and reverted the third.

That is my miss on the review: I checked #254's target list mirrored the cadjs pattern and that nothing pinned `0.1.0`, but I never ran a bump end to end, which is the only thing that shows this.

## Two changes, because either alone leaves a trap

- the mirrored cadjs lockfile targets declare the implicitjs field too — the vendored copy that really does ship inside `skills/cad-viewer` carries `0.1.0` on `main` today;
- targets resolving to one real file are merged into a single write holding the **union** of their fields, so the next field added to a canonical target cannot be silently reverted by a mirror nobody updated in step.

## Verification

Reproduced the gate locally: bump `VERSION` to 0.4.10, run the sync, and `--check` comes back clean with the lockfile's implicitjs record at 0.4.10. `VERSION` itself is untouched — the Release workflow owns that.

Three tests in `tests/python/global/test_release_version_sync.py` pin the merge, the field across every copy of that lockfile, and the gate itself. Reverting the field additions fails the suite by name on both mirrors:

```
AssertionError: ['packages', '../implicitjs', 'version'] not found in [['version'], ['packages', '', 'version']]
  : viewer/packages/cadjs/package-lock.json would ship a stale implicitjs version
```

Global suite 79, `bundle.sh --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
