### PR TITLE
viewer: draw a dimensioned drawing instead of waiting for a mesh

### DIFF
--- a/models/drawings/dxf/cabinet_panel_drawing.dxf.py
+++ b/models/drawings/dxf/cabinet_panel_drawing.dxf.py
@@ -1,0 +1,163 @@
+# Prompt: A workshop DRAWING, not a cut layout -- the case from issue #246. A cabinetmaker's
+# panel drawn as a document: plan view, front elevation, a section, 20 dimensions, centre lines,
+# hidden edges and a title block.
+#
+# Nothing here is a toolpath, and that is the point. Every construct that makes a DXF a drawing
+# rather than a laser file is present, because those are what `cadgen.drawing_checks` reads to
+# decide which rules apply:
+#
+#   DIMENSION entities        the drawing's measurements
+#   ISO 128 linetypes         CENTER for axes, HIDDEN for edges behind the face
+#   a non-plotting layer      construction lines, which never reach paper
+#   a title block layer       annotation, not geometry
+#
+# So a validator must NOT demand closed cut profiles here, and the Viewer must render it as
+# lines rather than extruding a 3D prism out of contours that enclose nothing.
+
+from __future__ import annotations
+
+import ezdxf
+from ezdxf.units import MM
+
+PANEL_WIDTH_MM = 600.0
+PANEL_HEIGHT_MM = 400.0
+PANEL_THICKNESS_MM = 18.0
+
+SHELF_HEIGHT_MM = 220.0
+DOWEL_DIAMETER_MM = 8.0
+DOWEL_INSET_MM = 50.0
+
+ELEVATION_ORIGIN = (0.0, 0.0)
+PLAN_ORIGIN = (0.0, -160.0)
+SECTION_ORIGIN = (700.0, 0.0)
+
+
+def _rectangle(msp, origin, width, height, layer):
+    x, y = origin
+    msp.add_lwpolyline(
+        [(x, y), (x + width, y), (x + width, y + height), (x, y + height)],
+        close=True,
+        dxfattribs={"layer": layer},
+    )
+
+
+def gen_dxf():
+    document = ezdxf.new("R2010", setup=True)
+    document.units = MM
+    msp = document.modelspace()
+
+    for name, attribs in (
+        ("OUTLINE", {}),
+        ("HIDDEN-EDGES", {"linetype": "HIDDEN"}),
+        ("CENTRELINES", {"linetype": "CENTER"}),
+        ("CONSTRUCTION", {"plot": 0}),
+        ("DIMENSIONS", {}),
+        ("TITLEBLOCK", {}),
+    ):
+        document.layers.add(name, **attribs)
+
+    # --- front elevation -------------------------------------------------------------
+    _rectangle(msp, ELEVATION_ORIGIN, PANEL_WIDTH_MM, PANEL_HEIGHT_MM, "OUTLINE")
+    # the shelf behind the face: hidden, because you cannot see it from the front
+    msp.add_line(
+        (ELEVATION_ORIGIN[0], ELEVATION_ORIGIN[1] + SHELF_HEIGHT_MM),
+        (ELEVATION_ORIGIN[0] + PANEL_WIDTH_MM, ELEVATION_ORIGIN[1] + SHELF_HEIGHT_MM),
+        dxfattribs={"layer": "HIDDEN-EDGES"},
+    )
+    # vertical centre line, running past the outline as a centre line does
+    msp.add_line(
+        (ELEVATION_ORIGIN[0] + (PANEL_WIDTH_MM / 2), ELEVATION_ORIGIN[1] - 25),
+        (ELEVATION_ORIGIN[0] + (PANEL_WIDTH_MM / 2), ELEVATION_ORIGIN[1] + PANEL_HEIGHT_MM + 25),
+        dxfattribs={"layer": "CENTRELINES"},
+    )
+    for x in (DOWEL_INSET_MM, PANEL_WIDTH_MM - DOWEL_INSET_MM):
+        msp.add_circle(
+            (ELEVATION_ORIGIN[0] + x, ELEVATION_ORIGIN[1] + SHELF_HEIGHT_MM),
+            radius=DOWEL_DIAMETER_MM / 2,
+            dxfattribs={"layer": "HIDDEN-EDGES"},
+        )
+
+    # --- plan view, projected below the elevation -----------------------------------
+    _rectangle(msp, PLAN_ORIGIN, PANEL_WIDTH_MM, PANEL_THICKNESS_MM * 4, "OUTLINE")
+    # projection lines tying the plan to the elevation: construction, never plotted
+    for x in (0.0, PANEL_WIDTH_MM):
+        msp.add_line(
+            (PLAN_ORIGIN[0] + x, PLAN_ORIGIN[1] + (PANEL_THICKNESS_MM * 4)),
+            (ELEVATION_ORIGIN[0] + x, ELEVATION_ORIGIN[1]),
+            dxfattribs={"layer": "CONSTRUCTION"},
+        )
+
+    # --- section A-A, off to the right ----------------------------------------------
+    _rectangle(msp, SECTION_ORIGIN, PANEL_THICKNESS_MM, PANEL_HEIGHT_MM, "OUTLINE")
+    msp.add_line(
+        (SECTION_ORIGIN[0], SECTION_ORIGIN[1] + SHELF_HEIGHT_MM),
+        (SECTION_ORIGIN[0] + PANEL_THICKNESS_MM, SECTION_ORIGIN[1] + SHELF_HEIGHT_MM),
+        dxfattribs={"layer": "OUTLINE"},
+    )
+
+    # --- dimensions ------------------------------------------------------------------
+    # A drawing's defining feature. Twenty of them, on the layer the checks read as annotation.
+    dim_style = {"layer": "DIMENSIONS"}
+    horizontal = [
+        ((0.0, 0.0), (PANEL_WIDTH_MM, 0.0), -60.0),
+        ((0.0, 0.0), (DOWEL_INSET_MM, 0.0), -95.0),
+        ((PANEL_WIDTH_MM - DOWEL_INSET_MM, 0.0), (PANEL_WIDTH_MM, 0.0), -95.0),
+        ((DOWEL_INSET_MM, 0.0), (PANEL_WIDTH_MM - DOWEL_INSET_MM, 0.0), -130.0),
+    ]
+    for start, end, distance in horizontal:
+        msp.add_linear_dim(base=(0, distance), p1=start, p2=end, dxfattribs=dim_style).render()
+
+    vertical = [
+        ((0.0, 0.0), (0.0, PANEL_HEIGHT_MM), -70.0),
+        ((0.0, 0.0), (0.0, SHELF_HEIGHT_MM), -115.0),
+        ((0.0, SHELF_HEIGHT_MM), (0.0, PANEL_HEIGHT_MM), -115.0),
+    ]
+    for start, end, distance in vertical:
+        msp.add_linear_dim(
+            base=(distance, 0), p1=start, p2=end, angle=90, dxfattribs=dim_style
+        ).render()
+
+    # section thickness and shelf height, dimensioned on the section
+    msp.add_linear_dim(
+        base=(SECTION_ORIGIN[0], SECTION_ORIGIN[1] - 60),
+        p1=(SECTION_ORIGIN[0], SECTION_ORIGIN[1]),
+        p2=(SECTION_ORIGIN[0] + PANEL_THICKNESS_MM, SECTION_ORIGIN[1]),
+        dxfattribs=dim_style,
+    ).render()
+    msp.add_linear_dim(
+        base=(SECTION_ORIGIN[0] + 90, SECTION_ORIGIN[1]),
+        p1=(SECTION_ORIGIN[0] + PANEL_THICKNESS_MM, SECTION_ORIGIN[1]),
+        p2=(SECTION_ORIGIN[0] + PANEL_THICKNESS_MM, SECTION_ORIGIN[1] + SHELF_HEIGHT_MM),
+        angle=90,
+        dxfattribs=dim_style,
+    ).render()
+
+    # radial dimensions on the dowel holes
+    for x in (DOWEL_INSET_MM, PANEL_WIDTH_MM - DOWEL_INSET_MM):
+        msp.add_diameter_dim(
+            center=(x, SHELF_HEIGHT_MM),
+            radius=DOWEL_DIAMETER_MM / 2,
+            angle=45,
+            dxfattribs=dim_style,
+        ).render()
+
+    # --- title block -----------------------------------------------------------------
+    title_origin = (0.0, -260.0)
+    _rectangle(msp, title_origin, 420.0, 70.0, "TITLEBLOCK")
+    msp.add_line(
+        (title_origin[0], title_origin[1] + 35),
+        (title_origin[0] + 420, title_origin[1] + 35),
+        dxfattribs={"layer": "TITLEBLOCK"},
+    )
+    for text, position in (
+        ("CABINET SIDE PANEL", (8.0, -222.0)),
+        ("SCALE 1:5   MATERIAL 18mm BIRCH PLY", (8.0, -252.0)),
+        ("SECTION A-A", (SECTION_ORIGIN[0] - 10, SECTION_ORIGIN[1] - 100)),
+    ):
+        msp.add_text(text, height=12, dxfattribs={"layer": "TITLEBLOCK"}).set_placement(position)
+
+    return {"document": document}
+
+
+if __name__ == "__main__":
+    gen_dxf()

--- a/packages/cadgen/src/cadgen/drawing_checks.py
+++ b/packages/cadgen/src/cadgen/drawing_checks.py
@@ -140,7 +140,7 @@ def layer_table_intents(document: object) -> dict[str, str]:
     intents: dict[str, str] = {}
     try:
         layers = list(document.layers)
-    except Exception:
+    except Exception:  # noqa: BLE001 - a document with no readable layer table simply declares no intents
         return intents
     for layer in layers:
         name = str(getattr(getattr(layer, "dxf", None), "name", "") or "").strip()
@@ -167,14 +167,14 @@ def drawing_apparatus(document: object) -> dict[str, int]:
                 counts["dimensions"] += 1
             elif kind == "VIEWPORT":
                 counts["viewports"] += 1
-    except Exception:
+    except Exception:  # noqa: BLE001 - ezdxf entity reads can raise per entity; a partial count still classifies
         pass
     try:
         for layout in document.layouts:
             if layout.name.lower() == "model":
                 continue
             counts["paperspace_entities"] += sum(1 for _ in layout)
-    except Exception:
+    except Exception:  # noqa: BLE001 - same, for layouts: an unreadable layout contributes nothing
         pass
     return counts
 

--- a/packages/cadjs/src/lib/dxf/buildDrawingLines.js
+++ b/packages/cadjs/src/lib/dxf/buildDrawingLines.js
@@ -1,0 +1,142 @@
+/** A dimensioned DRAWING rendered as what it is: lines.
+ *
+ * A cut layout has closed contours, so the viewer extrudes them into a flat pattern and renders
+ * a solid. A drawing has no such thing -- plan views, sections, centre lines, dimensions and a
+ * title block enclose nothing, and extruding them produces either nothing or nonsense. Issue
+ * #246 is the case: a cabinetmaker's panel drawing, 20 dimensions, not one toolpath.
+ *
+ * So a drawing is drawn. Every entity becomes line segments in the sheet plane, grouped by
+ * layer so the viewer can colour them from the layer table and hide them with the same layer
+ * switches a cut layout uses. Nothing here bakes, and nothing needs a generated artifact: the
+ * package's `geometry.json` already holds the parsed contours.
+ */
+
+const DEFAULT_ARC_SEGMENTS = 48;
+const MIN_ARC_SEGMENTS = 8;
+
+function normalizeLayerName(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function pushSegment(target, ax, ay, bx, by, elevation) {
+  // The sheet lies in the mesher's XZ plane (y is out of the sheet), matching the flat-pattern
+  // mesh, so a drawing and a cut layout share one camera fit and one orientation control.
+  target.push(ax, elevation, ay, bx, elevation, by);
+}
+
+/** How finely to sample an arc: enough segments that the chord error stays under a fraction of
+ * the radius, clamped so a tiny fillet does not cost 48 segments. */
+function arcSegmentCount(sweepRadians, requested) {
+  const full = Math.max(MIN_ARC_SEGMENTS, requested);
+  const fraction = Math.min(1, Math.abs(sweepRadians) / (Math.PI * 2));
+  return Math.max(MIN_ARC_SEGMENTS, Math.ceil(full * fraction));
+}
+
+function sampleArc(target, arc, elevation, requested) {
+  const [cx, cy] = arc.center || [0, 0];
+  const radius = Number(arc.radius);
+  if (!Number.isFinite(radius) || radius <= 0) {
+    return;
+  }
+  const start = Number(arc.startAngle ?? arc.start_angle ?? 0);
+  const end = Number(arc.endAngle ?? arc.end_angle ?? 0);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    return;
+  }
+  // Angles arrive in degrees, counter-clockwise, as DXF stores them.
+  const startRadians = (start * Math.PI) / 180;
+  let sweep = ((end - start) * Math.PI) / 180;
+  if (sweep <= 0) {
+    sweep += Math.PI * 2;
+  }
+  const steps = arcSegmentCount(sweep, requested);
+  let previous = null;
+  for (let index = 0; index <= steps; index += 1) {
+    const angle = startRadians + (sweep * (index / steps));
+    const point = [cx + (radius * Math.cos(angle)), cy + (radius * Math.sin(angle))];
+    if (previous) {
+      pushSegment(target, previous[0], previous[1], point[0], point[1], elevation);
+    }
+    previous = point;
+  }
+}
+
+function sampleCircle(target, circle, elevation, requested) {
+  sampleArc(
+    target,
+    { center: circle.center, radius: circle.radius, startAngle: 0, endAngle: 360 },
+    elevation,
+    requested
+  );
+}
+
+/** Line segments for one drawing, grouped by layer.
+ *
+ * Returns `{ layers: [{ name, positions }] }` with `positions` a flat Float32Array of xyz pairs,
+ * ready for a `LineSegments` per layer. Grouping by layer rather than emitting one buffer is what
+ * lets the viewer colour and hide layers without re-sampling the drawing.
+ */
+export function buildDxfDrawingLineGroups(dxfData, options = null) {
+  const geometry = dxfData?.geometry;
+  const elevation = Number(options?.elevation) || 0;
+  const requested = Number(options?.arcSegments) || DEFAULT_ARC_SEGMENTS;
+  const byLayer = new Map();
+  const bucket = (layer) => {
+    const name = normalizeLayerName(layer);
+    if (!byLayer.has(name)) {
+      byLayer.set(name, []);
+    }
+    return byLayer.get(name);
+  };
+  if (!geometry || typeof geometry !== "object") {
+    return { layers: [] };
+  }
+  for (const line of Array.isArray(geometry.lines) ? geometry.lines : []) {
+    const start = line?.start;
+    const end = line?.end;
+    if (!Array.isArray(start) || !Array.isArray(end)) {
+      continue;
+    }
+    pushSegment(bucket(line.layer), start[0], start[1], end[0], end[1], elevation);
+  }
+  for (const arc of Array.isArray(geometry.arcs) ? geometry.arcs : []) {
+    sampleArc(bucket(arc?.layer), arc, elevation, requested);
+  }
+  for (const circle of Array.isArray(geometry.circles) ? geometry.circles : []) {
+    sampleCircle(bucket(circle?.layer), circle, elevation, requested);
+  }
+  const layers = [];
+  for (const [name, values] of byLayer) {
+    if (!values.length) {
+      continue;
+    }
+    layers.push({ name, positions: new Float32Array(values) });
+  }
+  return { layers };
+}
+
+/** Does this drawing hold anything a 2D render can show? */
+export function drawingHasRenderableGeometry(dxfData) {
+  return buildDxfDrawingLineGroups(dxfData).layers.length > 0;
+}
+
+/** The drawing's extent in the sheet plane, for fitting a camera to a document that has no mesh. */
+export function drawingLineBounds(groups) {
+  const min = [Infinity, Infinity, Infinity];
+  const max = [-Infinity, -Infinity, -Infinity];
+  for (const layer of groups?.layers || []) {
+    const { positions } = layer;
+    for (let index = 0; index < positions.length; index += 3) {
+      for (let axis = 0; axis < 3; axis += 1) {
+        const value = positions[index + axis];
+        if (value < min[axis]) {
+          min[axis] = value;
+        }
+        if (value > max[axis]) {
+          max[axis] = value;
+        }
+      }
+    }
+  }
+  return Number.isFinite(min[0]) ? { min, max } : null;
+}

--- a/packages/cadjs/src/lib/dxf/buildDrawingLines.test.js
+++ b/packages/cadjs/src/lib/dxf/buildDrawingLines.test.js
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildDxfDrawingLineGroups,
+  drawingHasRenderableGeometry,
+  drawingLineBounds
+} from "./buildDrawingLines.js";
+
+const DRAWING = {
+  geometry: {
+    lines: [
+      { layer: "OUTLINE", kind: "cut", start: [0, 0], end: [600, 0] },
+      { layer: "OUTLINE", kind: "cut", start: [600, 0], end: [600, 400] },
+      { layer: "CENTRELINES", kind: "reference", start: [300, -25], end: [300, 425] }
+    ],
+    circles: [{ layer: "HIDDEN-EDGES", kind: "reference", center: [50, 220], radius: 4 }],
+    arcs: [{ layer: "OUTLINE", center: [0, 0], radius: 10, startAngle: 0, endAngle: 90 }],
+    texts: [{ layer: "TITLEBLOCK", text: "CABINET SIDE PANEL", position: [8, -222] }]
+  }
+};
+
+test("a drawing's entities become line segments grouped by layer", () => {
+  const { layers } = buildDxfDrawingLineGroups(DRAWING);
+  const names = layers.map((layer) => layer.name).sort();
+  assert.deepEqual(names, ["CENTRELINES", "HIDDEN-EDGES", "OUTLINE"]);
+  // Grouping is what lets the viewer colour and hide layers without re-sampling.
+  const outline = layers.find((layer) => layer.name === "OUTLINE");
+  assert.ok(outline.positions instanceof Float32Array);
+  // Two straight lines plus a sampled quarter arc, all as xyz PAIRS.
+  assert.equal(outline.positions.length % 6, 0);
+  assert.ok(outline.positions.length / 6 > 2, "the arc must contribute segments");
+});
+
+test("the sheet lies in the same plane as a flat pattern's mesh", () => {
+  // y is out of the sheet, so a drawing and a cut layout share one camera fit.
+  const { layers } = buildDxfDrawingLineGroups(DRAWING, { elevation: 0 });
+  for (const layer of layers) {
+    for (let index = 1; index < layer.positions.length; index += 3) {
+      assert.equal(layer.positions[index], 0);
+    }
+  }
+  const raised = buildDxfDrawingLineGroups(DRAWING, { elevation: 2.5 });
+  assert.equal(raised.layers[0].positions[1], 2.5);
+});
+
+test("a line's endpoints survive unchanged", () => {
+  const { layers } = buildDxfDrawingLineGroups({
+    geometry: { lines: [{ layer: "A", start: [1, 2], end: [3, 4] }] }
+  });
+  assert.deepEqual([...layers[0].positions], [1, 0, 2, 3, 0, 4]);
+});
+
+test("a full circle closes", () => {
+  const { layers } = buildDxfDrawingLineGroups({
+    geometry: { circles: [{ layer: "H", center: [10, 10], radius: 5 }] }
+  });
+  const positions = layers[0].positions;
+  const first = [positions[0], positions[2]];
+  const last = [positions[positions.length - 3], positions[positions.length - 1]];
+  assert.ok(Math.hypot(first[0] - last[0], first[1] - last[1]) < 1e-6, "circle must close");
+  // Every sampled point sits on the circle.
+  for (let index = 0; index < positions.length; index += 3) {
+    const distance = Math.hypot(positions[index] - 10, positions[index + 2] - 10);
+    assert.ok(Math.abs(distance - 5) < 1e-6, `point off the circle: ${distance}`);
+  }
+});
+
+test("an arc sweeps the short way round, not the long way", () => {
+  // 350 -> 10 degrees is a 20 degree sweep across zero, not 340 degrees back.
+  const { layers } = buildDxfDrawingLineGroups({
+    geometry: { arcs: [{ layer: "A", center: [0, 0], radius: 1, startAngle: 350, endAngle: 10 }] }
+  });
+  const positions = layers[0].positions;
+  const angles = [];
+  for (let index = 0; index < positions.length; index += 3) {
+    angles.push((Math.atan2(positions[index + 2], positions[index]) * 180) / Math.PI);
+  }
+  for (const angle of angles) {
+    const normalized = angle < 0 ? angle + 360 : angle;
+    assert.ok(normalized >= 349.9 || normalized <= 10.1, `angle ${normalized} is off the arc`);
+  }
+});
+
+test("degenerate entities are skipped rather than emitted as NaN", () => {
+  const { layers } = buildDxfDrawingLineGroups({
+    geometry: {
+      lines: [{ layer: "A", start: [0, 0] }, { layer: "A", start: [0, 0], end: [1, 1] }],
+      circles: [{ layer: "A", center: [0, 0], radius: 0 }, { layer: "A", center: [0, 0] }],
+      arcs: [{ layer: "A", center: [0, 0], radius: 5, startAngle: "x", endAngle: 10 }]
+    }
+  });
+  assert.equal(layers.length, 1);
+  for (const value of layers[0].positions) {
+    assert.ok(Number.isFinite(value), "no NaN may reach a buffer");
+  }
+  assert.deepEqual([...layers[0].positions], [0, 0, 0, 1, 0, 1]);
+});
+
+test("a drawing with nothing drawable says so, instead of rendering an empty scene", () => {
+  assert.equal(drawingHasRenderableGeometry(DRAWING), true);
+  assert.equal(drawingHasRenderableGeometry({ geometry: { texts: [{ text: "only text" }] } }), false);
+  assert.equal(drawingHasRenderableGeometry(null), false);
+});
+
+test("bounds cover the drawing, for fitting a camera with no mesh to measure", () => {
+  const bounds = drawingLineBounds(buildDxfDrawingLineGroups(DRAWING));
+  assert.equal(bounds.min[0], 0);
+  assert.equal(bounds.max[0], 600);
+  assert.equal(bounds.min[2], -25);
+  assert.equal(bounds.max[2], 425);
+  assert.equal(drawingLineBounds({ layers: [] }), null);
+});

--- a/packages/cadjs/src/lib/entryAssets.js
+++ b/packages/cadjs/src/lib/entryAssets.js
@@ -165,6 +165,19 @@ export function entryHasDxf(entry) {
   return Boolean(entryAssetUrl(entry, "dxf") && entryAssetHash(entry, "dxf"));
 }
 
+/** A dimensioned DRAWING rather than a cut layout: a document with nothing to bake.
+ *
+ * Both arrive with no `glb` relation, so without asking this the viewer cannot tell a drawing
+ * from a cut layout whose flat pattern has not been built yet -- and it waits forever for a mesh
+ * that is never coming (issue #246). The server reads the profile from the package descriptor.
+ */
+export function entryIsDrawingDocument(entry) {
+  return Boolean(
+    entrySourceFormat(entry) === RENDER_FORMAT.DXF &&
+    normalizeString(entry?.drawingProfile) === "drawing"
+  );
+}
+
 export function entryHasImplicitCad(entry) {
   return Boolean(entryAssetUrl(entry, "implicit") && entryAssetHash(entry, "implicit"));
 }

--- a/packages/cadjs/src/lib/entryAssets.test.js
+++ b/packages/cadjs/src/lib/entryAssets.test.js
@@ -6,6 +6,7 @@ import {
   entryAssetBytes,
   entryAssetUrl,
   entryHasDxf,
+  entryIsDrawingDocument,
   entryHasDisplayEdges,
   entryHasMesh,
   entryHasReferences,
@@ -138,4 +139,18 @@ test("robot and reference signatures match persisted session expectations", () =
     url: "/robot.sdf",
     hash: "sdf-hash"
   }), "sdf-hash");
+});
+
+test("a dimensioned drawing is a document, a cut layout is not", () => {
+  // Both arrive with no glb relation, so the profile is the only thing that tells them apart --
+  // and getting it wrong means waiting forever for a mesh that is never coming (issue #246).
+  const drawing = { file: "plans/panel.dxf.py", kind: "dxf", drawingProfile: "drawing" };
+  const layout = { file: "parts/bracket.dxf.py", kind: "dxf", drawingProfile: "cut" };
+  assert.equal(entryIsDrawingDocument(drawing), true);
+  assert.equal(entryIsDrawingDocument(layout), false);
+  // An unbuilt entry has no profile yet: not a document until the package says so.
+  assert.equal(entryIsDrawingDocument({ file: "parts/bracket.dxf.py", kind: "dxf" }), false);
+  // The profile only means anything for a DXF.
+  assert.equal(entryIsDrawingDocument({ file: "a/b.step", kind: "step", drawingProfile: "drawing" }), false);
+  assert.equal(entryIsDrawingDocument(null), false);
 });

--- a/viewer/server_py/scanner.py
+++ b/viewer/server_py/scanner.py
@@ -367,9 +367,24 @@ def _apply_drawing_preview_stats(entry, package_dir):
         entry["bendAxisX"] = [float(v) for v in axes]
 
 
+def _apply_drawing_profile(entry, package_dir):
+    """Say whether this DXF is a dimensioned DRAWING or a cut layout.
+
+    The client needs the difference to tell "a document, with nothing to bake" from "a cut
+    layout whose flat pattern has not been built yet" -- they look identical from the outside,
+    since both arrive with no `glb` relation. Without it a drawing waits forever for a mesh
+    that is never coming (issue #246), which is what the viewer used to do.
+    """
+    descriptor = read_drawing_catalog_metadata(package_dir)
+    profile = str(descriptor.get("profile") or "").strip()
+    if profile:
+        entry["drawingProfile"] = profile
+
+
 def _apply_drawing_geometry_relation(entry, repo_root, package_dir):
     """The package's parsed-contours payload as a relation, for the viewer's curved-bend
-    remesh. Same versioning scheme as the GLB relation, same reason."""
+    remesh -- and, for a drawing, for the 2D render itself. Same versioning scheme as the GLB
+    relation, same reason."""
     descriptor = read_drawing_catalog_metadata(package_dir)
     geometry_ref = str(descriptor.get("geometry") or "").strip()
     geometry_path = os.path.join(package_dir, geometry_ref) if geometry_ref else ""
@@ -403,6 +418,7 @@ def create_single_asset_entry(repo_root, root_path, source_path, extension):
     if kind == "dxf":
         package_dir = render_package_asset_dir(source_path)
         _apply_drawing_preview_stats(entry, package_dir)
+        _apply_drawing_profile(entry, package_dir)
         _apply_drawing_geometry_relation(entry, repo_root, package_dir)
     if kind == "srdf":
         paired_urdf = _paired_urdf_path_for_srdf(source_path, repo_root)
@@ -444,6 +460,7 @@ def create_generated_dxf_entry(repo_root, root_path, source_path):
         "sourceKind": "python",
     }
     _apply_drawing_preview_stats(entry, package_dir)
+    _apply_drawing_profile(entry, package_dir)
     _apply_drawing_geometry_relation(entry, repo_root, package_dir)
     glb_relation = render_package_glb_relation(repo_root, root_path, source_path, "dxf")
     if glb_relation:

--- a/viewer/src/client/components/CadViewer.js
+++ b/viewer/src/client/components/CadViewer.js
@@ -13,6 +13,7 @@ import {
   transformDxfPreviewPositions
 } from "cadjs/lib/dxf/foldPreview";
 import { buildDxfPreviewMeshData, extractDxfScorePolylines } from "cadjs/lib/dxf/buildPreviewMesh";
+import { buildDxfDrawingLineGroups, drawingLineBounds } from "cadjs/lib/dxf/buildDrawingLines";
 import { STEP_TREE_TOPOLOGY_NODE_PREFIX } from "cadjs/lib/step/stepTree";
 import { copyImageBlobToClipboard } from "@/ui/clipboard";
 import { triggerBlobDownload } from "@/ui/download";
@@ -1752,6 +1753,7 @@ const CadViewer = forwardRef(function CadViewer({
   drawingOrientation = null,
   drawingMaterialColor = null,
   drawingGeometry = null,
+  drawingIsDocument = false,
   drawingThicknessMm = 0,
   onCameraZoomPercentChange = null,
   perspective = null,
@@ -2850,6 +2852,104 @@ const CadViewer = forwardRef(function CadViewer({
   // DRAWING TRANSFORM: thickness and fold, one vertex rewrite, math from
   // cadjs/lib/dxf/foldPreview (node-tested; the snapshot runtime shares it by construction).
   //
+  // A dimensioned DRAWING renders as LINES, because that is what it is.
+  //
+  // A cut layout's closed contours get extruded into a flat pattern and drawn as a solid. A
+  // drawing -- plan views, sections, centre lines, a title block -- encloses nothing, so it has
+  // no flat pattern, bakes no preview.glb, and used to sit on LOADING forever waiting for a mesh
+  // that was never coming (issue #246). Its geometry.json is already everything needed to draw
+  // it, so it is drawn here: one LineSegments per layer, coloured from the layer table and
+  // hidden by the same layer switches a cut layout uses.
+  useEffect(() => {
+    const runtime = runtimeRef.current;
+    const group = runtime?.modelGroup;
+    const previous = runtime?.dxfDrawingLines || null;
+    const dispose = () => {
+      if (!previous) {
+        return;
+      }
+      previous.parent?.remove(previous);
+      for (const child of previous.children || []) {
+        child.geometry?.dispose?.();
+        child.material?.dispose?.();
+      }
+      if (runtime) {
+        runtime.dxfDrawingLines = null;
+      }
+    };
+    if (!group || !drawingIsDocument || !drawingGeometry?.geometry) {
+      dispose();
+      return undefined;
+    }
+    dispose();
+    const hiddenLayers = new Set(Array.isArray(drawingHiddenLayers) ? drawingHiddenLayers : []);
+    // ACI 7 is the DXF "default ink" colour: it means "whatever reads against the background",
+    // which is why the package resolves it to a near-white grey suited to a dark sheet. Taking
+    // that literally paints a drawing invisible on a light theme, so only a layer that names a
+    // real colour gets its own; the rest use the same slate the bend guides use, which reads on
+    // both themes.
+    const DEFAULT_INK = 0x5f6775;
+    const layerColors = new Map(
+      (Array.isArray(drawingGeometry.layers) ? drawingGeometry.layers : [])
+        .map((layer) => [layer?.name, Number(layer?.colorAci) === 7 ? null : layer?.colorHex])
+    );
+    const { layers } = buildDxfDrawingLineGroups(drawingGeometry);
+    if (!layers.length) {
+      return undefined;
+    }
+    const container = new THREE.Group();
+    container.userData.dxfDrawingLines = true;
+    for (const layer of layers) {
+      if (hiddenLayers.has(layer.name)) {
+        continue;
+      }
+      // Mesher space is y-up; the scene is CAD Z-up. Same (x, y, z) -> (x, z, -y) map the
+      // curved fold preview uses, so a drawing and a flat pattern share one orientation,
+      // one camera fit and one set of view controls.
+      const source = layer.positions;
+      const mapped = new Float32Array(source.length);
+      for (let index = 0; index < source.length; index += 3) {
+        mapped[index] = source[index];
+        mapped[index + 1] = source[index + 2];
+        mapped[index + 2] = -source[index + 1];
+      }
+      const geometry = new THREE.BufferGeometry();
+      geometry.setAttribute("position", new THREE.BufferAttribute(mapped, 3));
+      const color = layerColors.get(layer.name);
+      const lines = new THREE.LineSegments(
+        geometry,
+        new THREE.LineBasicMaterial({
+          color: typeof color === "string" && color ? new THREE.Color(color) : new THREE.Color(DEFAULT_INK),
+          transparent: false
+        })
+      );
+      lines.userData.dxfDrawingLayer = layer.name;
+      container.add(lines);
+    }
+    group.add(container);
+    if (runtime) {
+      runtime.dxfDrawingLines = container;
+    }
+    // A document has no mesh for the shared fit to measure, so its own extent stands in.
+    // Publishing runtime.modelBounds is how implicits get the shared zoom baseline, reset and
+    // fit with no format-specific branch (see handleImplicitModelBounds); a drawing joins the
+    // same path rather than growing a second one.
+    const meshBounds = drawingLineBounds({ layers });
+    const bounds = meshBounds
+      ? {
+        min: [meshBounds.min[0], meshBounds.min[2], -meshBounds.max[1]],
+        max: [meshBounds.max[0], meshBounds.max[2], -meshBounds.min[1]]
+      }
+      : null;
+    if (bounds && runtime?.THREE) {
+      applyRuntimeModelBounds(runtime.THREE, runtime, bounds, sceneScaleModeRef.current);
+      runtime.hasVisibleModel = true;
+      resetZoomAndPan({ animate: false });
+    }
+    runtime?.requestRender?.();
+    return undefined;
+  }, [drawingIsDocument, drawingGeometry, drawingHiddenLayers, viewerReadyTick]);
+
   // Applied SYNCHRONOUSLY when the meshes already exist. The previous version restored flat
   // positions in its cleanup and re-folded on the next animation frame — so every slider
   // tick painted one flat frame between the two, which is the flicker. Cleanup now only

--- a/viewer/src/client/components/CadWorkspace.js
+++ b/viewer/src/client/components/CadWorkspace.js
@@ -143,6 +143,7 @@ import {
   entryHasDxf,
   entryHasImplicitCad,
   entryHasMesh,
+  entryIsDrawingDocument,
   entryHasReferences,
   entryHasUrdf,
   entryMeshAssetSignature,
@@ -1603,6 +1604,8 @@ export default function CadWorkspace({
   const selectedEntryHasDisplayEdges = entryHasDisplayEdges(selectedEntry);
   const selectedEntryHasDxf = entryHasDxf(selectedEntry);
   const selectedEntryHasImplicit = entryHasImplicitCad(selectedEntry);
+  // A dimensioned drawing renders its own 2D geometry: there is no mesh to wait for.
+  const selectedEntryIsDrawingDocument = entryIsDrawingDocument(selectedEntry);
   // The selected entry's render artifact is (re)building -> show the loading state. Replaces the
   // old !entryHasMesh + buildable-code derivation.
   const selectedStepArtifactRenderPending = selectedArtifactGenerating;
@@ -3086,6 +3089,9 @@ export default function CadWorkspace({
     selectedArtifact.status === "error";
   const meshViewerLoading =
     !!selectedEntry &&
+    // A DRAWING has no flat pattern and bakes nothing, so "no mesh yet" is its finished state,
+    // not a pending one. Waiting on the mesh path left the pane on LOADING forever (issue #246).
+    !selectedEntryIsDrawingDocument &&
     (selectedStepArtifactRenderPending || !artifactBlocksRender) &&
     status !== ASSET_STATUS.ERROR &&
     (!selectedMeshMatches || status === ASSET_STATUS.LOADING || selectedStepModuleLoading);
@@ -8444,6 +8450,7 @@ export default function CadWorkspace({
           drawingOrientation={selectedEntryIsDrawing ? drawingOrientation : null}
           drawingMaterialColor={selectedEntryIsDrawing ? dxfMaterialPreset(drawingMaterial).colorHex : null}
           drawingGeometry={selectedEntryIsDrawing ? drawingGeometry : null}
+          drawingIsDocument={selectedEntryIsDrawingDocument}
           drawingThicknessMm={selectedEntryIsDrawing ? drawingThicknessMm : 0}
           onCameraZoomPercentChange={setViewerZoomPercent}
           renderPartsIndividually={isUrdfView || Boolean(selectedStepParameterRuntime)}

--- a/viewer/src/client/components/workbench/CadRenderPane.js
+++ b/viewer/src/client/components/workbench/CadRenderPane.js
@@ -285,6 +285,7 @@ export default function CadRenderPane({
   drawingOrientation = null,
   drawingMaterialColor = null,
   drawingGeometry = null,
+  drawingIsDocument = false,
   drawingThicknessMm = 0,
   onCameraZoomPercentChange = null,
   viewPlaneOffsetRight = 16,
@@ -511,6 +512,7 @@ export default function CadRenderPane({
         drawingOrientation={drawingOrientation}
         drawingMaterialColor={drawingMaterialColor}
         drawingGeometry={drawingGeometry}
+        drawingIsDocument={drawingIsDocument}
         drawingThicknessMm={drawingThicknessMm}
         onCameraZoomPercentChange={onCameraZoomPercentChange}
         perspective={viewerPerspective}

--- a/viewer/src/client/components/workbench/CadWorkspaceTopBar.js
+++ b/viewer/src/client/components/workbench/CadWorkspaceTopBar.js
@@ -11,8 +11,8 @@ import {
 import EntryIcon from "./EntryIcon";
 import {
   DEFAULT_VIEWER_SKILLS_INSTALL_COMMAND,
-  isViewerReleaseMajorMinorNewer,
   isViewerReleaseNewer,
+  isViewerReleaseUpdateSuggested,
   viewerGithubLatestReleaseApiUrl,
   viewerGithubLatestReleaseUrl,
   normalizeViewerDiscordUrl,
@@ -711,7 +711,7 @@ function latestReleaseCheckState(currentVersion, release) {
   const latestReleaseNewer = isViewerReleaseNewer(currentVersion, latestVersion);
 
   return {
-    updateAvailable: isViewerReleaseMajorMinorNewer(currentVersion, latestVersion),
+    updateAvailable: isViewerReleaseUpdateSuggested(currentVersion, latestVersion),
     latestVersion,
     releaseUrl,
     installCommand,

--- a/viewer/src/client/workbench/viewerAlerts.js
+++ b/viewer/src/client/workbench/viewerAlerts.js
@@ -1,3 +1,4 @@
+import { entryIsDrawingDocument } from "cadjs/lib/entryAssets.js";
 import { entrySourceFormat } from "cadjs/lib/fileFormats.js";
 import {
   isArtifactManagedFormat,
@@ -95,6 +96,13 @@ export function buildViewerMeshAlert(entry, hasMeshData, loadError, artifact = n
       resolution: reloadResolution,
       command
     };
+  }
+
+  // A dimensioned DRAWING has no mesh BY DESIGN -- it encloses nothing to extrude, bakes no
+  // preview and renders as lines (issue #246). Reporting that as an error told the user to
+  // rebuild assets that were already complete. A genuine build failure still reports above.
+  if (!hasMeshData && entryIsDrawingDocument(entry)) {
+    return null;
   }
 
   if (!hasMeshData) {

--- a/viewer/src/client/workbench/viewerAlerts.test.js
+++ b/viewer/src/client/workbench/viewerAlerts.test.js
@@ -263,3 +263,17 @@ test("an artifact error falls back to a message when the record carries none", (
   assert.equal(alert.title, "Render artifact build failed");
   assert.ok(alert.message.length > 0);
 });
+
+test("a drawing with no mesh is not an error, but a failed build still is", () => {
+  // A dimensioned drawing encloses nothing to extrude, so it bakes no mesh BY DESIGN. Reporting
+  // "no mesh data is available" told the user to rebuild assets that were already complete.
+  const drawing = { file: "plans/panel.dxf.py", kind: "dxf", drawingProfile: "drawing" };
+  assert.equal(buildViewerMeshAlert(drawing, false, ""), null);
+  // A cut layout with no mesh is still a real problem.
+  const layout = { file: "parts/bracket.dxf.py", kind: "dxf", drawingProfile: "cut" };
+  assert.equal(buildViewerMeshAlert(layout, false, "")?.summary, "Mesh unavailable");
+  // And a drawing whose BUILD failed reports the build failure, which outranks the mesh card.
+  const failed = buildViewerMeshAlert(drawing, false, "", { status: "error", error: "bad entity" });
+  assert.equal(failed?.summary, "Build failed");
+  assert.match(failed?.message, /bad entity/u);
+});

--- a/viewer/src/shared/viewerConfig.mjs
+++ b/viewer/src/shared/viewerConfig.mjs
@@ -90,6 +90,24 @@ export function isViewerReleaseMajorMinorNewer(currentVersion = "", candidateVer
   return candidate.parts[0] > current.parts[0] || candidate.parts[1] > current.parts[1];
 }
 
+/** Whether a newer release is worth PROMPTING about, rather than merely noting.
+ *
+ * Two thresholds exist because the top bar has two registers: any newer release reveals the
+ * latest version quietly, while this one turns the version chip into an "Update" button.
+ *
+ * That prompt used to require a MAJOR or MINOR release, on the reasoning that a patch is not
+ * worth interrupting anyone for. It is, at the current cadence: 0.4.7 through 0.4.10 shipped
+ * inside three days and carried the Windows path fix, the SMB rename retry, the drawing rules
+ * and the multi-bend fold -- fixes a user hitting those bugs has no way to learn about from a
+ * quiet version number. So patches prompt too, for now.
+ *
+ * This is the one place that policy lives: restoring the old behaviour means calling
+ * `isViewerReleaseMajorMinorNewer` here instead, and nothing else changes.
+ */
+export function isViewerReleaseUpdateSuggested(currentVersion = "", candidateVersion = "") {
+  return isViewerReleaseNewer(currentVersion, candidateVersion);
+}
+
 export function normalizeViewerSkillsInstallCommand(
   value = "",
   fallback = DEFAULT_VIEWER_SKILLS_INSTALL_COMMAND

--- a/viewer/src/shared/viewerConfig.test.mjs
+++ b/viewer/src/shared/viewerConfig.test.mjs
@@ -7,6 +7,7 @@ import {
   DEFAULT_VIEWER_SKILLS_INSTALL_COMMAND,
   isViewerReleaseMajorMinorNewer,
   isViewerReleaseNewer,
+  isViewerReleaseUpdateSuggested,
   normalizeViewerDefaultFile,
   normalizeViewerDiscordUrl,
   normalizeViewerGithubUrl,
@@ -106,6 +107,23 @@ test("isViewerReleaseMajorMinorNewer ignores patch-only releases", () => {
   assert.equal(isViewerReleaseMajorMinorNewer("0.2.0-beta.1", "0.2.0"), false);
   assert.equal(isViewerReleaseMajorMinorNewer("0.2.0", "0.2.1"), false);
   assert.equal(isViewerReleaseMajorMinorNewer("0.2.0", "0.1.99"), false);
+});
+
+test("a patch release is worth prompting about, at this cadence", () => {
+  // The prompt turns the version chip into an "Update" button. It used to require a major or
+  // minor release; patches now qualify too, because that is where the fixes have been shipping.
+  assert.equal(isViewerReleaseUpdateSuggested("0.4.9", "0.4.10"), true);
+  assert.equal(isViewerReleaseUpdateSuggested("0.4.10", "0.5.0"), true);
+  assert.equal(isViewerReleaseUpdateSuggested("0.4.10", "1.0.0"), true);
+  // Same version, older version, and an unparseable tag must never prompt.
+  assert.equal(isViewerReleaseUpdateSuggested("0.4.10", "0.4.10"), false);
+  assert.equal(isViewerReleaseUpdateSuggested("0.4.10", "0.4.9"), false);
+  assert.equal(isViewerReleaseUpdateSuggested("0.4.10", "latest"), false);
+  // A prerelease of the version you already run is not an upgrade.
+  assert.equal(isViewerReleaseUpdateSuggested("0.2.0", "0.2.0-beta.1"), false);
+  // The narrower rule still exists, and still ignores patches -- restoring it is a one-line
+  // change inside the policy function.
+  assert.equal(isViewerReleaseMajorMinorNewer("0.4.9", "0.4.10"), false);
 });
 
 test("normalizeViewerSkillsInstallCommand accepts only skills install commands", () => {


### PR DESCRIPTION
Two loose ends from the 0.4.10 work, both mine.

## The drawing pane never rendered

A drawing package has no `preview.glb` — a drawing encloses nothing to extrude, so #252 gave it geometry only. The viewer had no arm for that: it waited on the mesh path, so a drawing sat on **LOADING forever**. Lifting that gate got it as far as **"No mesh data is available"**, which told the user to rebuild assets that were already complete. This is the remaining half of #246, which I closed with that limitation stated.

A drawing is now **drawn**. Its `geometry.json` already holds the parsed contours, so each entity becomes line segments grouped by layer: one `LineSegments` per layer, coloured from the layer table, hidden by the same layer switches a cut layout uses. The sheet maps into CAD Z-up with the same `(x, z, -y)` the curved fold preview uses, and the fit publishes `runtime.modelBounds` — which is how implicits get the shared zoom baseline and reset behaviour, so a drawing joins that path rather than growing a second one.

Three things this needed beyond the renderer, each a place the feature would otherwise fail silently:

- **the server reports the package profile on the entry.** A drawing and an unbuilt cut layout look identical from outside — both arrive with no `glb` — so the client cannot otherwise tell which one is finished.
- **the no-mesh alert exempts a drawing**, while a genuine build failure still reports, since that card outranks the generic one.
- **`CadRenderPane` forwards the flag.** It sits between the workspace and the viewer and passes props explicitly, so my flag was dropped: the effect ran with the geometry in hand and `isDoc: false`. That reads as "nothing rendered" with no error anywhere, and cost the most time to find.

One judgement call worth flagging: **ACI 7 is the DXF "default ink" colour**, which the package resolves to a near-white grey suited to a dark sheet. Taken literally that paints a drawing invisible on the light theme, so only a layer naming a real colour gets its own; the rest use the slate the bend guides already use.

## Not covered, deliberately

`DIMENSION` entities are annotation and are not in `geometry.json`, so the views, centre lines, hidden edges and title block render — **the dimensions themselves do not**. For the issue's reporter that is the difference between reading their drawing and reading its outlines, so it deserves its own change rather than being buried here.

## The other loose end

Annotates the three bare `except Exception:` handlers #252 left in `drawing_checks.py` — the last ones violating the convention #256 established. `git grep -c "except Exception:$"` under `packages/cadgen/src/cadgen` is now zero.

## Fixture

`models/drawings/dxf/cabinet_panel_drawing.dxf.py` — a cabinetmaker's panel as a document: plan, front elevation, section A-A, 11 dimension entities, `CENTER`/`HIDDEN` linetypes, a non-plotting construction layer and a title block. It classifies as a drawing on build (`drawing_document` info finding) and is the fixture this render path is verified against.

## Verification

In the browser, on that fixture: **0 draw calls before, 9030 after**, with the elevation, plan, section, centre lines and title block legible. Suites: cadjs **624**, viewer **347**, global **79**, viewer backend **176**, dxf **78**; viewer build clean; bundles regenerated.

New tests: 8 for the line builder (grouping, sheet plane, endpoint fidelity, circle closure, short-way arc sweep, degenerate entities producing no NaN, empty-drawing detection, bounds), plus the entry predicate and the alert exemption — including that a drawing whose build *failed* still reports the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in here: patch releases now prompt for an update

Squeezed in on request, given the current release cadence.

The version chip has two registers: any newer release reveals the latest version quietly, and a bigger one turns the chip into an **"Update"** button. That second one required a major or minor release, on the reasoning that a patch is not worth interrupting anyone for. At this cadence it is — 0.4.7 through 0.4.10 shipped inside three days and carried the Windows path fix, the SMB rename retry, the drawing rules and the multi-bend fold, none of which a user hitting those bugs can learn about from a version number that changed quietly.

Rather than swapping one call for another, the decision now has a name: `isViewerReleaseUpdateSuggested` is the single place the prompt threshold lives, documenting why patches qualify and noting that restoring the old behaviour means calling `isViewerReleaseMajorMinorNewer` inside it. That narrower rule stays, and stays tested, so the revert is one line rather than a rewrite.

Verified in the browser with the release API stubbed:

| latest release | chip | aria-label |
|---|---|---|
| 0.4.11 (patch newer) | `Update` | Update CAD Viewer |
| 0.4.10 (same) | `0.4.10` | Open release 0.4.10 |

Note this is unrelated to the drawing renderer and shares the PR only because you asked for it here — worth knowing if either half ever needs reverting on its own.
