### PR TITLE
cadgen: build the Node bootstrap URL with as_uri, not string concatenation (closes #266)

### DIFF
--- a/packages/cadgen/src/cadgen/_internal/node_runtime.py
+++ b/packages/cadgen/src/cadgen/_internal/node_runtime.py
@@ -57,7 +57,6 @@ import threading
 from collections import deque
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
-from urllib.request import pathname2url
 
 __all__ = [
     "NODE_ENV_VARS",
@@ -194,7 +193,13 @@ def node_resolve_bootstrap() -> str:
             f"cadgen's Node resolve bootstrap is missing: {path}. This file must ship with "
             "the package (see [tool.setuptools.package-data] in cadgen's pyproject.toml)."
         )
-    return "file://" + pathname2url(str(path))
+    # ``Path.as_uri()``, NOT "file://" + pathname2url. On Windows pathname2url already returns a
+    # leading ``///`` (nturl2path), so concatenating another ``file://`` produced a five-slash URL
+    # that Node rejects outright -- ERR_INVALID_FILE_URL_PATH, before the builder wrote anything
+    # (issue #266). POSIX returned ``/usr/...`` from the same call, so the bug was invisible
+    # there. as_uri() is correct on both and percent-encodes, which the plugin's own install path
+    # needs: it contains a space on Windows.
+    return path.as_uri()
 
 
 def _dispatch(message: Mapping[str, Any], run: Any) -> bool:

--- a/tests/python/packages/cadgen/test_node_resolve_bootstrap.py
+++ b/tests/python/packages/cadgen/test_node_resolve_bootstrap.py
@@ -1,0 +1,90 @@
+"""The Node builder's ``--import`` bootstrap URL has to be valid on Windows too.
+
+`node_runtime` built it as ``"file://" + pathname2url(path)``. On POSIX `pathname2url` returns
+``/usr/...`` and that concatenation is correct, which is why this went unnoticed; on Windows it
+returns a leading ``///`` (urllib delegates to `nturl2path`), so the prefix doubled into a
+five-slash URL and Node rejected it before the builder wrote anything:
+
+    TypeError [ERR_INVALID_FILE_URL_PATH]: File URL path must be absolute
+      input: 'file://///C:/Users/.../node_resolve_register.mjs'
+
+Issue #266. Every Node builder invocation on Windows went through that line, in every vendored
+copy of the module, so it is worth pinning from a POSIX CI box as well as a Windows one --
+`nturl2path` and `PureWindowsPath` are importable everywhere, so the platform-specific behaviour
+is testable without the platform.
+"""
+
+from __future__ import annotations
+
+import nturl2path
+import unittest
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+from tests.python.support.paths import add_repo_path, repo_path
+
+add_repo_path("packages/cadgen/src")
+
+from cadgen._internal.node_runtime import node_resolve_bootstrap  # noqa: E402
+
+WINDOWS_PATH = r"C:\Users\M\AppData\Roaming\npm\plugin 0.4.10\cadgen\_internal\node_resolve_register.mjs"
+POSIX_PATH = "/home/m/.local/share/plugin 0.4.10/cadgen/_internal/node_resolve_register.mjs"
+
+
+class NodeResolveBootstrapUrlTests(unittest.TestCase):
+    def test_the_bootstrap_url_is_a_valid_absolute_file_url(self) -> None:
+        url = node_resolve_bootstrap()
+        self.assertTrue(url.startswith("file:///"), url)
+        # Four or more slashes is the #266 failure: Node reads everything after ``file://`` as a
+        # host, so an extra pair makes the path non-absolute.
+        self.assertFalse(url.startswith("file:////"), f"malformed file URL: {url}")
+
+    def test_the_url_points_at_the_shipped_bootstrap_file(self) -> None:
+        from urllib.parse import urlparse
+        from urllib.request import url2pathname
+
+        resolved = Path(url2pathname(urlparse(node_resolve_bootstrap()).path))
+        self.assertTrue(resolved.is_file(), resolved)
+        self.assertEqual("node_resolve_register.mjs", resolved.name)
+
+    def test_as_uri_is_correct_on_both_platforms_where_concatenation_was_not(self) -> None:
+        """The fix, and the bug it replaced, on both platform flavours from one box."""
+        # What the old line produced on Windows: pathname2url already supplies ``///``.
+        broken = "file://" + nturl2path.pathname2url(WINDOWS_PATH)
+        self.assertTrue(broken.startswith("file://///"), broken)
+
+        # What as_uri() produces: three slashes, drive letter intact, spaces encoded.
+        windows_url = PureWindowsPath(WINDOWS_PATH).as_uri()
+        self.assertTrue(windows_url.startswith("file:///C:/"), windows_url)
+        self.assertFalse(windows_url.startswith("file:////"), windows_url)
+        self.assertIn("plugin%200.4.10", windows_url, "a space in the install path must be encoded")
+
+        posix_url = PurePosixPath(POSIX_PATH).as_uri()
+        self.assertTrue(posix_url.startswith("file:///home/"), posix_url)
+        self.assertIn("plugin%200.4.10", posix_url)
+
+    def test_no_vendored_copy_builds_a_file_url_by_concatenation(self) -> None:
+        """The module is vendored into every skill runtime, so the pattern must be gone from all
+        of them -- a stale copy would keep failing on Windows while the source read correctly."""
+        offenders = []
+        # Committed trees only. `tmp/` holds throwaway copies the bundle checks extract for
+        # comparison, and a stale one there says nothing about what ships.
+        roots = [repo_path("packages"), repo_path("skills"), repo_path("viewer")]
+        candidates = [
+            candidate
+            for root in roots
+            for candidate in root.rglob("node_runtime.py")
+            if not any(part in {"node_modules", "dist", "tmp", "__pycache__"} or part.startswith(".")
+                       for part in candidate.relative_to(repo_path()).parts)
+        ]
+        self.assertTrue(candidates, "expected at least the canonical module")
+        for candidate in candidates:
+            text = candidate.read_text(encoding="utf-8")
+            # Strip comments so this test cannot be tripped by prose describing the bug.
+            code = "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+            if '"file://" +' in code or "'file://' +" in code:
+                offenders.append(str(candidate.relative_to(repo_path())))
+        self.assertEqual([], offenders, "these build a file URL by concatenation")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #266.

Every Node builder invocation on Windows died before writing anything:

```
TypeError [ERR_INVALID_FILE_URL_PATH]: File URL path must be absolute
  input: 'file://///C:/Users/.../node_resolve_register.mjs'
```

The `--import` bootstrap URL was assembled as `"file://" + pathname2url(path)`. On Windows urllib delegates `pathname2url` to `nturl2path`, which **already returns a leading `///`**, so the prefix doubled into five slashes and Node read everything after `file://` as a host. On POSIX the same call returns `/usr/...` and the concatenation is correct — which is exactly why this shipped: there is no POSIX symptom to notice.

`Path.as_uri()` is right on both platforms and percent-encodes, which this path needs independently: the plugin's install directory contains a space on Windows, the same hazard as #245.

@M-Stege reported it with the cause already located and two working alternatives — thank you, that turned this into a one-line change.

## Confirming it without Windows

`nturl2path` and `PureWindowsPath` are importable everywhere, so the platform-specific behaviour is testable from a POSIX box:

```python
'file://' + nturl2path.pathname2url(r'C:\...\node_resolve_register.mjs')
# -> 'file://///C:/...'                       the five slashes, reproduced
PureWindowsPath(r'C:\...\node_resolve_register.mjs').as_uri()
# -> 'file:///C:/...'                          what Node accepts
```

## Tests

Four, in `tests/python/packages/cadgen/test_node_resolve_bootstrap.py`:

- the live URL is an absolute three-slash `file://` URL, and explicitly **not** four-or-more;
- it resolves back to the shipped `node_resolve_register.mjs`;
- both platform flavours are pinned from one box, including `plugin%200.4.10` for the space;
- **no committed copy of `node_runtime.py` builds a file URL by concatenation** — the module is vendored into every skill runtime, and a stale copy would keep failing on Windows while the source read correctly. Reverting the fix fails this one by name.

That last test initially failed on two throwaway copies under `tmp/` that the bundle checks extract for comparison, so its scan is limited to committed trees.

## Verification

cadgen **273** tests, bundles regenerated, and a real DXF drawing rebuilt through the Node builder to confirm the bootstrap still loads on this platform.

Also from the reporter's run, unprompted: #252 behaves as intended on their real workshop drawing — `drawing_document: treated as a dimensioned drawing (37 dimension/leader entities)`, no layer renamed. This was the last thing standing between that fix and a regenerated DXF for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
