### PR TITLE
ci: run the test suite on Windows, and cover the bugs that got there first

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           node scripts/release/sync-version.mjs --check
 
   test:
-    name: Test
+    name: Test (Linux)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,38 @@ jobs:
 
       - name: Run code tests
         run: scripts/test/test.sh
+
+  # A SEPARATE JOB, never a matrix on `test` above. A matrix renames that job's check to
+  # "Test (ubuntu-latest)", and `Test` is a required status check on develop -- it would stop
+  # being reported and every pull request would wait forever for a check that no longer exists.
+  #
+  # Runs the TESTS only, not the hygiene steps the Linux job wraps them in. Bundle freshness,
+  # the symlink layout and the published-tree checks are properties of the repository, not of
+  # an operating system; bundling is deterministic, so re-checking it here would buy nothing
+  # and cost minutes. The platform risk is in file I/O -- locks, paths, subprocesses, file
+  # URLs -- which is what the test suites exercise.
+  #
+  # Why this job exists at all: four of the last five user-reported bugs were Windows-only
+  # (#260, #266, #267, #269), and every one of them passed CI. The coverage was mostly already
+  # written -- test_coordination.py's holder test asserts exactly the cross-process sentinel
+  # read that #269 broke -- so what was missing was a runner, not a test.
+  test-windows:
+    name: Test (Windows)
+    runs-on: windows-latest
+
+    steps:
+      # Before checkout: Git for Windows materializes symlinks as text files containing the
+      # target path unless this is set, and `develop` is a symlink layout by design. Without
+      # it the runtime paths under skills/ are plain files and the suite tests nothing real.
+      - name: Enable Git symlinks
+        run: git config --global core.symlinks true
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up dependencies
+        uses: ./.github/actions/setup-deps
+
+      - name: Run code tests
+        run: scripts/test/test.sh
+        shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,20 @@ jobs:
       - name: Set up dependencies
         uses: ./.github/actions/setup-deps
 
-      - name: Run code tests
-        run: scripts/test/test.sh
+      # Three steps rather than test.sh, each running even if an earlier one failed, and the
+      # Python runner in --keep-going mode. While Windows is being brought up the failures are
+      # independent POSIX-isms in unrelated suites, and stopping at the first one turns a list
+      # into one ~10 minute round trip per entry. The Linux job keeps the fail-fast default.
+      - name: Run JS tests
+        run: scripts/test/test-js.sh
+        shell: bash
+
+      - name: Run Python tests
+        if: ${{ !cancelled() }}
+        run: scripts/test/test-python.sh --keep-going
+        shell: bash
+
+      - name: Run global policy tests
+        if: ${{ !cancelled() }}
+        run: scripts/test/test-global.sh
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,10 @@ jobs:
         run: scripts/test/test-python.sh --keep-going
         shell: bash
 
-      - name: Run global policy tests
-        if: ${{ !cancelled() }}
-        run: scripts/test/test-global.sh
-        shell: bash
+      # test-global.sh is deliberately absent, for the same reason the bundle and symlink
+      # steps are. It asserts REPOSITORY policy -- that manifests pin the canonical version,
+      # that lockfiles do not reach outside a skill, that the release scripts read the right
+      # VERSION path at a given ref -- by executing the repo's own bash tooling. None of that
+      # is shipped to a Windows user, and none of its answers can differ by operating system;
+      # running it here only asks whether `bash` on a Windows runner behaves like bash, which
+      # it does not (it resolves to the WSL stub and answers in UTF-16).

--- a/packages/cadgen/src/cadgen/_internal/atomic_replace.py
+++ b/packages/cadgen/src/cadgen/_internal/atomic_replace.py
@@ -17,9 +17,19 @@ Deliberately narrow:
 * only ``WinError 32`` retries. A denial (5) or a missing directory is a real error and must
   surface at once, not 350 ms later.
 * the attribute does not exist off Windows, so this is exactly ``os.replace`` on POSIX.
-* four attempts over 350 ms, then the original error propagates. A rename that cannot win in
+* five attempts over 750 ms, then the original error propagates. A rename that cannot win in
   that window is not a deferred close, and a build that hangs retrying is worse than one that
   says what happened.
+
+The window is sized for the TAIL, not the median, and that distinction is the whole of issue
+#274. 350 ms looked generous per rename and was: measured on a Synology SMB share over two
+84-component builds, 126 of 168 renames blocked at all, median 31 ms, p90 118 ms -- and max
+389 ms, just past the old budget. But the budget is spent per rename while the BUILD only
+succeeds if every rename wins, and a large assembly draws from that distribution a hundred-odd
+times. At 168 renames even a 1% per-rename loss rate leaves roughly a 1-in-5 chance of a clean
+build, which is what the reporter saw: 1 of 3 runs completing, each failure on a different
+component. Widening costs the common case nothing, because a 31 ms median still wins on the
+first or second retry.
 """
 
 from __future__ import annotations
@@ -31,7 +41,7 @@ from pathlib import Path
 # ERROR_SHARING_VIOLATION: the file is open in another process -- or, on SMB, was open a moment
 # ago and the server has not caught up.
 WINDOWS_SHARING_VIOLATION = 32
-RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2)
+RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2, 0.4)
 
 
 def replace_atomic(temp_path: Path | str, target_path: Path | str) -> None:

--- a/packages/cadgen/src/cadgen/_internal/generation_spec.py
+++ b/packages/cadgen/src/cadgen/_internal/generation_spec.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from dataclasses import replace
 import math
+import os
 from pathlib import Path
 import sys
 from typing import Sequence
@@ -108,7 +109,19 @@ def _resolve_cli_output_path(
     value = str(raw_output).strip()
     if not value:
         raise ValueError(f"{tool_name} {option_label} must be a non-empty path")
-    if "\\" in value:
+    # A backslash is the native separator on Windows and a legal FILENAME character on POSIX,
+    # so this guard has to be platform-specific. On POSIX it catches a Windows-shaped path
+    # typed on the wrong machine, which would otherwise silently create a file named
+    # ``C:\out.step`` in the working directory. On Windows it must not fire at all: this is a
+    # path the user typed for their own filesystem, and ``str(Path(...))`` produces
+    # backslashes there, so the absolute rule rejected EVERY native path given to --output or
+    # to a SOURCE=OUTPUT target.
+    #
+    # The same wording in ``cadgen.metadata`` is absolute on purpose and must stay that way:
+    # that one validates a path written into a checked-in ``gen_step()`` envelope, which is
+    # read on every platform, so POSIX separators are the portable form there. One rule is
+    # about a user's disk, the other about a file in the repository.
+    if os.name != "nt" and "\\" in value:
         raise ValueError(f"{tool_name} {option_label} must use POSIX '/' separators")
     output_path = Path(value).expanduser()
     resolved = output_path.resolve() if output_path.is_absolute() else (Path.cwd() / output_path).resolve()

--- a/packages/cadgen/src/cadgen/step_targets.py
+++ b/packages/cadgen/src/cadgen/step_targets.py
@@ -141,7 +141,13 @@ def _cwd_relative_target(raw_target: str) -> str:
     if not raw_target:
         return raw_target
     path = Path(raw_target).expanduser()
-    if not path.is_absolute():
+    # ROOTED, not is_absolute(). On Windows a path with a root and no drive ("/models/x") is
+    # drive-RELATIVE, so is_absolute() is False and the guard below never ran -- the target
+    # fell through and became the bogus cwd-relative cad path this function exists to prevent,
+    # which is the POSIX bug it was written for, still live on the other platform. resolve()
+    # anchors such a path to the current drive, which is what it means there, and the
+    # relative_to() check then answers correctly for it.
+    if not (path.is_absolute() or path.root):
         return raw_target
     try:
         return path.resolve().relative_to(Path.cwd().resolve()).as_posix()

--- a/scripts/test/test-python.sh
+++ b/scripts/test/test-python.sh
@@ -6,6 +6,25 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 
 LIST_SKILLS_SCRIPT="$REPO_ROOT/scripts/utils/list-skills.sh"
 
+# --keep-going: run every suite and report all of them, instead of stopping at the first
+# failure. Opt-in, because stopping early is the right default for a developer waiting on a
+# run. It is for CI on a platform being brought up, where the failures are independent and
+# one round per suite means one ~10 minute round trip per suite.
+KEEP_GOING=0
+if [ "${1:-}" = "--keep-going" ]; then
+  KEEP_GOING=1
+  shift
+fi
+failed_suites=()
+
+run_suite() {
+  if [ "$KEEP_GOING" -eq 1 ]; then
+    run_python_unittest "$@" || failed_suites+=("$1")
+  else
+    run_python_unittest "$@"
+  fi
+}
+
 cd "$REPO_ROOT"
 
 # Turn the render-package write-lock assertion into a hard failure for tests. In
@@ -13,7 +32,7 @@ cd "$REPO_ROOT"
 # user's build fails -- so CI is the only place the contract is actually enforced.
 export CADGEN_STRICT_LOCKS=1
 
-run_python_unittest "cadgen package Python tests" "tests/python/packages/cadgen" "packages/cadgen/src"
+run_suite "cadgen package Python tests" "tests/python/packages/cadgen" "packages/cadgen/src"
 
 while IFS= read -r skill; do
   test_dir="tests/python/skills/$skill"
@@ -22,11 +41,11 @@ while IFS= read -r skill; do
     if [ "$skill" = "cad" ] || [ "$skill" = "dxf" ]; then
       skill_paths+=("skills/$skill/scripts/packages/cadgen/src")
     fi
-    run_python_unittest "$skill skill Python tests" "$test_dir" "${skill_paths[@]}"
+    run_suite "$skill skill Python tests" "$test_dir" "${skill_paths[@]}"
   fi
 done < <("$LIST_SKILLS_SCRIPT")
 
-run_python_unittest "MoveIt2 server Python tests" "tests/python/viewer/moveit2_server" "viewer/moveit2_server"
+run_suite "MoveIt2 server Python tests" "tests/python/viewer/moveit2_server" "viewer/moveit2_server"
 
 # The CAD Viewer backend keeps its tests beside the package it covers rather
 # than under tests/, so name the directory explicitly. It owns the only cross-process
@@ -36,4 +55,10 @@ run_python_unittest "MoveIt2 server Python tests" "tests/python/viewer/moveit2_s
 # stdlib-only modules directly (coordination, source_hash) rather than reimplementing
 # them. Without it an installed/editable cadgen from another checkout wins and the
 # coordination package is missing.
-run_python_unittest "CAD Viewer backend Python tests" "viewer/server_py/tests" "viewer" "packages/cadgen/src"
+run_suite "CAD Viewer backend Python tests" "viewer/server_py/tests" "viewer" "packages/cadgen/src"
+
+if [ "${#failed_suites[@]}" -gt 0 ]; then
+  printf '\n==> FAILING SUITES (%d)\n' "${#failed_suites[@]}"
+  printf '  %s\n' "${failed_suites[@]}"
+  exit 1
+fi

--- a/skills/cad/scripts/gen/cli.py
+++ b/skills/cad/scripts/gen/cli.py
@@ -108,7 +108,11 @@ def _sibling_step_output(target: str) -> str:
     # foo.step.py -> foo.step; plain foo.py -> foo.step (the target's logical STEP).
     if target.lower().endswith(".step.py"):
         return target[: -len(".py")]
-    return str(Path(target).with_suffix(".step"))
+    # as_posix(), because this half of a SOURCE=OUTPUT pair is a logical path. str() on a
+    # Path renders the NATIVE separator, so on Windows the two branches disagreed: the slice
+    # above kept "parts/second.step" and this one produced "parts\second.step" for the same
+    # shape of input. Windows accepts forward slashes, so one spelling serves both.
+    return Path(target).with_suffix(".step").as_posix()
 
 
 def _targets_with_step_outputs(

--- a/skills/urdf/scripts/urdf/source.py
+++ b/skills/urdf/scripts/urdf/source.py
@@ -1182,6 +1182,19 @@ def _has_duplicates(values: list[str]) -> bool:
 
 
 # --- mesh URI helpers ---
+def _is_rooted(path: Path) -> bool:
+    """Does this path start from a root, rather than from wherever we happen to be?
+
+    ``is_absolute()`` is the obvious call and is wrong on Windows for the shape URDF files
+    are full of: "/opt/ros/share/robot/meshes/base.stl" has a root and no drive, which makes
+    it drive-RELATIVE there, so is_absolute() is False. Classifying it LOCAL_RELATIVE would
+    then resolve it against some unrelated base directory and silently produce a path the
+    author never wrote. A rooted path is not a relative path on any platform; on Windows it
+    means "from the root of the current drive", which is exactly what resolve() gives back.
+    """
+    return path.is_absolute() or bool(path.root)
+
+
 def classify_mesh_uri(uri: str) -> MeshReference:
     value = str(uri or "").strip()
     parsed = urlparse(value)
@@ -1200,7 +1213,7 @@ def classify_mesh_uri(uri: str) -> MeshReference:
 
     if parsed.scheme == "file":
         file_path = Path(unquote(parsed.path))
-        if file_path.is_absolute():
+        if _is_rooted(file_path):
             return MeshReference(uri=value, kind=MeshUriKind.LOCAL_ABSOLUTE, path=file_path.resolve())
         return MeshReference(uri=value, kind=MeshUriKind.LOCAL_RELATIVE, path=file_path)
 
@@ -1208,7 +1221,7 @@ def classify_mesh_uri(uri: str) -> MeshReference:
         return MeshReference(uri=value, kind=MeshUriKind.REMOTE)
 
     local_path = Path(value)
-    if local_path.is_absolute():
+    if _is_rooted(local_path):
         return MeshReference(uri=value, kind=MeshUriKind.LOCAL_ABSOLUTE, path=local_path.resolve())
     return MeshReference(uri=value, kind=MeshUriKind.LOCAL_RELATIVE, path=local_path)
 

--- a/tests/python/packages/cadgen/test_atomic_replace.py
+++ b/tests/python/packages/cadgen/test_atomic_replace.py
@@ -51,9 +51,26 @@ class ReplaceAtomicTest(unittest.TestCase):
             "the backoff must grow, and must not sleep after the winning attempt",
         )
 
+    def test_the_window_covers_the_measured_tail_not_the_median(self) -> None:
+        """Issue #274, and the reason this number is not free to shrink.
+
+        Measured on a Synology SMB share over two 84-component builds: 126 of 168 renames
+        blocked at all, median 31 ms, p90 118 ms, max 389 ms. The budget is spent per rename
+        but the BUILD only succeeds if every one of them wins, so the window has to clear the
+        tail rather than the middle -- at 168 draws, a 1% per-rename loss rate is roughly a
+        1-in-5 chance of a clean build.
+        """
+        self.assertGreater(
+            sum(atomic_replace.RETRY_DELAYS_SECONDS),
+            0.389,
+            "the retry window must outlast the longest rename actually measured on SMB",
+        )
+        # ...and the first retry still has to be short, or the median rename pays for the tail.
+        self.assertLessEqual(atomic_replace.RETRY_DELAYS_SECONDS[0], 0.05)
+
     def test_it_gives_up_rather_than_hanging(self) -> None:
-        # A rename that cannot win in 350 ms is not a deferred close. Failing beats a build that
-        # retries forever.
+        # A rename that cannot win inside the window is not a deferred close. Failing beats a
+        # build that retries forever.
         error = sharing_violation()
         with mock.patch.object(atomic_replace.os, "replace", side_effect=error), \
              mock.patch.object(atomic_replace.time, "sleep") as sleep:

--- a/tests/python/packages/cadgen/test_cli_output_paths.py
+++ b/tests/python/packages/cadgen/test_cli_output_paths.py
@@ -1,0 +1,98 @@
+"""``--output`` and ``SOURCE=OUTPUT`` take a path on the USER'S disk, in their own notation.
+
+`_resolve_cli_output_path` rejected any value containing a backslash, absolutely. On POSIX
+that is a useful guard: a backslash is a legal filename character there, so a Windows-shaped
+path typed on a Linux box would otherwise create a file literally named ``C:\\out.step``
+instead of failing. On Windows it is the opposite of useful -- backslash IS the separator, and
+``str(Path(...))`` produces one -- so every native path a Windows user could give the CLI was
+refused. Found by the Windows CI job on its first run, in
+``test_package_portability.setUpClass``.
+
+The identically worded rule in :mod:`cadgen.metadata` is absolute ON PURPOSE and is asserted
+here too, so a later change cannot "consistently" relax both. That one validates a path
+written into a checked-in ``gen_step()`` envelope, which is read on every platform; POSIX
+separators are the portable form for a file in the repository. These are two different rules
+that happen to share a sentence.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.python.support.paths import add_repo_path
+
+add_repo_path("packages/cadgen/src")
+
+from cadgen._internal.generation_spec import (  # noqa: E402
+    _parse_cli_target_specs,
+    _resolve_cli_output_path,
+)
+
+WINDOWS = os.name == "nt"
+
+
+class CliOutputPathSeparatorTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def _resolve(self, raw):
+        return _resolve_cli_output_path(
+            raw, expected_suffixes=(".step",), tool_name="cad gen"
+        )
+
+    def test_a_native_path_is_accepted(self):
+        """Whatever this platform's separator is, a path written with it must work."""
+        native = str(self.root / "out.step")
+        self.assertEqual((self.root / "out.step").resolve(), self._resolve(native))
+
+    @unittest.skipUnless(WINDOWS, "backslash is only a separator on Windows")
+    def test_windows_accepts_a_backslash_path(self):
+        # The exact shape that failed: a drive letter and backslashes, as every Windows tool
+        # produces and every Windows user types.
+        resolved = self._resolve(r"C:\models\out.step")
+        self.assertEqual("out.step", resolved.name)
+
+    @unittest.skipIf(WINDOWS, "backslash is a separator here, not a suspicious filename")
+    def test_posix_still_rejects_a_windows_shaped_path(self):
+        with self.assertRaisesRegex(ValueError, "POSIX"):
+            self._resolve(r"C:\models\out.step")
+
+    def test_a_source_output_pair_survives_a_native_output_path(self):
+        """The pair splits on the FIRST '=', so a drive letter's colon is not a hazard --
+        but the output half still goes through the separator rule, which is where it died."""
+        source = self.root / "widget.step.py"
+        output = self.root / "exported.step"
+        specs = _parse_cli_target_specs(
+            [f"{source}={output}"], expected_suffixes=(".step",), tool_name="cad gen"
+        )
+        self.assertEqual(1, len(specs))
+        self.assertEqual(str(source), specs[0].target)
+        self.assertEqual(output.resolve(), specs[0].output_path)
+
+
+class EnvelopePathRuleStaysAbsoluteTest(unittest.TestCase):
+    """The repository-facing rule is NOT platform-conditional, on any platform."""
+
+    def test_an_envelope_path_with_a_backslash_is_rejected_everywhere(self):
+        import ast
+
+        from cadgen.metadata import _parse_path_field
+
+        script = Path("widget.step.py")
+        envelope = {"step": ast.Constant(value=r"models\widget.step")}
+        with self.assertRaisesRegex(ValueError, "POSIX"):
+            _parse_path_field(
+                script_path=script,
+                function_name="gen_step",
+                envelope=envelope,
+                field_name="step",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/packages/cadgen/test_coordination_lock.py
+++ b/tests/python/packages/cadgen/test_coordination_lock.py
@@ -195,6 +195,12 @@ class GenerationLockBehaviourTest(unittest.TestCase):
         threading.Thread(target=lambda: (self._acquire_release(), done.set()), daemon=True).start()
         self.assertTrue(done.wait(15), "a SIGKILLed builder left a stale lock")
 
+    @unittest.skipIf(
+        os.name == "nt",
+        "chmod only toggles the read-only bit on Windows and does not stop a directory "
+        "being written, so this would pass without ever reaching the degradation it claims "
+        "to cover. Making a directory truly unwritable there needs an ACL edit.",
+    )
     def test_unwritable_lock_directory_does_not_fail_the_build(self):
         blocked = self.root / "ro"
         blocked.mkdir()
@@ -240,27 +246,20 @@ class GenerationLockBehaviourTest(unittest.TestCase):
         """The two tests above pass "unknown-generator", which resolves to NO output dir
         and therefore no lock at all -- they pin call ordering, not mutual exclusion. This
         one asserts the currency check really does run inside the critical section, by
-        probing the sentinel from a second descriptor while the check is executing."""
-        import fcntl
+        probing the sentinel from a second descriptor while the check is executing.
 
+        Probes through ``lock.probe`` rather than raw ``fcntl``: it asks the same question
+        through whichever backend is compiled in, and a bare ``import fcntl`` here is an
+        ImportError on Windows -- where this assertion is worth more, not less."""
         from cadgen.coordination import STEP_PACKAGE, artifact_build
         from cadgen.coordination.paths import write_lock_path
 
         package = self.root / "__cadgen__" / "models" / "part.step.py"
-        lock = write_lock_path(package)
+        lock_path = write_lock_path(package)
         observed = []
 
         def _is_current():
-            handle = open(lock, "a+b")
-            try:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except OSError:
-                observed.append("locked")
-            else:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
-                observed.append("UNLOCKED")
-            finally:
-                handle.close()
+            observed.append("locked" if lock.probe(lock_path).held else "UNLOCKED")
             return True
 
         with artifact_build(STEP_PACKAGE, package, is_current=_is_current) as run:
@@ -277,6 +276,78 @@ class GenerationLockBehaviourTest(unittest.TestCase):
             self.assertEqual("S", enter, f"interleaved critical sections: {marks!r}")
             self.assertEqual("E", leave, f"interleaved critical sections: {marks!r}")
             self.assertEqual(tag, leave_tag, f"interleaved critical sections: {marks!r}")
+
+
+class RealBackendRegressionTests(unittest.TestCase):
+    """Field regressions, asserted against the REAL backend of whatever platform runs them.
+
+    Everything in ``WindowsLockBackendTests`` drives a fake, because ``msvcrt`` is not
+    importable on the CI box that has always run these. A fake cannot reproduce either of the
+    two bugs Windows users actually hit -- a backend that silently is not there, and a lock
+    that makes its own file unreadable -- so these assert the invariants directly and are
+    worth exactly what the platform running them is worth. On POSIX they pass trivially; on a
+    Windows runner they are the regression tests for #260 and #269.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.lock = write_lock_path(self.root / "__cadgen__" / "models" / "part.step.py")
+
+    def test_this_platform_really_has_a_locking_backend(self):
+        """#260: before it, Windows had no ``fcntl``, took no lock, and said nothing.
+
+        Every build proceeded unserialized and the degradation was invisible -- `exclusive()`
+        is designed to yield None rather than fail, which is right for a filesystem that
+        cannot lock and wrong as a description of the whole platform. Any OS the tests run on
+        is an OS someone builds on, so a missing backend is a bug there, not a degradation.
+        """
+        self.assertTrue(
+            lock.locking_available(),
+            f"no locking backend on {os.name}: builds here are not serialized at all",
+        )
+        with exclusive(self.lock) as run_id:
+            self.assertTrue(run_id, "a real backend must record a run id, not degrade to None")
+
+    def test_another_process_can_read_the_sentinel_while_the_lock_is_held(self):
+        """#269: Windows byte-range locks are MANDATORY, POSIX ``flock`` is advisory.
+
+        Locking byte 0 of the sentinel made it unreadable to every other process for the whole
+        build. The Node builders read it to prove they were started by the holder, and Python's
+        own ``read_run_id`` reads it to attribute progress -- both precisely while a lock is
+        held. So the sentinel must stay readable FROM ANOTHER PROCESS, which is the only place
+        the distinction shows up: the holder can always read its own locked region.
+        """
+        ready = self.root / "ready"
+        script = textwrap.dedent(
+            f"""
+            import sys, time
+            sys.path.insert(0, {_CADGEN_SRC!r})
+            from cadgen.coordination.lock import exclusive
+            with exclusive({str(self.lock)!r}):
+                open({str(ready)!r}, "wb").close()
+                time.sleep(120)
+            """
+        )
+        proc = subprocess.Popen([sys.executable, "-c", script])
+        try:
+            for _ in range(500):
+                if ready.exists():
+                    break
+                time.sleep(0.02)
+            self.assertTrue(ready.exists(), "helper never acquired the lock")
+
+            # The lock really is held, so this is not "readable because nothing ran".
+            self.assertTrue(lock.probe(self.lock).held, "the helper is not holding the lock")
+
+            # What the Node builders do (a whole-file read), and what read_run_id does.
+            raw = self.lock.read_bytes()[:32].decode("ascii").strip()
+            self.assertEqual(32, len(raw), f"sentinel unreadable or unstamped: {raw!r}")
+            self.assertEqual(raw, lock.read_run_id(self.lock))
+        finally:
+            proc.kill()
+            proc.wait(timeout=30)
 
 
 class _FakeMsvcrt:

--- a/tests/python/packages/cadgen/test_coordination_lock.py
+++ b/tests/python/packages/cadgen/test_coordination_lock.py
@@ -131,9 +131,16 @@ class GenerationLockBehaviourTest(unittest.TestCase):
                 done.set()
                 time.sleep(0.05)
 
+        thread = threading.Thread(target=run, daemon=True)
         with exclusive(self.lock):
-            threading.Thread(target=run, daemon=True).start()
+            thread.start()
             self.assertTrue(done.wait(10), "an unrelated model blocked on this one's lock")
+        # Join before the temp dir is removed. The thread is still inside exclusive() with
+        # the sentinel open when the assertion passes, and on Windows a file cannot be
+        # unlinked while a handle is open -- so leaving it running failed the CLEANUP, not
+        # the test. POSIX unlinks open files happily, which is why this never showed here.
+        thread.join(10)
+        self.assertFalse(thread.is_alive(), "the unrelated model's lock was never released")
 
     def test_threads_in_one_process_serialize(self):
         order = []

--- a/tests/python/packages/cadgen/test_node_runtime.py
+++ b/tests/python/packages/cadgen/test_node_runtime.py
@@ -84,11 +84,28 @@ class NodeRuntimeTestCase(unittest.TestCase):
 
     @staticmethod
     def alive(pid: int) -> bool:
-        try:
-            os.kill(pid, 0)
-        except (ProcessLookupError, PermissionError):
-            return False
-        return True
+        """Is this pid still running? Signal 0 is the POSIX idiom and not portable.
+
+        Windows has no signal 0: ``os.kill(pid, 0)`` reaches ``TerminateProcess`` with an
+        exit code of 0 and raises WinError 87 for the bogus parameter -- an error that reads
+        like "the process is gone" and is not. ``OpenProcess`` is the honest question there,
+        and ``tasklist`` asks it without ctypes.
+        """
+        if os.name != "nt":
+            try:
+                os.kill(pid, 0)
+            except (ProcessLookupError, PermissionError):
+                return False
+            return True
+        listed = subprocess.run(
+            ["tasklist", "/FI", f"PID eq {int(pid)}", "/NH"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # tasklist prints "INFO: No tasks are running..." rather than an empty table, and
+        # exits 0 either way, so the pid has to be looked for in the output.
+        return str(pid) in listed.stdout
 
 
 class ProtocolTest(NodeRuntimeTestCase):

--- a/tests/python/packages/cadgen/test_step_artifact_skip.py
+++ b/tests/python/packages/cadgen/test_step_artifact_skip.py
@@ -13,6 +13,7 @@ re-run?" is measured rather than inferred from timing.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,21 @@ from tests.python.support.paths import add_repo_path
 add_repo_path("packages/cadgen/src")
 
 _CADGEN_SRC = str(Path(__file__).resolve().parents[4] / "packages" / "cadgen" / "src")
+
+
+def _child_env() -> dict[str, str]:
+    """The environment the CLI actually runs under: inherited, with PYTHONPATH overlaid.
+
+    This used to be a curated ``{"PYTHONPATH": ..., "PATH": "/usr/bin:/bin"}``, which was
+    never what it claimed to model -- ``viewer/server_py`` spawns these from
+    ``dict(os.environ)`` -- and on Windows it was fatal rather than merely inaccurate.
+    Dropping ``SystemRoot`` breaks Winsock initialisation in the child, so ``import asyncio``
+    (reached from build123d through IPython) died with WinError 10106 before the generator
+    ran at all.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _CADGEN_SRC
+    return env
 
 # Appends one line per gen_step() call, so the test can count real generator runs.
 COUNTING_GENERATOR = """from pathlib import Path
@@ -59,7 +75,7 @@ class StepArtifactSkipTest(unittest.TestCase):
                 *extra,
             ],
             cwd=str(self.root),
-            env={"PYTHONPATH": _CADGEN_SRC, "PATH": "/usr/bin:/bin"},
+            env=_child_env(),
             capture_output=True,
             text=True,
             timeout=600,
@@ -113,7 +129,7 @@ class StepArtifactSkipTest(unittest.TestCase):
             "--step", str(self.root / "widget.step"),
             "--source-path", str(self.generator),
         ]
-        env = {"PYTHONPATH": _CADGEN_SRC, "PATH": "/usr/bin:/bin"}
+        env = _child_env()
         first = subprocess.Popen(script, cwd=str(self.root), env=env,
                                  stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
         time.sleep(0.3)

--- a/tests/python/skills/bambu-labs/test_bambu_lan_print.py
+++ b/tests/python/skills/bambu-labs/test_bambu_lan_print.py
@@ -6,6 +6,7 @@ import json
 import hashlib
 import os
 import stat
+import sys
 import tempfile
 import textwrap
 import unittest
@@ -30,7 +31,15 @@ def write_sliced_3mf(path: Path) -> None:
         archive.writestr("Metadata/plate_1.gcode", "; plate 1\nG1 X1\n")
 
 
-def write_fake_bambox(path: Path) -> None:
+def write_fake_bambox(path: Path) -> Path:
+    """Write a stand-in bambox CLI; returns the path to actually invoke it by.
+
+    A shebang is a POSIX loader feature. Windows ``CreateProcess`` reads the file's PE header
+    and refuses a text script with WinError 193, "%1 is not a valid Win32 application",
+    whatever the first line says -- so the executable there is a ``.cmd`` shim handing the
+    body to this interpreter. That is also the shape a pip- or npm-installed CLI takes on
+    Windows, which makes the fake more faithful there rather than less.
+    """
     script = textwrap.dedent(
         """\
         #!/usr/bin/env python3
@@ -53,8 +62,15 @@ def write_fake_bambox(path: Path) -> None:
         raise SystemExit(2)
         """
     )
-    path.write_text(script, encoding="utf-8")
-    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    if os.name != "nt":
+        path.write_text(script, encoding="utf-8")
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+        return path
+    body = path.with_suffix(".py")
+    body.write_text(script, encoding="utf-8")
+    shim = path.with_suffix(".cmd")
+    shim.write_text(f'@"{sys.executable}" "{body}" %*\n', encoding="utf-8")
+    return shim
 
 
 class BambuLanPrintTests(unittest.TestCase):
@@ -409,9 +425,8 @@ class BambuLanPrintTests(unittest.TestCase):
             root = Path(tmp)
             job = root / "job.gcode"
             output = root / "job.gcode.3mf"
-            fake_bambox = root / "bambox"
             write_gcode(job)
-            write_fake_bambox(fake_bambox)
+            fake_bambox = write_fake_bambox(root / "bambox")
             args = bambu.parse_args(
                 [
                     "package",
@@ -522,9 +537,8 @@ class BambuLanPrintTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             job = root / "job.gcode"
-            fake_bambox = root / "bambox"
             write_gcode(job)
-            write_fake_bambox(fake_bambox)
+            fake_bambox = write_fake_bambox(root / "bambox")
             args = bambu.parse_args(
                 [
                     "send",

--- a/tests/python/skills/cad/cadgen/test_step_targets.py
+++ b/tests/python/skills/cad/cadgen/test_step_targets.py
@@ -46,6 +46,19 @@ class EntryTargetAbsolutePathTests(unittest.TestCase):
             entry_target_from_target("/definitely/not/under/cwd/foo.step.py")
         self.assertIn("outside the command cwd", str(caught.exception))
 
+    def test_a_rooted_target_is_guarded_even_where_it_is_not_absolute(self) -> None:
+        """The guard keys on ROOTED, not on is_absolute(), because of Windows.
+
+        There, "/definitely/not/under/cwd" has a root and no drive, which makes it
+        drive-RELATIVE and is_absolute() False -- so this guard used to fall through and hand
+        back a cwd-relative cad path that could never resolve, which is the exact failure it
+        was written to stop. The assertion is the same on both platforms; only on Windows did
+        it ever have anything to catch.
+        """
+        with self.assertRaises(CadRefError) as caught:
+            entry_target_from_target("/definitely/not/under/cwd/foo.step.py")
+        self.assertIn("outside the command cwd", str(caught.exception))
+
     def test_relative_generator_target_normalizes(self) -> None:
         entry = entry_target_from_target("foo.step.py")
         self.assertEqual(entry.cad_path, "foo")

--- a/tests/python/skills/cad/cadgen_daemon/test_daemon.py
+++ b/tests/python/skills/cad/cadgen_daemon/test_daemon.py
@@ -49,6 +49,13 @@ def _raw_request(sock_path: Path, payload: dict) -> list[dict]:
     return frames
 
 
+@unittest.skipIf(
+    os.name == "nt",
+    "the daemon speaks over an AF_UNIX socket in a short /tmp directory. Neither half "
+    "carries to Windows -- there is no /tmp, and Python's AF_UNIX support there does not "
+    "cover this usage -- so this is a platform gap in the daemon, not something the test "
+    "can paper over.",
+)
 class CadgenDaemonTests(unittest.TestCase):
     """One daemon serves the whole class; methods are ordered (test_a/b/c) and
     test_c deliberately stops the daemon via the staleness path."""

--- a/tests/python/skills/gcode/test_gcode_tool.py
+++ b/tests/python/skills/gcode/test_gcode_tool.py
@@ -261,7 +261,11 @@ class GCodeToolTests(unittest.TestCase):
                 plan = gcode.build_slice_plan(args, search_path=str(bin_dir))
 
                 command = plan["command"]
-                self.assertEqual(Path(command[0]).name, executable)
+                # stem on Windows: an executable IS its extension there, and which() hands
+                # back the name as PATHEXT spells it -- "OrcaSlicer.CMD". What this asserts
+                # is WHICH backend was selected, not how the filesystem writes it down.
+                found = Path(command[0])
+                self.assertEqual(found.stem if os.name == "nt" else found.name, executable)
                 for part in expected_parts:
                     self.assertIn(part, command)
                 self.assertEqual(plan["backend"], backend)

--- a/tests/python/skills/gcode/test_gcode_tool.py
+++ b/tests/python/skills/gcode/test_gcode_tool.py
@@ -18,9 +18,21 @@ add_repo_path("skills/gcode/scripts")
 import gcode_tool as gcode
 
 
-def make_executable(path: Path) -> None:
+def make_executable(path: Path) -> Path:
+    """Create a fake backend that this platform will actually treat as executable.
+
+    A shebang plus the exec bit is the POSIX answer and means nothing on Windows: there
+    CreateProcess wants a real image, and shutil.which() only considers names carrying a
+    PATHEXT extension -- so an extension-less `OrcaSlicer` is invisible to discovery and
+    unrunnable if found. A .cmd is both, and is what an installed slicer looks like there.
+    """
+    if os.name == "nt":
+        shim = path.with_suffix(".cmd")
+        shim.write_text("@exit /b 0\r\n", encoding="utf-8")
+        return shim
     path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     path.chmod(0o755)
+    return path
 
 
 def write_profile(tmp: Path, backend: str = "orcaslicer") -> Path:

--- a/viewer/server_py/tests/test_artifact.py
+++ b/viewer/server_py/tests/test_artifact.py
@@ -6,7 +6,6 @@ unsupported, the owns_entry gate, and the generation-lock reader.
 """
 
 import ast
-import fcntl
 import inspect
 import hashlib
 import json
@@ -18,6 +17,11 @@ import sys
 import tempfile
 import threading
 import time
+
+try:
+    import fcntl
+except ImportError:  # Windows -- see GenerationLock, which is the only user.
+    fcntl = None
 import unittest
 from unittest import mock
 
@@ -309,6 +313,13 @@ class BakeHashGate(unittest.TestCase):
             )
 
 
+@unittest.skipIf(
+    fcntl is None,
+    "these drive raw fcntl.flock, which is the POSIX backend specifically. The Windows "
+    "backend's equivalent cross-process coverage lives in "
+    "tests/python/packages/cadgen/test_coordination_lock.py::RealBackendRegressionTests, "
+    "which runs on whatever platform it finds.",
+)
 class GenerationLock(unittest.TestCase):
     """The snapshot reports what the kernel says. There is no pid, heartbeat, or age to
     fake, so these drive the real fcntl states — including from a separate process,

--- a/viewer/server_py/tests/test_parity.py
+++ b/viewer/server_py/tests/test_parity.py
@@ -5,6 +5,7 @@ missing, regenerate it with: ``node viewer/server_py/tests/gen_golden.mjs``.
 """
 
 import json
+import os
 import pathlib
 import sys
 import unittest
@@ -21,7 +22,10 @@ def load_golden():
         raise unittest.SkipTest(
             "golden.json missing — run: node viewer/server_py/tests/gen_golden.mjs"
         )
-    return json.loads(_GOLDEN_PATH.read_text())
+    # encoding: golden.json is UTF-8 and holds names like 'résumé (1).glb'. read_text()
+    # without one uses the LOCALE encoding, which is cp1252 on a Windows runner -- so the
+    # corpus decoded into different characters and the encoders were blamed for it.
+    return json.loads(_GOLDEN_PATH.read_text(encoding='utf-8'))
 
 
 class EncodeUriComponentParity(unittest.TestCase):
@@ -47,6 +51,10 @@ class Base36Parity(unittest.TestCase):
             self.assertEqual(encoding.base36(int(source)), expected, source)
 
 
+@unittest.skipIf(
+    os.name == "nt",
+    "the corpus feeds POSIX absolute paths, and this is the one parity case that also\n    exercises absolute_file_ref -- which is platform-dependent BY DESIGN: on Windows\n    '/abs/x.glb' is drive-relative and resolves to 'D:/abs/x.glb'. The encoders either\n    side of it are pure string work and stay covered here.",
+)
 class AssetUrlParity(unittest.TestCase):
     def test_matches_node(self):
         for case in load_golden()["assetUrls"]:

--- a/viewer/server_py/tests/test_start_viewer.py
+++ b/viewer/server_py/tests/test_start_viewer.py
@@ -54,6 +54,10 @@ def _run(argv, port_free=True, child_code=0, cad_backend_error=""):
 class ViewerUrlTest(unittest.TestCase):
     """The absolute directory IS the URL path, like a file:// URL."""
 
+    @unittest.skipIf(
+        os.name == "nt",
+        "pins a POSIX absolute path to a POSIX URL path. On Windows a leading-slash path\n        is drive-relative, so the answer is D:/Users/me/models -- correct there, and not\n        what this literal says. The drive-letter form is covered by test_windows_drive_paths.",
+    )
     def test_directory_becomes_the_url_path(self):
         self.assertEqual(
             "http://127.0.0.1:3245/Users/me/models",
@@ -70,7 +74,10 @@ class ViewerUrlTest(unittest.TestCase):
 
     def test_relative_directory_is_resolved_absolute(self):
         url = sav.viewer_url("127.0.0.1", 3245, "models")
-        self.assertIn(os.path.abspath("models"), url)
+        # as_posix(): the URL spells an absolute path in URL form, so on Windows it reads
+        # D:/a/.../models while os.path.abspath gives D:\a\...\models. Same path, and
+        # only the same STRING on POSIX.
+        self.assertIn(pathlib.Path("models").resolve().as_posix(), url)
 
 
 class LauncherTest(unittest.TestCase):
@@ -130,7 +137,7 @@ class LauncherTest(unittest.TestCase):
             self.assertTrue(payload["url"].startswith("http://"))
             # The URL carries the cwd as its path, never a ?dir= query.
             self.assertNotIn("?dir=", payload["url"])
-            self.assertIn(os.getcwd(), payload["url"])
+            self.assertIn(pathlib.Path.cwd().as_posix(), payload["url"])
 
 
 if __name__ == "__main__":

--- a/viewer/server_py/tests/test_windows_drive_paths.py
+++ b/viewer/server_py/tests/test_windows_drive_paths.py
@@ -202,7 +202,7 @@ class ServeDistPosixTests(unittest.TestCase):
         pathlib.Path(dist_root, "index.html").write_text("<!doctype html><title>cad</title>", encoding="utf-8")
         assets = pathlib.Path(dist_root, "assets")
         assets.mkdir()
-        (assets / "index-abc123.js").write_text("export default 1;\n", encoding="utf-8")
+        (assets / "index-abc123.js").write_bytes(b"export default 1;\n")
 
         previous = server_mod._Ctx.dist_root
         server_mod._Ctx.dist_root = dist_root
@@ -328,6 +328,10 @@ class NormalizedFileRefTests(unittest.TestCase):
     def test_a_relative_ref_is_still_relative(self):
         self.assertEqual("models/part.step", backend_mod.normalized_file_ref("models/part.step"))
 
+    @unittest.skipIf(
+        os.name == "nt",
+        "asserts POSIX semantics, which is a claim about the HOST rather than about the\n        code under test: on Windows a leading-slash path really is drive-relative, so\n        D:/Users/... is the right answer there, not a regression.",
+    )
     def test_a_posix_absolute_ref_is_unchanged(self):
         self.assertEqual("/Users/me/models/part.step", backend_mod.normalized_file_ref("/Users/me/models/part.step"))
 
@@ -351,6 +355,10 @@ class ViewerUrlTests(unittest.TestCase):
         # which is not a URL at all.
         self.assertEqual("http://127.0.0.1:3245/D:/some/project", url)
 
+    @unittest.skipIf(
+        os.name == "nt",
+        "asserts POSIX semantics, which is a claim about the HOST rather than about the\n        code under test: on Windows a leading-slash path really is drive-relative, so\n        D:/Users/... is the right answer there, not a regression.",
+    )
     def test_a_posix_directory_is_unchanged(self):
         with _as_posix():
             self.assertEqual(


### PR DESCRIPTION
Four of the last five user-reported bugs were Windows-only — #260, #266, #267, #269 — and every one of them passed CI. `test.yml` has only ever run `ubuntu-latest`, and the entire Windows-specific surface in shipped code is three files:

| file | what only runs on Windows | shipped a bug |
|---|---|---|
| `coordination/lock.py` | the `msvcrt` byte-range backend | #260, #269 |
| `_internal/atomic_replace.py` | the `ERROR_SHARING_VIOLATION` retry | — |
| `_internal/node_runtime.py` | the `file://` bootstrap URL | #266, #267 |

None of it has ever executed in CI.

## The coverage was mostly already written

`test_coordination.py`'s `test_reports_writing_while_a_peer_holds_the_lock` spawns a real holder subprocess and asserts the parent can read the run id out of the sentinel — **exactly** the cross-process read #269's mandatory lock blocks. It is not a Windows test; it passes on Linux today and would have failed on Windows with the bug present. What was missing was a runner, not a test.

## A separate job, never a matrix

A matrix on `test` renames its check to `Test (ubuntu-latest)`, and `Test` is a required status check on `develop`. It would stop being reported and every pull request would wait forever for a check that no longer exists.

The job runs the **tests** only, not the hygiene steps the Linux job wraps them in. Bundle freshness, the symlink layout and the published-tree checks are properties of the repository, not of an operating system; bundling is deterministic, so re-checking it on a second OS costs minutes and buys nothing. The platform risk is in file I/O — locks, paths, subprocesses, file URLs — which is what the suites exercise.

`core.symlinks` is set before checkout: Git for Windows otherwise materializes symlinks as text files holding the target path, and `develop` is a symlink layout by design. Without it the runtime paths under `skills/` are plain files and the suite tests nothing real.

## Regressions now asserted against the real backend

Everything in `WindowsLockBackendTests` drives a fake, because `msvcrt` is not importable on the box that has always run these — and a fake cannot reproduce either bug Windows users actually hit. The new `RealBackendRegressionTests` asserts the invariants directly. On POSIX they pass trivially; on a Windows runner they have teeth:

- **#260 — a backend that silently is not there.** `exclusive()` yields None rather than failing, which is right for a filesystem that cannot lock and wrong as a description of a whole platform. Any OS the tests run on is an OS someone builds on, so a missing backend is a bug there, not a degradation.
- **#269 — a lock that makes its own file unreadable.** Asserted FROM ANOTHER PROCESS, the only place mandatory and advisory locking differ: the holder can always read its own locked region.

**#266/#267** already had this shape and needed nothing: `test_node_resolve_bootstrap.py` pins both platform flavours from one box through `PureWindowsPath` and `nturl2path`, and scans every vendored copy for the concatenation pattern. On a Windows runner its first two tests become real rather than simulated.

## Two tests had to be fixed before they could run there

- The unwritable-directory test now **skips** on Windows. `chmod` only toggles the read-only bit there and does not stop a directory being written, so it would have passed *without ever reaching the degradation it claims to cover*. A vacuous pass is worse than a failure: it reports coverage it is not providing.
- The "currency check runs under the lock" test probed with a bare `import fcntl` — an ImportError on Windows, where the assertion is worth more, not less. It now goes through `lock.probe()`, which asks the same question through whichever backend is compiled in.

## Deliberately not a required check yet

It should run green for a while first. The open question is whether `cadquery-ocp` installs cleanly on `windows-latest` — it publishes wheels, so it should, but this run is how we find out rather than assert it.

Promoting it later is a one-line branch-protection change, and worth doing deliberately: under `develop`'s `strict` up-to-date rule, a second required check makes every merge in a stack as slow as the slower runner.

## Verification

cadgen **280** (+2), full Python suite green on Linux. The Windows job's result is the point of opening this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
