### PR TITLE
Size the worker pool to the machine, and wait at the cap

### DIFF
--- a/packages/cadgen/src/cadgen/daemon/pool.py
+++ b/packages/cadgen/src/cadgen/daemon/pool.py
@@ -6,12 +6,21 @@ The dispatch rule, which is the whole design:
 2. All busy and the pool is below its cap — spawn one and wait for it. That caller pays
    roughly one OCP import, the same as running cold, but the worker PERSISTS, so a burst
    converges to warm instead of paying the import every time.
-3. At the cap — return None and let the caller run cold. A bounded pool that queues would
-   be worse than no pool for parallel work, which is exactly the trap the single-process
-   daemon fell into.
+3. At the cap — wait a short while for one to free, then run cold if none does.
 
-Sizing: a warm worker is ~274 MB resident, so the default cap is deliberately small.
-Workers are spawned lazily, so a sequential user still only ever starts one.
+Rule 3 used to give up immediately, on the grounds that a queue is what made the old
+single-process daemon worse than useless. That lesson was real but it was about a cap of
+ONE: with a pool, refusing to wait at all means the cap bounds nothing. Overflow still
+runs, so N callers produce N OCP processes no matter what the cap says, and the machine
+can be driven into swap by a burst the pool was supposed to govern. A bounded wait puts
+the ceiling back without reintroducing the serialisation: nobody blocks indefinitely, and
+the cold path is still there the moment waiting stops paying.
+
+The wait is bounded by roughly what running cold would have cost, so waiting is never the
+slower choice by much. Jobs are usually short relative to an OCP import, so nearly every
+wait ends in a warm worker rather than at the deadline.
+
+Sizing follows the machine rather than a constant. See max_workers().
 """
 
 from __future__ import annotations
@@ -24,20 +33,148 @@ import sys
 import threading
 import time
 
-DEFAULT_MAX_WORKERS = 4
 DEFAULT_RECYCLE_AFTER = 200
 DEFAULT_WORKER_IDLE_SECONDS = 300.0
 _SPAWN_TIMEOUT_SECONDS = 120.0
 
+# A warm worker measures ~281 MB resident on macOS/arm64 once it has served a job (the OCP
+# import is lazy, so a freshly spawned one is ~25 MB until then). Adding a SECOND worker
+# costs the system only ~50 MB, because OCP's mapped libraries are shared -- so summing RSS
+# overstates the real cost by roughly 5x.
+#
+# The conservative figure is used anyway, deliberately. It only binds on small or
+# containerised machines, which is exactly where over-spawning hurts and where the shared
+# pages are least likely to save you; on anything roomy the CPU bound below decides first,
+# so the pessimism costs nothing there.
+WORKER_MEMORY_BYTES = 300 * 1024 * 1024
+# Half the box. The rest is for the OS, the caller, the browser the Viewer runs in, and the
+# geometry a build allocates on top of a worker's resting footprint.
+MEMORY_FRACTION = 0.5
+# Past this, more warm processes stop being the bottleneck and start being a liability to
+# supervise. Nothing subtle -- just a refusal to let a huge machine spawn absurdly.
+MAX_WORKERS_CEILING = 32
+# Kept for machines where neither memory nor CPU can be read.
+FALLBACK_MAX_WORKERS = 4
+
+# How long a caller waits at the cap before running cold. A first job's OCP import measured
+# 0.54 s with a warm page cache, so this is a few times the cost of the thing the caller
+# would do instead -- long enough that a short job ahead of it frees a worker, short enough
+# that waiting never becomes the expensive option. Cold-cache imports are slower, which is
+# an argument for the headroom rather than against the bound.
+DEFAULT_WAIT_SECONDS = 2.0
+
+
+def _env_int(name: str) -> int | None:
+    try:
+        value = int(os.environ.get(name, ""))
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def _container_memory_limit() -> int | None:
+    """A cgroup memory cap, which is the real limit inside a container.
+
+    Physical RAM is the HOST's there. A 2 GB container on a 128 GB host that sizes itself
+    against 128 GB gets OOM-killed, which is the shape of bug the JVM shipped for years
+    before UseContainerSupport.
+    """
+    for path, unlimited in (
+        ("/sys/fs/cgroup/memory.max", {"max"}),                  # cgroup v2
+        ("/sys/fs/cgroup/memory/memory.limit_in_bytes", set()),  # cgroup v1
+    ):
+        try:
+            with open(path, encoding="utf-8") as handle:
+                raw = handle.read().strip()
+        except OSError:
+            continue
+        if raw in unlimited:
+            continue
+        try:
+            value = int(raw)
+        except ValueError:
+            continue
+        # v1 spells "unlimited" as a huge sentinel rather than a word.
+        if 0 < value < (1 << 62):
+            return value
+    return None
+
+
+def _physical_memory() -> int | None:
+    """Total RAM, or None where it cannot be read.
+
+    TOTAL, never "available": available moves with the page cache and whatever else is
+    running, so sizing on it would give the same command a different cap from one run to
+    the next and make a report irreproducible. The fraction above is what leaves headroom.
+    """
+    try:
+        return os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE")
+    except (ValueError, OSError, AttributeError):
+        pass
+    if sys.platform == "win32":  # pragma: no cover - no daemon on Windows yet
+        import ctypes
+
+        class _MemoryStatusEx(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_ulonglong),
+                ("ullAvailPhys", ctypes.c_ulonglong),
+                ("ullTotalPageFile", ctypes.c_ulonglong),
+                ("ullAvailPageFile", ctypes.c_ulonglong),
+                ("ullTotalVirtual", ctypes.c_ulonglong),
+                ("ullAvailVirtual", ctypes.c_ulonglong),
+                ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+            ]
+
+        status = _MemoryStatusEx()
+        status.dwLength = ctypes.sizeof(_MemoryStatusEx)
+        if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(status)):
+            return int(status.ullTotalPhys)
+    return None
+
+
+def memory_budget() -> int | None:
+    """Bytes this pool may hold in warm workers, or None if RAM cannot be read."""
+    physical = _physical_memory()
+    limit = _container_memory_limit()
+    if limit is not None:
+        physical = limit if physical is None else min(physical, limit)
+    return None if physical is None else int(physical * MEMORY_FRACTION)
+
 
 def max_workers() -> int:
-    try:
-        configured = int(os.environ.get("CADGEN_DAEMON_MAX_WORKERS", ""))
-    except ValueError:
-        configured = 0
-    if configured > 0:
+    """How many warm workers this machine should hold.
+
+    Memory says what can be held, CPUs say what can usefully run at once, and the smaller
+    wins. The flat default this replaced scaled DOWN on small machines but never up, so a
+    64 GB workstation and an 8 GB laptop were both given four -- half the cores idle on one,
+    and no way to tell without reading the source.
+    """
+    configured = _env_int("CADGEN_DAEMON_MAX_WORKERS")
+    if configured is not None:
         return configured
-    return max(1, min(DEFAULT_MAX_WORKERS, (os.cpu_count() or 4) - 2))
+    by_cpu = (os.cpu_count() or FALLBACK_MAX_WORKERS) - 2
+    budget = memory_budget()
+    if budget is None:
+        return max(1, min(FALLBACK_MAX_WORKERS, by_cpu))
+    by_memory = budget // WORKER_MEMORY_BYTES
+    return max(1, min(by_memory, by_cpu, MAX_WORKERS_CEILING))
+
+
+def wait_seconds() -> float:
+    """Seconds to wait at the cap before telling the caller to run cold.
+
+    Zero restores the old refuse-immediately behaviour, for anyone who wants it back.
+    """
+    raw = os.environ.get("CADGEN_DAEMON_WAIT", "").strip()
+    if not raw:
+        return DEFAULT_WAIT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_WAIT_SECONDS
+    return max(0.0, value)
 
 
 def _recycle_after() -> int:
@@ -139,38 +276,64 @@ class Pool:
     """Owns every worker. Thread-safe; one lock, held only around bookkeeping."""
 
     def __init__(self) -> None:
-        self._lock = threading.Lock()
+        # A Condition, not a Lock: a caller at the cap sleeps here until release() or a
+        # reaper frees a slot, instead of being turned away the moment the pool is full.
+        self._cv = threading.Condition()
         self._workers: list[Worker] = []
+        # Spawns in flight. Counted against the cap so two callers arriving together
+        # cannot both see room for the last worker and both take it -- without this the
+        # pool can exceed its own ceiling, which is the one thing it is for.
+        self._pending = 0
         self.cold_overflows = 0
         self.crashes = 0
         self.recycles = 0
+        self.waits = 0
 
     # --- acquisition -------------------------------------------------------------
     def acquire(self) -> Worker | None:
         """A worker to run one job on, or None meaning "run this cold"."""
-        with self._lock:
-            self._reap_dead_locked()
-            for worker in self._workers:
-                if not worker.busy:
-                    worker.busy = True
-                    return worker
-            if len(self._workers) >= max_workers():
-                self.cold_overflows += 1
-                return None
+        deadline: float | None = None
+        with self._cv:
+            while True:
+                self._reap_dead_locked()
+                for worker in self._workers:
+                    if not worker.busy:
+                        worker.busy = True
+                        return worker
+                if len(self._workers) + self._pending < max_workers():
+                    self._pending += 1
+                    break
+                # At the cap. Wait for someone to finish rather than adding an OCP
+                # process to a machine that is already running as many as it should.
+                if deadline is None:
+                    budget = wait_seconds()
+                    if budget <= 0:
+                        self.cold_overflows += 1
+                        return None
+                    deadline = time.monotonic() + budget
+                    self.waits += 1
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    self.cold_overflows += 1
+                    return None
+                self._cv.wait(remaining)
         # Spawn outside the lock: it costs an OCP import and must not block acquire().
         try:
             worker = Worker()
         except (OSError, WorkerGone):
-            with self._lock:
+            with self._cv:
+                self._pending -= 1
                 self.crashes += 1
+                self._cv.notify()  # the slot this spawn reserved is free again
             return None
-        with self._lock:
+        with self._cv:
+            self._pending -= 1
             worker.busy = True
             self._workers.append(worker)
             return worker
 
     def release(self, worker: Worker, *, healthy: bool = True) -> None:
-        with self._lock:
+        with self._cv:
             worker.busy = False
             worker.last_used = time.monotonic()
             worker.jobs_served += 1
@@ -182,6 +345,10 @@ class Pool:
                 # Bound OCP's memory growth over a long-lived session.
                 self.recycles += 1
                 self._drop_locked(worker)
+            # A worker went idle, or dropping one freed a slot to spawn into. Either way
+            # somebody waiting at the cap can stop waiting; without this they sleep to
+            # their deadline and run cold with an idle worker sitting right there.
+            self._cv.notify()
 
     # --- maintenance -------------------------------------------------------------
     def _drop_locked(self, worker: Worker) -> None:
@@ -196,7 +363,7 @@ class Pool:
 
     def reap_idle(self) -> None:
         """Drop idle workers down to one, so a finished burst returns the memory."""
-        with self._lock:
+        with self._cv:
             self._reap_dead_locked()
             now = time.monotonic()
             idle = [w for w in self._workers if not w.busy and now - w.last_used > DEFAULT_WORKER_IDLE_SECONDS]
@@ -204,15 +371,18 @@ class Pool:
                 if len(self._workers) <= 1:
                     break
                 self._drop_locked(worker)
+            self._cv.notify_all()
 
     def shutdown(self) -> None:
-        with self._lock:
+        with self._cv:
             for worker in list(self._workers):
                 self._drop_locked(worker)
+            # Nobody should still be waiting for a pool that is going away.
+            self._cv.notify_all()
 
     # --- introspection -----------------------------------------------------------
     def snapshot(self) -> dict:
-        with self._lock:
+        with self._cv:
             return {
                 "maxWorkers": max_workers(),
                 "workers": [
@@ -220,6 +390,8 @@ class Pool:
                     for w in self._workers
                 ],
                 "coldOverflows": self.cold_overflows,
+                "waits": self.waits,
+                "waitSeconds": wait_seconds(),
                 "recycles": self.recycles,
                 "crashes": self.crashes,
             }

--- a/packages/cadgen/src/cadgen/daemon/server.py
+++ b/packages/cadgen/src/cadgen/daemon/server.py
@@ -349,9 +349,8 @@ def _handle_request(
 
     worker = _POOL.acquire()
     if worker is None:
-        # Every worker busy and the pool is capped. Queueing here is what made the old
-        # single-process daemon worse than useless for parallel work, so tell the client
-        # to run cold instead.
+        # Capped, and nothing freed up within the wait. acquire() has already spent that
+        # budget, so this really is the point where running cold beats waiting longer.
         _log(f"{tool}: pool at capacity; client runs cold")
         with send_lock:
             _send(conn, {"cold": True})

--- a/skills/cad/references/step-generation.md
+++ b/skills/cad/references/step-generation.md
@@ -132,11 +132,21 @@ CADGEN_WARM=0 python scripts/gen part.step.py   # force a cold in-process run
   OCP itself, so a model that crashes the CAD kernel costs one worker rather than the
   daemon. The first call spawns a worker (paying the import once); later calls run in a
   warm one and stream the CLI's stdout/stderr and exit code back unchanged.
-- **Parallel builds are supported.** A burst spawns workers up to a cap
-  (`CADGEN_DAEMON_MAX_WORKERS`, default `min(4, cores-2)`); beyond that, callers run cold
-  rather than queue. A second burst reuses the first's workers, so repeated parallel work
-  converges to warm. This is a change: the daemon used to hold exactly one job, which is
-  why parallel builders were told to avoid it.
+- **Parallel builds are supported.** A burst spawns workers up to a cap, and a second
+  burst reuses the first's workers, so repeated parallel work converges to warm. This is a
+  change: the daemon used to hold exactly one job, which is why parallel builders were
+  told to avoid it.
+- **The cap follows the machine**: the smaller of what memory allows (half of RAM, or the
+  cgroup limit inside a container, divided by ~300 MB a warm worker holds) and what the
+  cores allow (`cores - 2`), never more than 32. A 64 GB workstation gets 30 where it used
+  to get 4. `CADGEN_DAEMON_MAX_WORKERS` overrides it outright.
+- **At the cap a caller waits briefly**, then runs cold if nothing frees up —
+  `CADGEN_DAEMON_WAIT`, default 2s, and 0 restores the old give-up-immediately behaviour.
+  Jobs are usually short next to an OCP import, so most waits end in a warm worker. The
+  wait is what makes the cap mean anything: without it every overflow caller starts its
+  own OCP process, so the pool bounded nothing.
+- `cadgen daemon status` reports `waits` and `coldOverflows`. Overflows climbing during
+  normal work means the machine is genuinely saturated, not that the cap is too small.
 - Both front doors use it — `scripts/gen` and `cadgen step gen` alike — and so does the
   CAD Viewer, so a terminal build and a viewer build share the same warm processes.
 - The daemon is **per worktree**: the socket is

--- a/tests/python/packages/cadgen/test_daemon_pool.py
+++ b/tests/python/packages/cadgen/test_daemon_pool.py
@@ -171,11 +171,17 @@ class Sizing(unittest.TestCase):
             self.assertEqual(pool_mod.max_workers(), 7)
 
     def test_the_default_leaves_the_machine_room(self):
+        import os as _os
+
         with mock.patch.dict(os.environ, {"CADGEN_DAEMON_MAX_WORKERS": ""}):
             cap = pool_mod.max_workers()
-        # ~274 MB resident each, so the default is deliberately small.
+        # The cap follows the machine now rather than a constant, so the property is that
+        # it leaves headroom -- at least one worker, never more cores than the box has
+        # spare, and never past the ceiling. Which bound binds is per-machine and is
+        # covered against simulated hardware in test_daemon_pool_sizing.
         self.assertGreaterEqual(cap, 1)
-        self.assertLessEqual(cap, pool_mod.DEFAULT_MAX_WORKERS)
+        self.assertLessEqual(cap, pool_mod.MAX_WORKERS_CEILING)
+        self.assertLessEqual(cap, max(1, (_os.cpu_count() or 4) - 2))
 
     def test_a_nonsense_cap_falls_back_rather_than_crashing(self):
         with mock.patch.dict(os.environ, {"CADGEN_DAEMON_MAX_WORKERS": "banana"}):

--- a/tests/python/packages/cadgen/test_daemon_pool_sizing.py
+++ b/tests/python/packages/cadgen/test_daemon_pool_sizing.py
@@ -1,0 +1,190 @@
+"""How big the pool gets, and what happens once it is full.
+
+Two changes are pinned here. The cap follows the machine instead of a constant, so a large
+box stops being handed the same four workers as a laptop. And a caller that arrives at the
+cap waits briefly for a worker instead of being turned away at once -- which is what makes
+the cap a real ceiling, because the old behaviour let every overflow caller start its own
+OCP process and bounded nothing at all.
+
+Machines are simulated rather than detected. These properties have to hold on hardware the
+test runner will never be, and a suite that only checks the box it happens to run on would
+pass everywhere and mean nothing.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+from unittest import mock
+
+from tests.python.support.paths import add_repo_path
+
+add_repo_path("packages", "cadgen", "src")
+
+from cadgen.daemon import pool as pool_mod  # noqa: E402
+
+GB = 1024**3
+
+
+class _FakeWorker:
+    """Stands in for a subprocess: sizing and dispatch are bookkeeping, not OCP."""
+
+    _next_pid = 1000
+
+    def __init__(self) -> None:
+        _FakeWorker._next_pid += 1
+        self.pid = _FakeWorker._next_pid
+        self.busy = False
+        self.jobs_served = 0
+        self.last_used = time.monotonic()
+
+    def alive(self) -> bool:
+        return True
+
+    def kill(self) -> None:
+        pass
+
+
+def sized(*, gb: float | None, cpus: int, cgroup: int | None = None) -> int:
+    with mock.patch.dict("os.environ", {"CADGEN_DAEMON_MAX_WORKERS": ""}, clear=False), \
+            mock.patch.object(pool_mod, "_physical_memory", return_value=None if gb is None else int(gb * GB)), \
+            mock.patch.object(pool_mod, "_container_memory_limit", return_value=cgroup), \
+            mock.patch("os.cpu_count", return_value=cpus):
+        return pool_mod.max_workers()
+
+
+class Sizing(unittest.TestCase):
+    def test_a_big_machine_is_no_longer_capped_at_a_constant(self):
+        # The regression this replaced: 64 GB / 32 cores also got four.
+        self.assertEqual(30, sized(gb=64, cpus=32))
+
+    def test_a_small_laptop_lands_where_it_always_did(self):
+        self.assertEqual(2, sized(gb=8, cpus=4))
+
+    def test_cpus_bind_before_memory_on_a_roomy_machine(self):
+        # 68 GB would hold ~113 workers; 10 cores is the real limit.
+        self.assertEqual(8, sized(gb=68, cpus=10))
+
+    def test_memory_binds_before_cpus_on_a_dense_one(self):
+        # Many cores, little RAM: an 8 GB box budgets 4 GB, which holds 13 workers, well
+        # under the 62 the cores would allow.
+        self.assertEqual(13, sized(gb=8, cpus=64))
+
+    def test_a_container_limit_beats_host_memory(self):
+        # The OOM-kill shape: a small container on a large host.
+        self.assertEqual(3, sized(gb=128, cpus=32, cgroup=2 * GB))
+
+    def test_the_ceiling_holds_on_an_enormous_machine(self):
+        self.assertEqual(pool_mod.MAX_WORKERS_CEILING, sized(gb=1024, cpus=256))
+
+    def test_it_never_returns_zero(self):
+        # A tiny container must still get one worker, not a pool that can never serve.
+        self.assertEqual(1, sized(gb=0.2, cpus=1))
+        self.assertEqual(1, sized(gb=64, cpus=1))
+
+    def test_unreadable_memory_falls_back_rather_than_guessing_big(self):
+        self.assertEqual(pool_mod.FALLBACK_MAX_WORKERS, sized(gb=None, cpus=32))
+
+    def test_an_explicit_setting_wins_over_every_bound(self):
+        with mock.patch.dict("os.environ", {"CADGEN_DAEMON_MAX_WORKERS": "12"}, clear=False):
+            self.assertEqual(12, pool_mod.max_workers())
+
+    def test_a_junk_setting_is_ignored_rather_than_crashing(self):
+        with mock.patch.dict("os.environ", {"CADGEN_DAEMON_MAX_WORKERS": "banana"}, clear=False), \
+                mock.patch.object(pool_mod, "_physical_memory", return_value=8 * GB), \
+                mock.patch.object(pool_mod, "_container_memory_limit", return_value=None), \
+                mock.patch("os.cpu_count", return_value=4):
+            self.assertEqual(2, pool_mod.max_workers())
+
+
+class WaitingAtTheCap(unittest.TestCase):
+    def setUp(self) -> None:
+        patcher = mock.patch.object(pool_mod, "Worker", _FakeWorker)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.pool = pool_mod.Pool()
+        self.addCleanup(self.pool.shutdown)
+
+    def _cap(self, n: int):
+        return mock.patch.object(pool_mod, "max_workers", return_value=n)
+
+    def test_a_freed_worker_is_handed_to_the_waiter(self):
+        with self._cap(1):
+            held = self.pool.acquire()
+            self.assertIsNotNone(held)
+
+            got: list = []
+            waiter = threading.Thread(target=lambda: got.append(self.pool.acquire()))
+            waiter.start()
+            time.sleep(0.1)                      # let it reach the wait
+            self.assertEqual([], got, "it should still be waiting, not already cold")
+            self.pool.release(held)
+            waiter.join(timeout=5)
+
+        self.assertIs(got[0], held, "the waiter should get the warm worker, not None")
+        self.assertEqual(0, self.pool.cold_overflows)
+        self.assertEqual(1, self.pool.waits)
+
+    def test_it_gives_up_and_runs_cold_when_nothing_frees(self):
+        with self._cap(1), mock.patch.object(pool_mod, "wait_seconds", return_value=0.2):
+            self.pool.acquire()
+            started = time.monotonic()
+            self.assertIsNone(self.pool.acquire())
+            waited = time.monotonic() - started
+
+        self.assertGreaterEqual(waited, 0.2, "it must actually wait before giving up")
+        self.assertLess(waited, 3.0, "the wait is bounded, not a queue")
+        self.assertEqual(1, self.pool.cold_overflows)
+
+    def test_zero_restores_the_old_refuse_immediately_behaviour(self):
+        with self._cap(1), mock.patch.object(pool_mod, "wait_seconds", return_value=0.0):
+            self.pool.acquire()
+            started = time.monotonic()
+            self.assertIsNone(self.pool.acquire())
+            self.assertLess(time.monotonic() - started, 0.1)
+        self.assertEqual(0, self.pool.waits)
+
+    def test_the_cap_holds_when_callers_arrive_together(self):
+        # Spawning happens outside the lock, so without reserving the slot first two
+        # threads could both see room for the last worker and both take it.
+        with self._cap(3), mock.patch.object(pool_mod, "wait_seconds", return_value=0.0):
+            got: list = []
+            lock = threading.Lock()
+
+            def grab():
+                worker = self.pool.acquire()
+                with lock:
+                    got.append(worker)
+
+            threads = [threading.Thread(target=grab) for _ in range(12)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+
+        workers = [w for w in got if w is not None]
+        self.assertEqual(3, len(workers), "the pool exceeded its own cap")
+        self.assertEqual(3, len({id(w) for w in workers}), "one worker served two callers")
+
+    def test_a_burst_below_the_cap_still_spawns_without_waiting(self):
+        # Rule 2 is unchanged: room in the pool means spawn, never wait.
+        with self._cap(4), mock.patch.object(pool_mod, "wait_seconds", return_value=30.0):
+            started = time.monotonic()
+            workers = [self.pool.acquire() for _ in range(4)]
+            self.assertLess(time.monotonic() - started, 1.0)
+        self.assertEqual(4, len([w for w in workers if w is not None]))
+        self.assertEqual(0, self.pool.waits)
+
+    def test_status_reports_the_wait_budget_and_how_often_it_was_used(self):
+        with self._cap(1), mock.patch.object(pool_mod, "wait_seconds", return_value=0.05):
+            self.pool.acquire()
+            self.pool.acquire()
+        snapshot = self.pool.snapshot()
+        self.assertEqual(1, snapshot["waits"])
+        self.assertEqual(1, snapshot["coldOverflows"])
+        self.assertIn("waitSeconds", snapshot)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #273, stacked on `release/0.5.0` because the pool only exists there.

Two changes, from one observation: the cap was not doing what its docstring said.

## Sizing

`min(4, cores-2)` scaled down on small machines but never up — a 4-core laptop got 2, and a 64 GB/32-core workstation also got 4. The cap is now the smaller of what memory allows (half of RAM, or the cgroup limit so a container is not sized against its host, over a worker's footprint) and what the cores allow (`cores-2`), under a ceiling of 32.

| machine | before | after |
|---|---|---|
| 8 GB laptop, 4 cores | 2 | 2 |
| 68 GB / 10 cores | 4 | 8 |
| 64 GB workstation, 32 cores | 4 | 30 |
| 2 GB container on a 128 GB host | 4 | 3 |
| GitHub runner, 7 GB / 2 cpu | 1 | 1 |

**Measured, not assumed** (macOS/arm64): a warm worker is ~281 MB resident, confirming the ~274 MB the code claimed — but a *second* worker costs the system only ~50 MB, because OCP's libraries are mapped shared. Three warm workers sum to 842 MB of RSS while the machine gives up ~200 MB, so summing RSS overstates the cost about 5×. The pessimistic figure is used anyway: memory only binds on small or containerised machines, which is where over-spawning actually hurts, and on a roomy machine the CPU bound decides first.

## Waiting at the cap

`acquire()` gave up immediately and the caller ran cold. That was justified by the old single-process daemon, whose queue made parallel work worse than useless — but *that* daemon's cap was one, and the lesson was don't serialise, not never wait.

Refusing to wait means the cap bounds nothing. Overflow still runs, so N callers produce N OCP processes however small the cap is, and a burst can drive the machine into swap that the pool was supposed to govern.

A caller at the cap now waits up to `CADGEN_DAEMON_WAIT` (2s, 0 restores the old behaviour), then runs cold. The budget is a few times a measured OCP import (0.54s, warm cache), so waiting is never much worse than what the caller would do instead, and jobs are short enough that most waits end warm.

Two supporting fixes this needed:

- The lock becomes a `Condition`, so release / idle-reap / shutdown wake a waiter. Without it a waiter sleeps to its deadline with an idle worker sitting beside it.
- In-flight spawns are counted against the cap. Spawning happens outside the lock, so two callers could each see room for the last worker and both take it — putting the pool over the ceiling it exists to enforce. There is a concurrency test for this.

`daemon status` now reports `waits` and the wait budget beside `coldOverflows`, which changes meaning: it says the machine is saturated, not that the cap is small.

## Verification

`scripts/test/test.sh` green (967 cadjs, 347 viewer, full Python suite, 93 policy), plus `bundle.sh --check`, `check-version.sh`, `test-global.sh`. 16 new sizing/waiting tests against simulated machines, and the behaviour was checked end-to-end with real worker subprocesses: a waiter is handed the freed worker the moment it is released, and gives up at its deadline when nothing frees.

**No CI on this PR** — `test.yml` only triggers on PRs to `develop`. Merging it into `release/0.5.0` makes #273 exercise it on both Linux and Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
