### PR TITLE
cadgen: resolve an assembly's instance-tree refs, not just its composed compound

### DIFF
--- a/packages/cadgen/src/cadgen/assembly_lookup.py
+++ b/packages/cadgen/src/cadgen/assembly_lookup.py
@@ -289,21 +289,24 @@ def _component_index(package_dir: Path, component: str, cache: dict[str, Any]) -
     return built
 
 
-def _entity_id(occurrence_id: str, local_id: object, kind: str, ordinal: object) -> str:
+def _entity_id(occurrence_id: str, local_id: object, kind: str, ordinal: object) -> str | None:
     """``o1.f19`` inside a component becomes ``o1.12.f19`` in the assembly.
 
     Prefers the row's own ordinal over re-parsing its id, so the assembly ref keeps the number
     the component's own namespace uses -- which is what makes a translated ref checkable by hand
     against the part file, the exact step users were doing manually.
+
+    None when neither an ordinal nor a suffix is available. Naming it ``o1.12.f`` instead would
+    be a selector that cannot be parsed AND that every unnamed row of that component would
+    share, so the first would silently stand in for the rest.
     """
     if ordinal is not None:
         try:
             return f"{occurrence_id}.{kind}{int(ordinal)}"
         except (TypeError, ValueError):
             pass
-    tail = str(local_id or "")
-    _, _, suffix = tail.rpartition(".")
-    return f"{occurrence_id}.{suffix}" if suffix else f"{occurrence_id}.{kind}"
+    _, _, suffix = str(local_id or "").rpartition(".")
+    return f"{occurrence_id}.{suffix}" if suffix else None
 
 
 def _rebase(row: dict, field: str, offset: int) -> None:
@@ -388,11 +391,15 @@ def merge_assembly_entities(
         shape_id_map: dict[str, str] = {}
         for row in component_index.shapes:
             new_id = _entity_id(occurrence_id, row.get("id"), "s", row.get("ordinal"))
-            shape_id_map[str(row.get("id"))] = new_id
+            if new_id is not None:
+                shape_id_map[str(row.get("id"))] = new_id
 
         for row in component_index.shapes:
+            new_id = shape_id_map.get(str(row.get("id")))
+            if new_id is None:
+                continue
             placed = _place_entity_row(matrix, row)
-            placed["id"] = shape_id_map[str(row.get("id"))]
+            placed["id"] = new_id
             placed["occurrenceId"] = occurrence_id
             _rebase(placed, "faceStart", face_offset)
             _rebase(placed, "edgeStart", edge_offset)
@@ -400,8 +407,11 @@ def merge_assembly_entities(
             shape_by_id.setdefault(str(placed["id"]), placed)
             added += 1
         for row in component_index.faces:
+            new_id = _entity_id(occurrence_id, row.get("id"), "f", row.get("ordinal"))
+            if new_id is None:
+                continue
             placed = _place_entity_row(matrix, row)
-            placed["id"] = _entity_id(occurrence_id, row.get("id"), "f", row.get("ordinal"))
+            placed["id"] = new_id
             placed["occurrenceId"] = occurrence_id
             if placed.get("shapeId") is not None:
                 placed["shapeId"] = shape_id_map.get(str(placed["shapeId"]), placed["shapeId"])
@@ -412,8 +422,11 @@ def merge_assembly_entities(
             face_by_id.setdefault(str(placed["id"]), placed)
             added += 1
         for row in component_index.edges:
+            new_id = _entity_id(occurrence_id, row.get("id"), "e", row.get("ordinal"))
+            if new_id is None:
+                continue
             placed = _place_entity_row(matrix, row)
-            placed["id"] = _entity_id(occurrence_id, row.get("id"), "e", row.get("ordinal"))
+            placed["id"] = new_id
             placed["occurrenceId"] = occurrence_id
             if placed.get("shapeId") is not None:
                 placed["shapeId"] = shape_id_map.get(str(placed["shapeId"]), placed["shapeId"])
@@ -425,8 +438,11 @@ def merge_assembly_entities(
             edge_by_id.setdefault(str(placed["id"]), placed)
             added += 1
         for row in component_index.vertices:
+            new_id = _entity_id(occurrence_id, row.get("id"), "v", row.get("ordinal"))
+            if new_id is None:
+                continue
             placed = _place_entity_row(matrix, row)
-            placed["id"] = _entity_id(occurrence_id, row.get("id"), "v", row.get("ordinal"))
+            placed["id"] = new_id
             placed["occurrenceId"] = occurrence_id
             _rebase(placed, "edgeStart", vertex_edge_offset)
             vertices.append(placed)
@@ -449,8 +465,17 @@ def merge_assembly_entities(
 
         # The occurrence's own ranges, now that its rows exist. Phase 1 wrote zeros because it
         # had no entities to point at, and a zero range reads as "this occurrence has no faces".
+        # A COPY. These row dicts are shared with the index we were handed, and
+        # SelectorIndex is a frozen value: writing ranges into them in place would leave the
+        # caller's index claiming slices of lists it does not have.
         occurrence_row = occurrence_by_id.get(occurrence_id)
         if isinstance(occurrence_row, dict):
+            occurrence_row = dict(occurrence_row)
+            occurrence_by_id[occurrence_id] = occurrence_row
+            for position, existing in enumerate(occurrence_rows):
+                if existing is not None and str(existing.get("id")) == occurrence_id:
+                    occurrence_rows[position] = occurrence_row
+                    break
             occurrence_row.update(
                 {
                     "shapeStart": shape_offset,

--- a/packages/cadgen/src/cadgen/assembly_lookup.py
+++ b/packages/cadgen/src/cadgen/assembly_lookup.py
@@ -1,0 +1,251 @@
+"""Selector resolution across a component package's INSTANCE TREE.
+
+An assembly is described by two artifacts that answer different questions, and until this module
+they disagreed about what an occurrence is:
+
+* ``assembly.json`` -- the package descriptor. Knows the instance tree: 160 occurrences for
+  ``tom_v2``, ids ``o1.1.1``/``o1.12``/``o1.11.7.1.1.1.2``, each naming a component and carrying
+  its placement. This is what ``snapshot --mode list`` enumerates and what the CAD Viewer hands
+  the user when they click a part.
+* ``topology.glb`` -- the whole-assembly selector sidecar, extracted from the COMPOSED compound.
+  A compound has no instance tree, so it flattens to ONE occurrence (``o1``) holding every solid:
+  162 shapes, 13866 faces, in a single namespace ``o1.s1``/``o1.f19``.
+
+``lookup.build_selector_index`` reads the second. So every ref the first hands out -- every ref a
+user can actually pick -- resolved to an error, and ``inspect refs --facts`` reported
+``occurrenceCount: 1`` for a 160-part assembly (issue 0b in tom-cad's FEEDBACK.md). The user's
+workaround was to re-identify each face by area and position in the owning part's own namespace,
+which is guesswork whenever a part appears at more than one occurrence.
+
+The fix needs no new data. Each occurrence names a component, and each ``components/<hash>.glb``
+already carries that part's own complete topology -- the yoke's component has its 66 faces sitting
+there unused. So this module ADDS the instance-tree occurrences to the flat index rather than
+replacing it: ``#o1.f19`` keeps resolving exactly as before, and ``#o1.12`` starts resolving.
+
+Coordinates are WORLD AT REST: occurrence transforms applied, parameter-sidecar poses not.
+That is the frame the viewer shows when the ref is picked and the frame ``snapshot --mode list``
+already reports its bounds in, so the two tools now agree. Reporting component-local coordinates
+instead would recreate the frame confusion that FEEDBACK.md P2 documents costing a wrong edit and
+a full revert.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from cadgen.lookup import SelectorIndex
+
+COMPONENTS_DIRNAME = "components"
+
+
+def _identity() -> list[float]:
+    return [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+
+
+def _matrix(raw: object) -> list[float]:
+    """A row-major 4x4 as 16 floats, or identity when the descriptor omits/mangles it."""
+    if not isinstance(raw, (list, tuple)) or len(raw) < 16:
+        return _identity()
+    try:
+        return [float(value) for value in raw[:16]]
+    except (TypeError, ValueError):
+        return _identity()
+
+
+def transform_point(matrix: list[float], point: object) -> list[float] | None:
+    if not isinstance(point, (list, tuple)) or len(point) < 3:
+        return None
+    try:
+        x, y, z = (float(point[0]), float(point[1]), float(point[2]))
+    except (TypeError, ValueError):
+        return None
+    return [
+        matrix[0] * x + matrix[1] * y + matrix[2] * z + matrix[3],
+        matrix[4] * x + matrix[5] * y + matrix[6] * z + matrix[7],
+        matrix[8] * x + matrix[9] * y + matrix[10] * z + matrix[11],
+    ]
+
+
+def transform_bbox(matrix: list[float], bbox: object) -> dict[str, list[float]] | None:
+    """Transform an axis-aligned box by transforming its eight CORNERS and re-deriving min/max.
+
+    Transforming min and max alone is wrong under any rotation: it produces a box with the right
+    diagonal and the wrong extent, and every occurrence in a posed assembly is rotated.
+    """
+    if not isinstance(bbox, Mapping):
+        return None
+    low = bbox.get("min")
+    high = bbox.get("max")
+    if not isinstance(low, (list, tuple)) or not isinstance(high, (list, tuple)):
+        return None
+    if len(low) < 3 or len(high) < 3:
+        return None
+    try:
+        lows = [float(value) for value in low[:3]]
+        highs = [float(value) for value in high[:3]]
+    except (TypeError, ValueError):
+        return None
+    corners = [
+        transform_point(matrix, [x, y, z])
+        for x in (lows[0], highs[0])
+        for y in (lows[1], highs[1])
+        for z in (lows[2], highs[2])
+    ]
+    placed = [corner for corner in corners if corner is not None]
+    if not placed:
+        return None
+    return {
+        "min": [min(corner[axis] for corner in placed) for axis in range(3)],
+        "max": [max(corner[axis] for corner in placed) for axis in range(3)],
+    }
+
+
+def _component_bundle_reader():
+    """Imported lazily: cadgen._internal.glb pulls in the GLB machinery, and a part entry
+    never reaches this module."""
+    from cadgen._internal.glb import read_step_topology_bundle_from_glb
+
+    return read_step_topology_bundle_from_glb
+
+
+def _component_occurrence_bbox(bundle: object) -> object:
+    """The component's own root-occurrence bbox, in component-local coordinates."""
+    manifest = getattr(bundle, "manifest", None)
+    if not isinstance(manifest, Mapping):
+        return None
+    columns = manifest.get("tables")
+    columns = columns.get("occurrenceColumns") if isinstance(columns, Mapping) else None
+    rows = manifest.get("occurrences")
+    if not isinstance(columns, list) or not isinstance(rows, list) or not rows:
+        return None
+    first = rows[0]
+    if not isinstance(first, list):
+        return None
+    row = {str(columns[index]): first[index] for index in range(min(len(columns), len(first)))}
+    return row.get("bbox")
+
+
+def assembly_occurrence_rows(
+    descriptor: Mapping[str, Any],
+    package_dir: Path,
+) -> list[dict[str, Any]]:
+    """Instance-tree occurrences as selector-index rows, in world coordinates at rest.
+
+    Column names mirror the topology sidecar's ``occurrenceColumns`` so that consumers written
+    against that table (``entry_summary``, ``reporting``) need no special case for assemblies.
+    """
+    rows = descriptor.get("occurrences")
+    if not isinstance(rows, list):
+        return []
+    read_bundle = None
+    bbox_by_component: dict[str, object] = {}
+    materialized: list[dict[str, Any]] = []
+    for entry in rows:
+        if not isinstance(entry, Mapping):
+            continue
+        occurrence_id = str(entry.get("id") or "").strip()
+        if not occurrence_id:
+            continue
+        matrix = _matrix(entry.get("transform"))
+        component = str(entry.get("component") or "").strip()
+        local_bbox: object = None
+        if component:
+            if component not in bbox_by_component:
+                # Deduped by content hash: tom_v2 has 160 occurrences over 65 components, and
+                # the whole set reads in well under a second.
+                if read_bundle is None:
+                    read_bundle = _component_bundle_reader()
+                path = package_dir / COMPONENTS_DIRNAME / f"{component}.glb"
+                bundle = read_bundle(path) if path.is_file() else None
+                bbox_by_component[component] = _component_occurrence_bbox(bundle)
+            local_bbox = bbox_by_component[component]
+        materialized.append(
+            {
+                "id": occurrence_id,
+                "path": occurrence_id,
+                "name": str(entry.get("name") or occurrence_id),
+                "sourceName": str(entry.get("name") or occurrence_id),
+                "parentId": occurrence_id.rpartition(".")[0] or None,
+                "transform": matrix,
+                "bbox": transform_bbox(matrix, local_bbox),
+                "component": component or None,
+                # Entity ranges belong to phase 2; a reader must not mistake 0 for "has none".
+                "shapeStart": 0,
+                "shapeCount": 0,
+                "faceStart": 0,
+                "faceCount": 0,
+                "edgeStart": 0,
+                "edgeCount": 0,
+            }
+        )
+    return materialized
+
+
+def merge_assembly_occurrences(
+    index: SelectorIndex,
+    descriptor: Mapping[str, Any],
+    package_dir: Path,
+) -> SelectorIndex:
+    """Add the instance-tree occurrences to a flat whole-assembly index.
+
+    ADDITIVE on purpose. The flat namespace (``#o1.f19``, ``#o1.s3``) is what every existing
+    caller and test resolves against, and ``single_occurrence_id`` is what lets a bare ``#f19``
+    canonicalize; replacing the index would break both to fix a third thing.
+    """
+    rows = assembly_occurrence_rows(descriptor, package_dir)
+    if not rows:
+        return index
+    occurrences = list(index.occurrences)
+    occurrence_by_id = dict(index.occurrence_by_id)
+    added = 0
+    for row in rows:
+        occurrence_id = str(row.get("id") or "")
+        if not occurrence_id or occurrence_id in occurrence_by_id:
+            continue
+        occurrences.append(row)
+        occurrence_by_id[occurrence_id] = row
+        added += 1
+    if not added:
+        return index
+    # occurrenceCount came from the sidecar's stats and said 1 for a 160-part assembly, which is
+    # what `inspect refs --facts` reported. It is a count of what this index can resolve.
+    manifest = dict(index.manifest)
+    stats = dict(manifest.get("stats")) if isinstance(manifest.get("stats"), Mapping) else {}
+    stats["occurrenceCount"] = len(occurrences)
+    manifest["stats"] = stats
+    return replace(
+        index,
+        manifest=manifest,
+        occurrences=occurrences,
+        occurrence_by_id=occurrence_by_id,
+    )
+
+
+def index_with_assembly_occurrences(index: SelectorIndex, artifact: object) -> SelectorIndex:
+    """``merge_assembly_occurrences`` keyed off a ``StepTopologyArtifact``.
+
+    Lives here rather than at either call site because there are TWO of them and they had already
+    drifted: ``snapshot_cli.artifact_selector_index`` serves ``--focus``/``--hide``, while
+    ``inspect refs`` builds its own index from the same bundle. Fixing one would have left the
+    other reporting the bug, which is how 0b presented as three separate tool failures.
+
+    Anything that is not an assembly package returns untouched, so part entries are unaffected.
+    """
+    if index is None or artifact is None:
+        return index
+    if str(getattr(artifact, "kind", "")) != "assembly":
+        return index
+    package_dir = getattr(artifact, "artifact_path", None)
+    if not isinstance(package_dir, Path):
+        return index
+    from cadgen._internal.component_package import is_assembly_package, read_package_descriptor
+
+    if not is_assembly_package(package_dir):
+        return index
+    descriptor = read_package_descriptor(package_dir)
+    if not isinstance(descriptor, dict):
+        return index
+    return merge_assembly_occurrences(index, descriptor, package_dir)

--- a/packages/cadgen/src/cadgen/assembly_lookup.py
+++ b/packages/cadgen/src/cadgen/assembly_lookup.py
@@ -153,20 +153,34 @@ def _transform_params(matrix: list[float], params: object) -> object:
 
 
 def _place_entity_row(matrix: list[float], row: Mapping[str, Any]) -> dict[str, Any]:
+    """Copy a component row into world coordinates.
+
+    A geometry field that cannot be placed is REMOVED rather than left as it was. Keeping it
+    would publish a component-local coordinate in a row whose every other number is in assembly
+    space, with nothing marking which is which -- and it would be the same object shared by every
+    occurrence of that component, so the two identical spacers would report one position. The
+    frames must not mix silently; that is what FEEDBACK.md P2 cost a wrong edit and a revert.
+    """
     placed = dict(row)
     for field in _POINT_FIELDS:
         if field in placed:
             moved = transform_point(matrix, placed[field])
-            if moved is not None:
+            if moved is None:
+                placed.pop(field, None)
+            else:
                 placed[field] = moved
     for field in _DIRECTION_FIELDS:
         if field in placed:
             moved = transform_direction(matrix, placed[field])
-            if moved is not None:
+            if moved is None:
+                placed.pop(field, None)
+            else:
                 placed[field] = moved
     if "bbox" in placed:
         moved_box = transform_bbox(matrix, placed["bbox"])
-        if moved_box is not None:
+        if moved_box is None:
+            placed.pop("bbox", None)
+        else:
             placed["bbox"] = moved_box
     if "params" in placed:
         placed["params"] = _transform_params(matrix, placed["params"])
@@ -292,33 +306,59 @@ def _entity_id(occurrence_id: str, local_id: object, kind: str, ordinal: object)
     return f"{occurrence_id}.{suffix}" if suffix else f"{occurrence_id}.{kind}"
 
 
+def _rebase(row: dict, field: str, offset: int) -> None:
+    """Shift a range field that indexes a list we are concatenating into."""
+    if field in row:
+        try:
+            row[field] = offset + int(row[field] or 0)
+        except (TypeError, ValueError):
+            row[field] = offset
+
+
+# Offsets into the component's OWN proxy buffers (mesh triangles, edge polylines, surface
+# half-edges). The merged index carries the flat assembly's buffers, not the component's, so a
+# start copied across points into unrelated data. Dropped rather than rebased: there is nothing
+# in this index for them to point AT. Absent raises a KeyError at the reader; stale silently
+# returns the wrong triangles.
+_BUFFER_START_FIELDS = ("triangleStart", "segmentStart", "surfaceHalfEdgeStart")
+
+
 def merge_assembly_entities(
     index: SelectorIndex,
     descriptor: Mapping[str, Any],
     package_dir: Path,
 ) -> SelectorIndex:
-    """Add each occurrence's faces/edges/vertices, placed into world coordinates.
+    """Add each occurrence's shapes/faces/edges/vertices, placed into world coordinates.
 
     This is what makes a ref picked in the viewer measurable: `#o1.12.f19` is face 19 of that
     occurrence's component, and until now only the flat whole-assembly namespace resolved, whose
     numbering does not agree with the component's (FEEDBACK.md: "the assembly's f18 is the wall's
     face; the part's f18 is a 17.085 mm2 cylinder").
 
-    Adjacency survives the merge. Component relation rows index that component's own tables, so
-    they are re-based as they are concatenated -- otherwise `face_adjacent_edge_selectors` would
-    return confident, wrong neighbours, which is worse than returning none.
+    Every id and every RANGE is re-based as the tables concatenate. A component's rows index its
+    own tables: a face's `edgeStart` points into that component's faceEdgeRows, a shape's
+    `faceStart` slices that component's face list, an edge's `shapeId` names that component's
+    solid. Copied across unchanged they all still resolve -- against the wrong thing, which is
+    worse than not resolving. `#o1.12.f19` reported `shapeId s1`, and `s1` in the merged index is
+    a solid 40 mm away.
     """
     occurrences = descriptor.get("occurrences")
     if not isinstance(occurrences, list) or not occurrences:
         return index
 
+    shapes = list(index.shapes)
     faces = list(index.faces)
     edges = list(index.edges)
     vertices = list(index.vertices)
+    shape_by_id = dict(index.shape_by_id)
     face_by_id = dict(index.face_by_id)
     edge_by_id = dict(index.edge_by_id)
     vertex_by_id = dict(index.vertex_by_id)
+    occurrence_by_id = dict(index.occurrence_by_id)
+    occurrence_rows = list(index.occurrences)
     relations = {name: list(rows) for name, rows in index.relations.items()}
+    for name in ("faceEdgeRows", "edgeFaceRows", "edgeVertexRows", "vertexEdgeRows"):
+        relations.setdefault(name, [])
     cache: dict[str, Any] = {}
     added = 0
 
@@ -334,20 +374,40 @@ def merge_assembly_entities(
             continue
         matrix = _matrix(entry.get("transform"))
 
+        shape_offset = len(shapes)
         face_offset = len(faces)
         edge_offset = len(edges)
         vertex_offset = len(vertices)
-        face_edge_offset = len(relations.get("faceEdgeRows", []))
-        edge_face_offset = len(relations.get("edgeFaceRows", []))
-        edge_vertex_offset = len(relations.get("edgeVertexRows", []))
-        vertex_edge_offset = len(relations.get("vertexEdgeRows", []))
+        face_edge_offset = len(relations["faceEdgeRows"])
+        edge_face_offset = len(relations["edgeFaceRows"])
+        edge_vertex_offset = len(relations["edgeVertexRows"])
+        vertex_edge_offset = len(relations["vertexEdgeRows"])
 
+        # A face names its owning solid by id, so the rename has to be known before the faces
+        # are written or `shapeId` keeps pointing at the flat namespace.
+        shape_id_map: dict[str, str] = {}
+        for row in component_index.shapes:
+            new_id = _entity_id(occurrence_id, row.get("id"), "s", row.get("ordinal"))
+            shape_id_map[str(row.get("id"))] = new_id
+
+        for row in component_index.shapes:
+            placed = _place_entity_row(matrix, row)
+            placed["id"] = shape_id_map[str(row.get("id"))]
+            placed["occurrenceId"] = occurrence_id
+            _rebase(placed, "faceStart", face_offset)
+            _rebase(placed, "edgeStart", edge_offset)
+            shapes.append(placed)
+            shape_by_id.setdefault(str(placed["id"]), placed)
+            added += 1
         for row in component_index.faces:
             placed = _place_entity_row(matrix, row)
             placed["id"] = _entity_id(occurrence_id, row.get("id"), "f", row.get("ordinal"))
             placed["occurrenceId"] = occurrence_id
-            if "edgeStart" in placed:
-                placed["edgeStart"] = face_edge_offset + int(placed.get("edgeStart") or 0)
+            if placed.get("shapeId") is not None:
+                placed["shapeId"] = shape_id_map.get(str(placed["shapeId"]), placed["shapeId"])
+            _rebase(placed, "edgeStart", face_edge_offset)
+            for field in _BUFFER_START_FIELDS:
+                placed.pop(field, None)
             faces.append(placed)
             face_by_id.setdefault(str(placed["id"]), placed)
             added += 1
@@ -355,8 +415,12 @@ def merge_assembly_entities(
             placed = _place_entity_row(matrix, row)
             placed["id"] = _entity_id(occurrence_id, row.get("id"), "e", row.get("ordinal"))
             placed["occurrenceId"] = occurrence_id
-            if "faceStart" in placed:
-                placed["faceStart"] = edge_face_offset + int(placed.get("faceStart") or 0)
+            if placed.get("shapeId") is not None:
+                placed["shapeId"] = shape_id_map.get(str(placed["shapeId"]), placed["shapeId"])
+            _rebase(placed, "faceStart", edge_face_offset)
+            _rebase(placed, "vertexStart", edge_vertex_offset)
+            for field in _BUFFER_START_FIELDS:
+                placed.pop(field, None)
             edges.append(placed)
             edge_by_id.setdefault(str(placed["id"]), placed)
             added += 1
@@ -364,34 +428,51 @@ def merge_assembly_entities(
             placed = _place_entity_row(matrix, row)
             placed["id"] = _entity_id(occurrence_id, row.get("id"), "v", row.get("ordinal"))
             placed["occurrenceId"] = occurrence_id
+            _rebase(placed, "edgeStart", vertex_edge_offset)
             vertices.append(placed)
             vertex_by_id.setdefault(str(placed["id"]), placed)
             added += 1
 
         component_relations = component_index.relations
-        relations.setdefault("faceEdgeRows", []).extend(
+        relations["faceEdgeRows"].extend(
             edge_offset + int(value) for value in component_relations.get("faceEdgeRows", [])
         )
-        relations.setdefault("edgeFaceRows", []).extend(
+        relations["edgeFaceRows"].extend(
             face_offset + int(value) for value in component_relations.get("edgeFaceRows", [])
         )
-        relations.setdefault("edgeVertexRows", []).extend(
+        relations["edgeVertexRows"].extend(
             vertex_offset + int(value) for value in component_relations.get("edgeVertexRows", [])
         )
-        relations.setdefault("vertexEdgeRows", []).extend(
+        relations["vertexEdgeRows"].extend(
             edge_offset + int(value) for value in component_relations.get("vertexEdgeRows", [])
         )
-        # Silence the unused-offset warnings for the two vertex rebases above; they are read
-        # through the extend() calls and exist so a package that does carry vertices works.
-        del edge_vertex_offset, vertex_edge_offset
+
+        # The occurrence's own ranges, now that its rows exist. Phase 1 wrote zeros because it
+        # had no entities to point at, and a zero range reads as "this occurrence has no faces".
+        occurrence_row = occurrence_by_id.get(occurrence_id)
+        if isinstance(occurrence_row, dict):
+            occurrence_row.update(
+                {
+                    "shapeStart": shape_offset,
+                    "shapeCount": len(component_index.shapes),
+                    "faceStart": face_offset,
+                    "faceCount": len(component_index.faces),
+                    "edgeStart": edge_offset,
+                    "edgeCount": len(component_index.edges),
+                }
+            )
 
     if not added:
         return index
     return replace(
         index,
+        occurrences=occurrence_rows,
+        occurrence_by_id=occurrence_by_id,
+        shapes=shapes,
         faces=faces,
         edges=edges,
         vertices=vertices,
+        shape_by_id=shape_by_id,
         face_by_id=face_by_id,
         edge_by_id=edge_by_id,
         vertex_by_id=vertex_by_id,

--- a/packages/cadgen/src/cadgen/assembly_lookup.py
+++ b/packages/cadgen/src/cadgen/assembly_lookup.py
@@ -103,6 +103,76 @@ def transform_bbox(matrix: list[float], bbox: object) -> dict[str, list[float]] 
     }
 
 
+# How each entity field moves under a rigid placement. Classified by KEY, because the schema is
+# uniform across surface and curve types: a plane and a cylinder both carry `origin`/`axis`, a
+# line carries `origin`/`direction`, and a cylinder's `radius` is a length that a rigid transform
+# does not change. Anything unlisted is carried through untouched, which is right for ordinals,
+# counts, flags and areas -- and is why `params` is transformed key-by-key rather than wholesale.
+_POINT_FIELDS = ("center",)
+_POINT_PARAM_KEYS = ("origin",)
+_DIRECTION_FIELDS = ("normal",)
+_DIRECTION_PARAM_KEYS = ("axis", "direction")
+
+
+def transform_direction(matrix: list[float], vector: object) -> list[float] | None:
+    """Rotate a direction. The translation column must NOT apply -- a surface normal that picks
+    up the occurrence's offset stops being a unit vector and starts pointing somewhere false."""
+    if not isinstance(vector, (list, tuple)) or len(vector) < 3:
+        return None
+    try:
+        x, y, z = (float(vector[0]), float(vector[1]), float(vector[2]))
+    except (TypeError, ValueError):
+        return None
+    return [
+        matrix[0] * x + matrix[1] * y + matrix[2] * z,
+        matrix[4] * x + matrix[5] * y + matrix[6] * z,
+        matrix[8] * x + matrix[9] * y + matrix[10] * z,
+    ]
+
+
+def _transform_params(matrix: list[float], params: object) -> object:
+    """Place a face's or edge's surface/curve parameters.
+
+    Leaving these in component-local coordinates while `center` and `bbox` are placed would be
+    the worst of both: a cylinder whose centre is in the assembly and whose axis origin is in the
+    part, with nothing in the payload saying so. That is the frame mismatch FEEDBACK.md P2 charges
+    a wrong edit and a full revert to.
+    """
+    if not isinstance(params, Mapping):
+        return params
+    placed: dict[str, Any] = {}
+    for key, value in params.items():
+        name = str(key)
+        if name in _POINT_PARAM_KEYS:
+            placed[name] = transform_point(matrix, value) or value
+        elif name in _DIRECTION_PARAM_KEYS:
+            placed[name] = transform_direction(matrix, value) or value
+        else:
+            placed[name] = value
+    return placed
+
+
+def _place_entity_row(matrix: list[float], row: Mapping[str, Any]) -> dict[str, Any]:
+    placed = dict(row)
+    for field in _POINT_FIELDS:
+        if field in placed:
+            moved = transform_point(matrix, placed[field])
+            if moved is not None:
+                placed[field] = moved
+    for field in _DIRECTION_FIELDS:
+        if field in placed:
+            moved = transform_direction(matrix, placed[field])
+            if moved is not None:
+                placed[field] = moved
+    if "bbox" in placed:
+        moved_box = transform_bbox(matrix, placed["bbox"])
+        if moved_box is not None:
+            placed["bbox"] = moved_box
+    if "params" in placed:
+        placed["params"] = _transform_params(matrix, placed["params"])
+    return placed
+
+
 def _component_bundle_reader():
     """Imported lazily: cadgen._internal.glb pulls in the GLB machinery, and a part entry
     never reaches this module."""
@@ -184,6 +254,151 @@ def assembly_occurrence_rows(
     return materialized
 
 
+def _component_index(package_dir: Path, component: str, cache: dict[str, Any]) -> Any:
+    """The component's own selector index, loaded once per content hash.
+
+    tom_v2 places 160 occurrences over 65 distinct components, so the cache is most of the cost:
+    the whole set reads in about 0.2 s.
+    """
+    if component in cache:
+        return cache[component]
+    from cadgen.lookup import build_selector_index
+
+    read_bundle = _component_bundle_reader()
+    path = package_dir / COMPONENTS_DIRNAME / f"{component}.glb"
+    bundle = read_bundle(path) if path.is_file() else None
+    manifest = getattr(bundle, "manifest", None)
+    built = None
+    if isinstance(manifest, Mapping):
+        built = build_selector_index(dict(manifest), buffers=getattr(bundle, "buffers", None))
+    cache[component] = built
+    return built
+
+
+def _entity_id(occurrence_id: str, local_id: object, kind: str, ordinal: object) -> str:
+    """``o1.f19`` inside a component becomes ``o1.12.f19`` in the assembly.
+
+    Prefers the row's own ordinal over re-parsing its id, so the assembly ref keeps the number
+    the component's own namespace uses -- which is what makes a translated ref checkable by hand
+    against the part file, the exact step users were doing manually.
+    """
+    if ordinal is not None:
+        try:
+            return f"{occurrence_id}.{kind}{int(ordinal)}"
+        except (TypeError, ValueError):
+            pass
+    tail = str(local_id or "")
+    _, _, suffix = tail.rpartition(".")
+    return f"{occurrence_id}.{suffix}" if suffix else f"{occurrence_id}.{kind}"
+
+
+def merge_assembly_entities(
+    index: SelectorIndex,
+    descriptor: Mapping[str, Any],
+    package_dir: Path,
+) -> SelectorIndex:
+    """Add each occurrence's faces/edges/vertices, placed into world coordinates.
+
+    This is what makes a ref picked in the viewer measurable: `#o1.12.f19` is face 19 of that
+    occurrence's component, and until now only the flat whole-assembly namespace resolved, whose
+    numbering does not agree with the component's (FEEDBACK.md: "the assembly's f18 is the wall's
+    face; the part's f18 is a 17.085 mm2 cylinder").
+
+    Adjacency survives the merge. Component relation rows index that component's own tables, so
+    they are re-based as they are concatenated -- otherwise `face_adjacent_edge_selectors` would
+    return confident, wrong neighbours, which is worse than returning none.
+    """
+    occurrences = descriptor.get("occurrences")
+    if not isinstance(occurrences, list) or not occurrences:
+        return index
+
+    faces = list(index.faces)
+    edges = list(index.edges)
+    vertices = list(index.vertices)
+    face_by_id = dict(index.face_by_id)
+    edge_by_id = dict(index.edge_by_id)
+    vertex_by_id = dict(index.vertex_by_id)
+    relations = {name: list(rows) for name, rows in index.relations.items()}
+    cache: dict[str, Any] = {}
+    added = 0
+
+    for entry in occurrences:
+        if not isinstance(entry, Mapping):
+            continue
+        occurrence_id = str(entry.get("id") or "").strip()
+        component = str(entry.get("component") or "").strip()
+        if not occurrence_id or not component:
+            continue
+        component_index = _component_index(package_dir, component, cache)
+        if component_index is None:
+            continue
+        matrix = _matrix(entry.get("transform"))
+
+        face_offset = len(faces)
+        edge_offset = len(edges)
+        vertex_offset = len(vertices)
+        face_edge_offset = len(relations.get("faceEdgeRows", []))
+        edge_face_offset = len(relations.get("edgeFaceRows", []))
+        edge_vertex_offset = len(relations.get("edgeVertexRows", []))
+        vertex_edge_offset = len(relations.get("vertexEdgeRows", []))
+
+        for row in component_index.faces:
+            placed = _place_entity_row(matrix, row)
+            placed["id"] = _entity_id(occurrence_id, row.get("id"), "f", row.get("ordinal"))
+            placed["occurrenceId"] = occurrence_id
+            if "edgeStart" in placed:
+                placed["edgeStart"] = face_edge_offset + int(placed.get("edgeStart") or 0)
+            faces.append(placed)
+            face_by_id.setdefault(str(placed["id"]), placed)
+            added += 1
+        for row in component_index.edges:
+            placed = _place_entity_row(matrix, row)
+            placed["id"] = _entity_id(occurrence_id, row.get("id"), "e", row.get("ordinal"))
+            placed["occurrenceId"] = occurrence_id
+            if "faceStart" in placed:
+                placed["faceStart"] = edge_face_offset + int(placed.get("faceStart") or 0)
+            edges.append(placed)
+            edge_by_id.setdefault(str(placed["id"]), placed)
+            added += 1
+        for row in component_index.vertices:
+            placed = _place_entity_row(matrix, row)
+            placed["id"] = _entity_id(occurrence_id, row.get("id"), "v", row.get("ordinal"))
+            placed["occurrenceId"] = occurrence_id
+            vertices.append(placed)
+            vertex_by_id.setdefault(str(placed["id"]), placed)
+            added += 1
+
+        component_relations = component_index.relations
+        relations.setdefault("faceEdgeRows", []).extend(
+            edge_offset + int(value) for value in component_relations.get("faceEdgeRows", [])
+        )
+        relations.setdefault("edgeFaceRows", []).extend(
+            face_offset + int(value) for value in component_relations.get("edgeFaceRows", [])
+        )
+        relations.setdefault("edgeVertexRows", []).extend(
+            vertex_offset + int(value) for value in component_relations.get("edgeVertexRows", [])
+        )
+        relations.setdefault("vertexEdgeRows", []).extend(
+            edge_offset + int(value) for value in component_relations.get("vertexEdgeRows", [])
+        )
+        # Silence the unused-offset warnings for the two vertex rebases above; they are read
+        # through the extend() calls and exist so a package that does carry vertices works.
+        del edge_vertex_offset, vertex_edge_offset
+
+    if not added:
+        return index
+    return replace(
+        index,
+        faces=faces,
+        edges=edges,
+        vertices=vertices,
+        face_by_id=face_by_id,
+        edge_by_id=edge_by_id,
+        vertex_by_id=vertex_by_id,
+        relations=relations,
+    )
+
+
 def merge_assembly_occurrences(
     index: SelectorIndex,
     descriptor: Mapping[str, Any],
@@ -225,7 +440,8 @@ def merge_assembly_occurrences(
 
 
 def index_with_assembly_occurrences(index: SelectorIndex, artifact: object) -> SelectorIndex:
-    """``merge_assembly_occurrences`` keyed off a ``StepTopologyArtifact``.
+    """The whole instance tree -- occurrences AND their entities -- keyed off a
+    ``StepTopologyArtifact``.
 
     Lives here rather than at either call site because there are TWO of them and they had already
     drifted: ``snapshot_cli.artifact_selector_index`` serves ``--focus``/``--hide``, while
@@ -248,4 +464,5 @@ def index_with_assembly_occurrences(index: SelectorIndex, artifact: object) -> S
     descriptor = read_package_descriptor(package_dir)
     if not isinstance(descriptor, dict):
         return index
-    return merge_assembly_occurrences(index, descriptor, package_dir)
+    merged = merge_assembly_occurrences(index, descriptor, package_dir)
+    return merge_assembly_entities(merged, descriptor, package_dir)

--- a/packages/cadgen/src/cadgen/snapshot_cli.py
+++ b/packages/cadgen/src/cadgen/snapshot_cli.py
@@ -802,7 +802,13 @@ def artifact_selector_index(artifact: StepTopologyArtifact | None) -> lookup.Sel
     if manifest is None:
         return None
     buffers = selector_bundle.buffers if isinstance(selector_bundle.buffers, Mapping) else None
-    return lookup.build_selector_index(manifest, buffers=buffers)
+    index = lookup.build_selector_index(manifest, buffers=buffers)
+    # The bundle is extracted from the COMPOSED compound, which has no instance tree, so it
+    # describes even a 160-part assembly as one occurrence -- and `--focus`/`--hide` rejected
+    # every ref `--mode list` had just handed out. See `cadgen.assembly_lookup`.
+    from cadgen.assembly_lookup import index_with_assembly_occurrences
+
+    return index_with_assembly_occurrences(index, artifact)
 
 
 def validate_occurrence_selector(selector: str, *, selector_index: lookup.SelectorIndex | None, source_label: str) -> None:

--- a/skills/cad/scripts/inspect/inspect_refs/inspect.py
+++ b/skills/cad/scripts/inspect/inspect_refs/inspect.py
@@ -253,6 +253,12 @@ def _load_step_context(
     else:
         manifest = artifact.selector_bundle.manifest
         selector_index = lookup.build_selector_index(manifest, buffers=artifact.selector_bundle.buffers)
+        # An assembly's selector bundle is extracted from the composed compound and knows one
+        # occurrence; the refs users pick come from the instance tree. Without this, every
+        # `#o1.12` the viewer or `snapshot --mode list` hands out failed to resolve here.
+        from cadgen.assembly_lookup import index_with_assembly_occurrences
+
+        selector_index = index_with_assembly_occurrences(selector_index, artifact)
 
     resolved_kind = _entry_kind_from_manifest(
         manifest,

--- a/tests/python/packages/cadgen/test_assembly_selector_refs.py
+++ b/tests/python/packages/cadgen/test_assembly_selector_refs.py
@@ -21,7 +21,7 @@ from tests.python.support.paths import add_repo_path
 
 add_repo_path("packages/cadgen/src")
 
-from build123d import Box, Compound, Pos  # noqa: E402
+from build123d import Box, Compound, Pos, Rot  # noqa: E402
 
 from cadgen import assembly_lookup, lookup  # noqa: E402
 from cadgen._internal import component_package  # noqa: E402
@@ -30,14 +30,23 @@ from cadgen.coordination.paths import write_lock_path  # noqa: E402
 
 
 def _demo_compound() -> Compound:
-    """Two identical boxes placed apart plus a distinct one: 3 occurrences over 2 components."""
+    """Two identical boxes placed apart, a distinct one, and one ROTATED.
+
+    The rotated occurrence is not decoration. Every other part here is placed by translation
+    alone, and under a translation a box's face normals stay axis-aligned whatever the rotation
+    code does -- so a transposed or dropped rotation passes unnoticed. `box_rot` is turned 90
+    degrees about Z, which swaps its X and Y extents and sends its +X normal to +Y, both of
+    which are wrong in a checkable way if the rotation is mishandled.
+    """
     first = Pos(0, 0, 0) * Box(10, 10, 10)
     first.label = "box_a_1"
     second = Pos(40, 0, 0) * Box(10, 10, 10)
     second.label = "box_a_2"
     third = Pos(0, 40, 0) * Box(4, 6, 8)
     third.label = "box_b"
-    assembly = Compound(children=[first, second, third])
+    rotated = Pos(0, -40, 0) * Rot(0, 0, 90) * Box(4, 6, 8)
+    rotated.label = "box_rot"
+    assembly = Compound(children=[first, second, third, rotated])
     assembly.label = "demo"
     return assembly
 
@@ -223,6 +232,8 @@ class PlacementAgainstAnalyticGeometryTest(AssemblyOccurrenceRefsTest):
         "box_a_1": ((5.0, 5.0, 5.0), (0.0, 0.0, 0.0)),
         "box_a_2": ((5.0, 5.0, 5.0), (40.0, 0.0, 0.0)),
         "box_b": ((2.0, 3.0, 4.0), (0.0, 40.0, 0.0)),
+        # rotated 90 deg about Z: the 4 mm X extent and 6 mm Y extent trade places.
+        "box_rot": ((3.0, 2.0, 4.0), (0.0, -40.0, 0.0)),
     }
 
     def _expected_box(self, half, centre):

--- a/tests/python/packages/cadgen/test_assembly_selector_refs.py
+++ b/tests/python/packages/cadgen/test_assembly_selector_refs.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 from tests.python.support.paths import add_repo_path
@@ -210,6 +211,186 @@ class AssemblyEntityRefsTest(AssemblyOccurrenceRefsTest):
         flat = self._flat_index()
         merged = self._merged()
         self.assertEqual(flat.single_occurrence_id, merged.single_occurrence_id)
+
+
+class MergedRowsAreInternallyConsistentTest(AssemblyOccurrenceRefsTest):
+    """Every id and every RANGE a merged row carries must point somewhere true.
+
+    A component's rows index that component's own tables. Copied across unchanged they all still
+    RESOLVE -- against the wrong thing, which is worse than not resolving at all, because the
+    caller gets a confident answer. `#o1.12.f19` used to report `shapeId s1`, and `s1` in the
+    merged index is a solid 40 mm away from the face claiming it.
+    """
+
+    def _merged(self) -> lookup.SelectorIndex:
+        occurrences = assembly_lookup.merge_assembly_occurrences(
+            self._flat_index(), self.descriptor, self.package_dir
+        )
+        return assembly_lookup.merge_assembly_entities(
+            occurrences, self.descriptor, self.package_dir
+        )
+
+    def test_a_face_names_a_shape_that_exists_and_contains_it(self) -> None:
+        merged = self._merged()
+        checked = 0
+        for face in merged.faces:
+            occurrence_id = str(face.get("occurrenceId") or "")
+            if not occurrence_id or occurrence_id == "o1":
+                continue
+            shape_id = str(face.get("shapeId") or "")
+            self.assertTrue(
+                shape_id.startswith(f"{occurrence_id}."),
+                f"{face['id']} names {shape_id}, which belongs to another occurrence",
+            )
+            shape = merged.shape_by_id.get(shape_id)
+            self.assertIsNotNone(shape, f"{face['id']} names a shape that does not resolve")
+            # Geometric consistency, not just naming: a face has to lie inside its own solid.
+            for axis in range(3):
+                self.assertGreaterEqual(
+                    face["bbox"]["min"][axis], shape["bbox"]["min"][axis] - 1e-6,
+                    f"{face['id']} sits outside {shape_id}",
+                )
+                self.assertLessEqual(
+                    face["bbox"]["max"][axis], shape["bbox"]["max"][axis] + 1e-6,
+                    f"{face['id']} sits outside {shape_id}",
+                )
+            checked += 1
+        self.assertGreater(checked, 0, "no placed faces were checked")
+
+    def test_shape_refs_resolve_and_slice_their_own_faces(self) -> None:
+        merged = self._merged()
+        checked = 0
+        for shape in merged.shapes:
+            occurrence_id = str(shape.get("occurrenceId") or "")
+            if not occurrence_id or occurrence_id == "o1":
+                continue
+            self.assertIsNotNone(lookup.lookup_selector(f"#{shape['id']}", merged))
+            start = int(shape.get("faceStart") or 0)
+            count = int(shape.get("faceCount") or 0)
+            self.assertGreater(count, 0)
+            for face in merged.faces[start : start + count]:
+                self.assertEqual(
+                    shape["id"], str(face.get("shapeId")),
+                    "a shape's face range must contain exactly its own faces",
+                )
+            checked += 1
+        self.assertGreater(checked, 0, "no placed shapes were checked")
+
+    def test_an_occurrence_range_slices_its_own_entities(self) -> None:
+        merged = self._merged()
+        checked = 0
+        for occurrence_id, row in merged.occurrence_by_id.items():
+            if occurrence_id == "o1" or not int(row.get("faceCount") or 0):
+                continue
+            start = int(row["faceStart"])
+            faces = merged.faces[start : start + int(row["faceCount"])]
+            self.assertTrue(faces, f"{occurrence_id} has an empty face range")
+            for face in faces:
+                self.assertEqual(occurrence_id, str(face.get("occurrenceId")))
+            checked += 1
+        self.assertGreater(checked, 0, "no occurrence ranges were checked")
+
+    def test_buffer_offsets_are_dropped_rather_than_carried_stale(self) -> None:
+        """These index the COMPONENT's proxy buffers. The merged index holds the flat
+        assembly's, so a copied start points into unrelated data -- silently, and only for
+        whoever renders a highlight from it. Absent makes that a KeyError instead."""
+        merged = self._merged()
+        for rows in (merged.faces, merged.edges):
+            for row in rows:
+                if not str(row.get("occurrenceId") or "").count("."):
+                    continue
+                for field in ("triangleStart", "segmentStart", "surfaceHalfEdgeStart"):
+                    self.assertNotIn(field, row, f"{row['id']} carries a stale {field}")
+
+    def test_adjacency_rows_stay_in_range(self) -> None:
+        """Every relation row is an index into a list we concatenated into. An un-rebased one
+        still lands somewhere -- on another occurrence's edge."""
+        merged = self._merged()
+        for face in merged.faces:
+            occurrence_id = str(face.get("occurrenceId") or "")
+            if not occurrence_id or occurrence_id == "o1":
+                continue
+            for selector in lookup.face_adjacent_edge_selectors(face, merged):
+                self.assertTrue(
+                    selector.startswith(f"{occurrence_id}."),
+                    f"{face['id']} is adjacent to {selector}, which is not its own",
+                )
+
+
+class DormantPathsTest(unittest.TestCase):
+    """Vertices, and geometry that cannot be placed.
+
+    No model in this repo carries vertices -- every component bundle reports vertexCount 0 -- so
+    the vertex rebasing is dead code that will wake up the first time a package has one. That is
+    exactly when nobody will be looking at it, so it is driven here with a synthetic component.
+    """
+
+    def _fake_component(self):
+        manifest = {
+            "tables": {
+                "occurrenceColumns": ["id", "name", "bbox"],
+                "shapeColumns": ["id", "occurrenceId", "ordinal", "bbox"],
+                "faceColumns": ["id", "occurrenceId", "shapeId", "ordinal", "center", "edgeStart", "edgeCount"],
+                "edgeColumns": ["id", "occurrenceId", "shapeId", "ordinal", "center", "vertexStart", "vertexCount"],
+                "vertexColumns": ["id", "occurrenceId", "ordinal", "center", "edgeStart", "edgeCount"],
+            },
+            "occurrences": [["o1", "part", None]],
+            "shapes": [["o1.s1", "o1", 1, None]],
+            "faces": [["o1.f1", "o1", "o1.s1", 1, [0.0, 0.0, 0.0], 0, 1]],
+            "edges": [["o1.e1", "o1", "o1.s1", 1, [0.0, 0.0, 0.0], 0, 2]],
+            "vertices": [
+                ["o1.v1", "o1", 1, [0.0, 0.0, 0.0], 0, 1],
+                ["o1.v2", "o1", 2, [1.0, 0.0, 0.0], 1, 1],
+            ],
+            "relations": {
+                "faceEdgeRows": [0],
+                "edgeFaceRows": [0],
+                "edgeVertexRows": [0, 1],
+                "vertexEdgeRows": [0, 0],
+            },
+        }
+        return lookup.build_selector_index(manifest)
+
+    def test_vertex_ranges_are_rebased_for_every_occurrence(self) -> None:
+        component = self._fake_component()
+        descriptor = {
+            "occurrences": [
+                {"id": "o1.1", "name": "a", "component": "c", "transform": None},
+                {"id": "o1.2", "name": "b", "component": "c",
+                 "transform": [1, 0, 0, 100, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]},
+            ]
+        }
+        flat = lookup.build_selector_index(
+            {"tables": {"occurrenceColumns": ["id"]}, "occurrences": [["o1"]]}
+        )
+        with mock.patch.object(assembly_lookup, "_component_index", return_value=component):
+            merged = assembly_lookup.merge_assembly_entities(flat, descriptor, Path("."))
+
+        for occurrence_id in ("o1.1", "o1.2"):
+            edge = merged.edge_by_id[f"{occurrence_id}.e1"]
+            neighbours = lookup.edge_adjacent_vertex_selectors(edge, merged)
+            self.assertEqual(
+                [f"{occurrence_id}.v1", f"{occurrence_id}.v2"], neighbours,
+                f"{occurrence_id}.e1 reached another occurrence's vertices",
+            )
+            vertex = merged.vertex_by_id[f"{occurrence_id}.v2"]
+            self.assertEqual(
+                [f"{occurrence_id}.e1"], lookup.vertex_adjacent_edge_selectors(vertex, merged),
+            )
+        # ...and the second occurrence is genuinely 100 mm away, not a shared row.
+        self.assertEqual(100.0, merged.vertex_by_id["o1.2.v1"]["center"][0])
+        self.assertEqual(0.0, merged.vertex_by_id["o1.1.v1"]["center"][0])
+
+    def test_geometry_that_cannot_be_placed_is_dropped_not_left_local(self) -> None:
+        """A field kept unplaced would be a component-local number in an otherwise world-space
+        row, shared by every occurrence of that component."""
+        placed = assembly_lookup._place_entity_row(
+            assembly_lookup._matrix([1, 0, 0, 5, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+            {"id": "x", "center": "not-a-point", "normal": None, "bbox": {"min": [0, 0, 0]}},
+        )
+        for field in ("center", "normal", "bbox"):
+            self.assertNotIn(field, placed, f"{field} survived unplaced")
+        self.assertEqual("x", placed["id"], "non-geometry fields are untouched")
 
 
 class PlacementAgainstAnalyticGeometryTest(AssemblyOccurrenceRefsTest):

--- a/tests/python/packages/cadgen/test_assembly_selector_refs.py
+++ b/tests/python/packages/cadgen/test_assembly_selector_refs.py
@@ -133,6 +133,76 @@ class AssemblyOccurrenceRefsTest(unittest.TestCase):
         self.assertEqual(len(centres), len(placed), "occurrences collapsed to one position")
 
 
+class AssemblyEntityRefsTest(AssemblyOccurrenceRefsTest):
+    """Phase 2: the refs users actually pick. `#o1.12.f19` is face 19 of that occurrence's
+    component, which is the translation they were doing by hand -- and which the flat
+    whole-assembly namespace cannot express, since its numbering does not agree with the
+    component's ("the assembly's f18 is the wall's face; the part's f18 is a cylinder")."""
+
+    def _merged(self) -> lookup.SelectorIndex:
+        return assembly_lookup.merge_assembly_entities(
+            self._flat_index(), self.descriptor, self.package_dir
+        )
+
+    def test_entity_refs_inside_an_occurrence_resolve(self) -> None:
+        merged = self._merged()
+        occurrence_id = str(self.descriptor["occurrences"][0]["id"])
+        found = lookup.lookup_selector(f"#{occurrence_id}.f1", merged)
+        self.assertIsNotNone(found, f"{occurrence_id}.f1 did not resolve")
+        self.assertEqual("face", found[0])
+
+    def test_a_face_keeps_its_component_ordinal(self) -> None:
+        """The assembly ref carries the number the PART's own namespace uses, so a translated
+        ref stays checkable by hand against the part file."""
+        merged = self._merged()
+        occurrence_id = str(self.descriptor["occurrences"][0]["id"])
+        kind, row = lookup.lookup_selector(f"#{occurrence_id}.f1", merged)
+        self.assertEqual(1, int(row["ordinal"]))
+        self.assertEqual(occurrence_id, str(row["occurrenceId"]))
+
+    def test_geometry_is_placed_and_rigid_invariants_survive(self) -> None:
+        merged = self._merged()
+        rows = [row for row in merged.faces if str(row.get("occurrenceId", "")).count(".") >= 1]
+        self.assertTrue(rows, "no placed faces were merged")
+        # The two identical boxes differ ONLY by placement, so component-local centres would be
+        # identical. Distinct centres prove the occurrence transform was applied.
+        centres = {tuple(round(value, 6) for value in row["center"]) for row in rows}
+        self.assertGreater(len(centres), 1, "faces collapsed to one position")
+        for row in rows:
+            self.assertGreater(float(row["area"]), 0.0, "a rigid placement must preserve area")
+
+    def test_a_normal_is_rotated_not_translated(self) -> None:
+        """The silent failure: putting a direction through the full matrix makes it absorb the
+        occurrence's offset, so it stops being a unit vector and points somewhere false."""
+        merged = self._merged()
+        placed = [row for row in merged.faces if row.get("normal") and row.get("occurrenceId")]
+        self.assertTrue(placed)
+        for row in placed:
+            length = sum(component * component for component in row["normal"]) ** 0.5
+            self.assertAlmostEqual(1.0, length, places=6, msg=f"{row['id']} normal is not unit")
+
+    def test_adjacency_stays_inside_the_occurrence(self) -> None:
+        """Relation rows index their own component's tables and are re-based as they merge.
+        Without that, adjacency returns confident wrong neighbours -- worse than none."""
+        merged = self._merged()
+        occurrence_id = str(self.descriptor["occurrences"][0]["id"])
+        _, face = lookup.lookup_selector(f"#{occurrence_id}.f1", merged)
+        neighbours = lookup.face_adjacent_edge_selectors(face, merged)
+        self.assertTrue(neighbours, "a solid's face has adjacent edges")
+        for selector in neighbours:
+            self.assertTrue(
+                selector.startswith(f"{occurrence_id}."),
+                f"{selector} escaped {occurrence_id} -- relation offsets are wrong",
+            )
+
+    def test_the_flat_entity_namespace_still_resolves(self) -> None:
+        """Additive, again: a bare `#f1` still canonicalizes through single_occurrence_id into
+        the composed-compound namespace, which is what every part-shaped caller relies on."""
+        flat = self._flat_index()
+        merged = self._merged()
+        self.assertEqual(flat.single_occurrence_id, merged.single_occurrence_id)
+
+
 class TransformArithmeticTest(unittest.TestCase):
     """A box transformed by its min/max alone keeps its diagonal and loses its extent. Every
     occurrence in a posed assembly is rotated, so this is the failure mode that matters."""
@@ -170,6 +240,34 @@ class TransformArithmeticTest(unittest.TestCase):
         rows = assembly_lookup.transform_bbox(assembly_lookup._matrix("nonsense"), box)
         self.assertEqual(box["min"], rows["min"])
         self.assertEqual(box["max"], rows["max"])
+
+    def test_a_direction_ignores_the_translation_column(self) -> None:
+        matrix = [
+            1.0, 0.0, 0.0, 100.0,
+            0.0, 1.0, 0.0, -50.0,
+            0.0, 0.0, 1.0, 7.0,
+            0.0, 0.0, 0.0, 1.0,
+        ]
+        self.assertEqual([0.0, 0.0, 1.0], assembly_lookup.transform_direction(matrix, [0, 0, 1]))
+        # ...while a POINT under the same matrix does move.
+        self.assertEqual([100.0, -50.0, 8.0], assembly_lookup.transform_point(matrix, [0, 0, 1]))
+
+    def test_params_move_by_key_not_wholesale(self) -> None:
+        """`origin` is a point, `axis`/`direction` are directions, `radius` is a length a rigid
+        transform does not change. Leaving params local while center is placed would put one
+        payload in two frames."""
+        matrix = [
+            1.0, 0.0, 0.0, 10.0,
+            0.0, 1.0, 0.0, 0.0,
+            0.0, 0.0, 1.0, 0.0,
+            0.0, 0.0, 0.0, 1.0,
+        ]
+        placed = assembly_lookup._transform_params(
+            matrix, {"origin": [1.0, 2.0, 3.0], "axis": [0.0, 0.0, 1.0], "radius": 3.0}
+        )
+        self.assertEqual([11.0, 2.0, 3.0], placed["origin"])
+        self.assertEqual([0.0, 0.0, 1.0], placed["axis"])
+        self.assertEqual(3.0, placed["radius"])
 
     def test_a_missing_bbox_is_none_rather_than_a_crash(self) -> None:
         self.assertIsNone(assembly_lookup.transform_bbox(assembly_lookup._matrix(None), None))

--- a/tests/python/packages/cadgen/test_assembly_selector_refs.py
+++ b/tests/python/packages/cadgen/test_assembly_selector_refs.py
@@ -1,0 +1,180 @@
+"""An assembly's refs must resolve in the namespace the tools actually hand out.
+
+Issue 0b (tom-cad FEEDBACK.md): `snapshot --mode list` and the CAD Viewer enumerate instance-tree
+occurrences -- `#o1.12 shoulder_yaw_yoke` -- while `inspect refs` and `snapshot --focus/--hide`
+resolved against the whole-assembly topology sidecar, which is extracted from the COMPOSED
+compound and therefore describes any assembly as ONE occurrence. Every ref a user could pick was
+rejected by every tool that could measure it, and `--facts` reported `occurrenceCount: 1` for a
+160-part assembly.
+
+These cover the merge itself (real package, real descriptor) and the transform arithmetic, which
+is the part with a wrong answer that looks plausible.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.python.support.paths import add_repo_path
+
+add_repo_path("packages/cadgen/src")
+
+from build123d import Box, Compound, Pos  # noqa: E402
+
+from cadgen import assembly_lookup, lookup  # noqa: E402
+from cadgen._internal import component_package  # noqa: E402
+from cadgen.coordination.lock import exclusive  # noqa: E402
+from cadgen.coordination.paths import write_lock_path  # noqa: E402
+
+
+def _demo_compound() -> Compound:
+    """Two identical boxes placed apart plus a distinct one: 3 occurrences over 2 components."""
+    first = Pos(0, 0, 0) * Box(10, 10, 10)
+    first.label = "box_a_1"
+    second = Pos(40, 0, 0) * Box(10, 10, 10)
+    second.label = "box_a_2"
+    third = Pos(0, 40, 0) * Box(4, 6, 8)
+    third.label = "box_b"
+    assembly = Compound(children=[first, second, third])
+    assembly.label = "demo"
+    return assembly
+
+
+class _FakeArtifact:
+    """Stands in for StepTopologyArtifact: the merge only reads `kind` and `artifact_path`."""
+
+    def __init__(self, kind: str, artifact_path: Path) -> None:
+        self.kind = kind
+        self.artifact_path = artifact_path
+
+
+class AssemblyOccurrenceRefsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="assembly-refs-")
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.package_dir = self.root / "__cadgen__" / "models" / "demo.step.py"
+        with exclusive(write_lock_path(self.package_dir)):
+            component_package.build_package_from_compound(
+                _demo_compound(), package_dir=self.package_dir, root_name="demo"
+            )
+        descriptor = component_package.read_package_descriptor(self.package_dir)
+        self.assertIsInstance(descriptor, dict, "fixture package has no descriptor")
+        self.descriptor = descriptor
+
+    def _flat_index(self) -> lookup.SelectorIndex:
+        """A stand-in for the composed-compound sidecar: one occurrence, as the real one has."""
+        manifest = {
+            "stats": {"occurrenceCount": 1, "shapeCount": 3},
+            "tables": {"occurrenceColumns": ["id", "name", "bbox"]},
+            "occurrences": [["o1", "demo.step", None]],
+        }
+        return lookup.build_selector_index(manifest)
+
+    def test_every_ref_the_lister_hands_out_resolves(self) -> None:
+        """The bug as reported: ids present in assembly.json, absent from the resolver."""
+        index = assembly_lookup.merge_assembly_occurrences(
+            self._flat_index(), self.descriptor, self.package_dir
+        )
+        ids = [str(row["id"]) for row in self.descriptor["occurrences"]]
+        self.assertTrue(ids, "fixture assembly declares no occurrences")
+        for occurrence_id in ids:
+            with self.subTest(occurrence=occurrence_id):
+                found = lookup.lookup_selector(f"#{occurrence_id}", index)
+                self.assertIsNotNone(found, f"{occurrence_id} did not resolve")
+                self.assertEqual("occurrence", found[0])
+
+    def test_the_flat_namespace_still_resolves(self) -> None:
+        """The merge is ADDITIVE. `#o1` and bare-ordinal refs are what every existing caller
+        and test uses; fixing instance refs must not cost them."""
+        flat = self._flat_index()
+        merged = assembly_lookup.merge_assembly_occurrences(
+            flat, self.descriptor, self.package_dir
+        )
+        self.assertIsNotNone(lookup.lookup_selector("#o1", merged))
+        self.assertEqual(flat.single_occurrence_id, merged.single_occurrence_id)
+
+    def test_the_reported_occurrence_count_stops_saying_one(self) -> None:
+        merged = assembly_lookup.merge_assembly_occurrences(
+            self._flat_index(), self.descriptor, self.package_dir
+        )
+        summary = lookup.entry_summary(merged)
+        self.assertGreater(
+            int(summary["occurrenceCount"]),
+            1,
+            "`inspect refs --facts` reported occurrenceCount 1 for a whole assembly",
+        )
+
+    def test_a_non_assembly_artifact_is_returned_untouched(self) -> None:
+        """The guardrail. Part entries are the common path and must not notice this change."""
+        flat = self._flat_index()
+        part = _FakeArtifact(kind="part", artifact_path=self.package_dir)
+        self.assertIs(flat, assembly_lookup.index_with_assembly_occurrences(flat, part))
+        self.assertIs(flat, assembly_lookup.index_with_assembly_occurrences(flat, None))
+
+    def test_a_missing_package_directory_is_not_an_error(self) -> None:
+        flat = self._flat_index()
+        absent = _FakeArtifact(kind="assembly", artifact_path=self.root / "nope")
+        self.assertIs(flat, assembly_lookup.index_with_assembly_occurrences(flat, absent))
+
+    def test_occurrences_are_reported_in_world_coordinates(self) -> None:
+        rows = assembly_lookup.assembly_occurrence_rows(self.descriptor, self.package_dir)
+        placed = [row for row in rows if row.get("bbox")]
+        self.assertTrue(placed, "no occurrence carried a bbox")
+        # The two identical boxes share a component and differ ONLY by placement, so
+        # component-local bboxes would make them indistinguishable. World coordinates are the
+        # frame the viewer shows and `snapshot --mode list` reports.
+        centres = {
+            tuple(round((row["bbox"]["min"][axis] + row["bbox"]["max"][axis]) / 2, 3) for axis in range(3))
+            for row in placed
+        }
+        self.assertEqual(len(centres), len(placed), "occurrences collapsed to one position")
+
+
+class TransformArithmeticTest(unittest.TestCase):
+    """A box transformed by its min/max alone keeps its diagonal and loses its extent. Every
+    occurrence in a posed assembly is rotated, so this is the failure mode that matters."""
+
+    def test_a_rotated_box_is_transformed_by_its_corners(self) -> None:
+        # 90 degrees about Z: x -> y, y -> -x.
+        matrix = [
+            0.0, -1.0, 0.0, 0.0,
+            1.0, 0.0, 0.0, 0.0,
+            0.0, 0.0, 1.0, 0.0,
+            0.0, 0.0, 0.0, 1.0,
+        ]
+        box = {"min": [0.0, 0.0, 0.0], "max": [2.0, 6.0, 1.0]}
+        placed = assembly_lookup.transform_bbox(matrix, box)
+        self.assertIsNotNone(placed)
+        for axis, (low, high) in enumerate(zip([-6.0, 0.0, 0.0], [0.0, 2.0, 1.0])):
+            self.assertAlmostEqual(low, placed["min"][axis], places=6)
+            self.assertAlmostEqual(high, placed["max"][axis], places=6)
+
+    def test_translation_moves_the_box(self) -> None:
+        matrix = [
+            1.0, 0.0, 0.0, 5.0,
+            0.0, 1.0, 0.0, -3.0,
+            0.0, 0.0, 1.0, 0.0,
+            0.0, 0.0, 0.0, 1.0,
+        ]
+        placed = assembly_lookup.transform_bbox(
+            matrix, {"min": [0.0, 0.0, 0.0], "max": [1.0, 1.0, 1.0]}
+        )
+        self.assertEqual([5.0, -3.0, 0.0], placed["min"])
+        self.assertEqual([6.0, -2.0, 1.0], placed["max"])
+
+    def test_a_malformed_transform_falls_back_to_identity(self) -> None:
+        box = {"min": [0.0, 0.0, 0.0], "max": [1.0, 2.0, 3.0]}
+        rows = assembly_lookup.transform_bbox(assembly_lookup._matrix("nonsense"), box)
+        self.assertEqual(box["min"], rows["min"])
+        self.assertEqual(box["max"], rows["max"])
+
+    def test_a_missing_bbox_is_none_rather_than_a_crash(self) -> None:
+        self.assertIsNone(assembly_lookup.transform_bbox(assembly_lookup._matrix(None), None))
+        self.assertIsNone(assembly_lookup.transform_bbox(assembly_lookup._matrix(None), {"min": [0, 0, 0]}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/packages/cadgen/test_assembly_selector_refs.py
+++ b/tests/python/packages/cadgen/test_assembly_selector_refs.py
@@ -290,6 +290,27 @@ class MergedRowsAreInternallyConsistentTest(AssemblyOccurrenceRefsTest):
             checked += 1
         self.assertGreater(checked, 0, "no occurrence ranges were checked")
 
+    def test_the_index_it_was_handed_is_left_alone(self) -> None:
+        """SelectorIndex is a frozen dataclass -- a value. `replace()` makes a new one, but the
+        ROW DICTS are shared, so writing occurrence ranges in place left the caller's index
+        claiming slices of lists it does not have."""
+        occurrences = assembly_lookup.merge_assembly_occurrences(
+            self._flat_index(), self.descriptor, self.package_dir
+        )
+        occurrence_id = str(self.descriptor["occurrences"][0]["id"])
+        before = dict(occurrences.occurrence_by_id[occurrence_id])
+        merged = assembly_lookup.merge_assembly_entities(
+            occurrences, self.descriptor, self.package_dir
+        )
+        self.assertEqual(
+            before, occurrences.occurrence_by_id[occurrence_id],
+            "the input index's occurrence row was rewritten in place",
+        )
+        self.assertGreater(
+            int(merged.occurrence_by_id[occurrence_id]["faceCount"]), 0,
+            "the merged index should carry the ranges instead",
+        )
+
     def test_buffer_offsets_are_dropped_rather_than_carried_stale(self) -> None:
         """These index the COMPONENT's proxy buffers. The merged index holds the flat
         assembly's, so a copied start points into unrelated data -- silently, and only for

--- a/tests/python/packages/cadgen/test_assembly_selector_refs.py
+++ b/tests/python/packages/cadgen/test_assembly_selector_refs.py
@@ -203,6 +203,90 @@ class AssemblyEntityRefsTest(AssemblyOccurrenceRefsTest):
         self.assertEqual(flat.single_occurrence_id, merged.single_occurrence_id)
 
 
+class PlacementAgainstAnalyticGeometryTest(AssemblyOccurrenceRefsTest):
+    """Placement checked against geometry we KNOW, not against our own arithmetic.
+
+    The other tests here compare what the merge produced with what `transform_point` says it
+    should be -- which is circular, since the merge calls `transform_point`. They pin that the
+    right matrix reached the right field; they cannot pin the matrix CONVENTION, because both
+    sides of the comparison share it.
+
+    The fixture's boxes are placed by build123d at coordinates chosen here, so their world
+    extents and face centres are known in advance by arithmetic no code in this repo performs.
+    Measured against a column-major misread of the transform: these fail 3 assertions and name
+    the wrong coordinates, where the circular tests fail 1 and only report that two occurrences
+    landed on top of each other. Both notice; only this one says what is wrong.
+    """
+
+    # (label, half-extents, placement) -> the world box build123d must produce.
+    _EXPECTED_BOXES = {
+        "box_a_1": ((5.0, 5.0, 5.0), (0.0, 0.0, 0.0)),
+        "box_a_2": ((5.0, 5.0, 5.0), (40.0, 0.0, 0.0)),
+        "box_b": ((2.0, 3.0, 4.0), (0.0, 40.0, 0.0)),
+    }
+
+    def _expected_box(self, half, centre):
+        return (
+            [centre[axis] - half[axis] for axis in range(3)],
+            [centre[axis] + half[axis] for axis in range(3)],
+        )
+
+    def test_occurrence_extents_match_geometry_placed_by_build123d(self) -> None:
+        rows = {
+            str(row["name"]): row
+            for row in assembly_lookup.assembly_occurrence_rows(self.descriptor, self.package_dir)
+        }
+        checked = 0
+        for label, (half, centre) in self._EXPECTED_BOXES.items():
+            row = rows.get(label)
+            if row is None or not row.get("bbox"):
+                continue
+            low, high = self._expected_box(half, centre)
+            for axis in range(3):
+                self.assertAlmostEqual(
+                    low[axis], row["bbox"]["min"][axis], places=4,
+                    msg=f"{label} min[{axis}] is not where build123d put it",
+                )
+                self.assertAlmostEqual(
+                    high[axis], row["bbox"]["max"][axis], places=4,
+                    msg=f"{label} max[{axis}] is not where build123d put it",
+                )
+            checked += 1
+        self.assertEqual(len(self._EXPECTED_BOXES), checked, "not every fixture box was checked")
+
+    def test_face_centres_land_on_the_box_faces_they_belong_to(self) -> None:
+        """A box's six faces sit at its face midpoints. Those are known numbers, so a placed
+        face centre can be checked without asking the placement code where it should be."""
+        merged = assembly_lookup.merge_assembly_entities(
+            self._flat_index(), self.descriptor, self.package_dir
+        )
+        by_occurrence: dict[str, list] = {}
+        for row in merged.faces:
+            occurrence_id = str(row.get("occurrenceId") or "")
+            if occurrence_id and occurrence_id != "o1":
+                by_occurrence.setdefault(occurrence_id, []).append(row)
+        names = {str(row["id"]): str(row.get("name")) for row in self.descriptor["occurrences"]}
+
+        checked = 0
+        for occurrence_id, faces in by_occurrence.items():
+            expected = self._EXPECTED_BOXES.get(names.get(occurrence_id, ""))
+            if expected is None:
+                continue
+            half, centre = expected
+            wanted = set()
+            for axis in range(3):
+                for sign in (-1, 1):
+                    point = list(centre)
+                    point[axis] = centre[axis] + sign * half[axis]
+                    wanted.add(tuple(round(value, 4) for value in point))
+            found = {tuple(round(value, 4) for value in row["center"]) for row in faces}
+            self.assertEqual(
+                wanted, found, f"{occurrence_id} ({names.get(occurrence_id)}) faces are misplaced"
+            )
+            checked += 1
+        self.assertEqual(len(self._EXPECTED_BOXES), checked, "not every fixture box was checked")
+
+
 class TransformArithmeticTest(unittest.TestCase):
     """A box transformed by its min/max alone keeps its diagonal and loses its extent. Every
     occurrence in a posed assembly is rotated, so this is the failure mode that matters."""


### PR DESCRIPTION
Fixes issue 0b in `../tom-cad/FEEDBACK.md`, its most expensive open item.

`snapshot --mode list` and the CAD Viewer enumerate instance-tree occurrences — `#o1.12 shoulder_yaw_yoke` — and **every tool that could measure one rejected it**:

```
inspect refs tom_v2.step.py '#o1.12'   -> ok:false, "did not resolve"
snapshot --focus '#o1.12'              -> unknown part/subassembly occurrence selector
inspect refs --facts                   -> occurrenceCount: 1     (for a 160-part assembly)
```

So every ref picked in the viewer had to be hand-translated into the owning part's local namespace before anything could measure it — guesswork whenever a part appears at more than one occurrence.

## Cause

Two artifacts describe an assembly, and they disagree about what an occurrence is.

| | knows | occurrences | namespace |
|---|---|---|---|
| `assembly.json` | the instance tree | **160** | `o1.1.1`, `o1.12`, `o1.11.7.1.1.1.2` |
| `topology.glb` | the composed compound | **1** | flat: `o1.s1…s162`, `o1.f1…f13866` |

A compound has no instance tree, so extraction flattens it. The **emitters** read the first, the **resolvers** read the second.

## Fix

No new data was needed, and nothing is regenerated. Each occurrence names a component, and each `components/<hash>.glb` already carries that part's own complete topology — the yoke's component has its 66 faces sitting there unused.

The merge is **additive**: `#o1.f19` resolves exactly as before, `#o1.12` starts resolving. Replacing the index would have broken the flat namespace and `single_occurrence_id` (what lets a bare `#f19` canonicalize) in order to fix a third thing.

**Coordinates are world at rest** — occurrence transforms applied, parameter-sidecar poses not. That is the frame the viewer shows when the ref is picked, and the one `--mode list` already reports `bounds` in, so the two now agree. Component-local coordinates would recreate the frame confusion FEEDBACK.md P2 records as costing a wrong edit and a full revert.

Boxes are placed by transforming all eight **corners**. Transforming min/max alone keeps the diagonal and loses the extent, and every occurrence in a posed assembly is rotated.

## The plan said "single choke point". It was wrong.

`inspect refs` builds its own selector index rather than calling `snapshot_cli`'s, so there were two construction sites that had already drifted. The artifact-aware helper lives in the new module and both call it — fixing one would have left the other still reporting the bug, which is exactly how 0b presented as three separate tool failures.

## Verification

Against the real 160-part assembly (`tom-cad/STEP_v2/tom_v2.step.py`):

- `#o1.12` → `ok:true`, `status:"resolved"`, `summary:"shoulder_yaw_yoke"`
- `snapshot --focus '#o1.12'` renders with the rest ghosted, instead of erroring

Neutering the merge fails **4 of the new tests by name**, including every occurrence id. cadgen **296** (+10), full Python suite green, bundles fresh.

One guardrail is a named test: `test_a_non_assembly_artifact_is_returned_untouched`. Part entries are the common path, and the real risk in this change is quietly disturbing them rather than failing to resolve assembly refs.

## Phase 2 is here too

Phase 1 fixed `--focus`/`--hide`, which take occurrence refs. It did not fix what was actually costing time: the refs a user **picks in the viewer** are entity refs, and `#o1.12.f19` still returned `ok:false`. FEEDBACK.md is explicit — *"every `#o1.12.fNN` ref a user picks in the viewer has to be re-identified by area and position"* — so phase 2 is what the feature needs, not a follow-up.

**The acceptance test is an equality.** On the real assembly `#o1.12.f19` reports `plane area=902.685366`, and `#f19` on `shoulder_yaw_yoke.step.py` reports **exactly the same face**. That equality *is* the hand-translation the user was performing.

Geometry is placed **field by field, classified by key** rather than by surface or curve type, because the schema is uniform:

| field | treatment |
|---|---|
| `center`, `params.origin` | point — full matrix |
| `normal`, `params.axis`, `params.direction` | direction — **rotation only** |
| `area`, `length`, `radius` | rigid invariant — carried through |
| `bbox` | all eight corners, min/max re-derived |

A direction given the translation column stops being a unit vector and points somewhere false, silently, since nothing downstream re-normalises. Measured on the real assembly: normals stay unit at 1.0, and a face's centre lands exactly on `matrix × local`.

`params` is transformed rather than dropped or passed through — leaving it local while `center` is placed would put one payload in two frames, the failure P2 charges a wrong edit and a full revert to.

**Adjacency survives.** Component relation rows index their own component's tables, so they are re-based as they concatenate. Without that, `face_adjacent_edge_selectors` returns confident wrong neighbours, which is worse than none. Measured: `o1.12.f19` reports 6 adjacent edges, all inside `o1.12`.

Cost is one component load per distinct content hash — 65 for tom_v2's 160 occurrences, ~0.2 s — and the whole `inspect refs` call runs in 2.0 s.

Two mutations confirm the tests bite: neutering the entity merge fails 5, and giving directions the translation column fails exactly the 3 direction tests. cadgen **310** (+14).

## Not here


**Bug 0** (viewer highlight splits between posed and unposed geometry) is a separate defect in `packages/cadjs`. Lead: the edge overlay's effect transform is gated behind a four-way conjunction in `topologyDisplayEdgeRuntime.js:241` while the face path has no equivalent gate — any one being false gives exactly the reported symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

