### PR TITLE
cadgen: Windows reports lock contention as EDEADLOCK, and we degraded on it silently

### DIFF
--- a/packages/cadgen/src/cadgen/coordination/lock.py
+++ b/packages/cadgen/src/cadgen/coordination/lock.py
@@ -58,6 +58,7 @@ import os
 import threading
 import time
 import uuid
+import warnings
 from pathlib import Path
 from typing import Callable, Iterator, NamedTuple
 
@@ -77,8 +78,28 @@ except ImportError:  # pragma: no cover - not reachable on darwin/linux CI
 # EWOULDBLOCK/EAGAIN for a contended LOCK_NB; Windows msvcrt raises EACCES instead. Folding
 # EACCES into the POSIX set would misread one of flock's "the filesystem refused this"
 # errors as contention, so the sets stay separate.
+#
+# EDEADLOCK is the one that matters and the one that was missing. The Windows CRT's
+# ``_locking`` reports a region already held by another handle as EDEADLOCK -- errno 36,
+# "Resource deadlock avoided" -- not as EACCES, whatever the mode. An errno that is not
+# recognised as contention falls through to the degradation branch in ``exclusive()``, so
+# the loser of a race did not wait for the winner: it carried on with NO LOCK AT ALL, and
+# said nothing. That is the opposite of what a lock is for, and it only happened under real
+# contention, so it stayed invisible while every uncontended build looked fine.
+#
+# By NUMBER, not by name. ``errno.EDEADLOCK`` does not exist on POSIX, so resolving it by name
+# would drop it exactly where the Windows backend is exercised by its fake -- leaving the fix
+# untestable off Windows, which is the situation that let the bug live in the first place.
+# 36 is EDEADLOCK on Windows and is not a POSIX errno, so naming it costs nothing here.
+WINDOWS_LOCK_CONTENTION_ERRNO = getattr(errno, "EDEADLOCK", 36)
+
 _FCNTL_BUSY_ERRNOS = (errno.EWOULDBLOCK, errno.EAGAIN)
-_MSVCRT_BUSY_ERRNOS = (errno.EWOULDBLOCK, errno.EAGAIN, errno.EACCES)
+_MSVCRT_BUSY_ERRNOS = (
+    errno.EWOULDBLOCK,
+    errno.EAGAIN,
+    errno.EACCES,
+    WINDOWS_LOCK_CONTENTION_ERRNO,
+)
 
 
 # Frozen: the Windows mutex sibling. Never read, never parsed -- only locked.
@@ -159,6 +180,25 @@ def _pad_mutex(handle) -> None:
         handle.write(b" ")
         handle.flush()
     handle.seek(0)
+
+
+def _warn_degraded(lock_path: Path, error: OSError) -> None:
+    """Announce that a build is proceeding without mutual exclusion, and why.
+
+    Warned rather than raised, because the policy this module has always stated is that a
+    missing lock must never be the reason a user's build fails. But it must not be a secret
+    either: a caller that hits this is writing an artifact directory that a peer may be
+    writing too, and the errno is the only clue to whether that is a filesystem which cannot
+    lock or a backend whose contention errno we failed to recognise.
+    """
+    name = errno.errorcode.get(getattr(error, "errno", None), str(getattr(error, "errno", "?")))
+    with contextlib.suppress(Exception):
+        warnings.warn(
+            f"generation lock unavailable for {lock_path}: {name} ({error}). This build is "
+            "not serialized against concurrent writers of the same artifact.",
+            RuntimeWarning,
+            stacklevel=4,
+        )
 
 
 def new_run_id() -> str:
@@ -296,12 +336,20 @@ def exclusive(
     try:
         try:
             _acquire(handle, mutex, deadline_ms=deadline_ms, on_wait=on_wait)
-        except OSError:
+        except OSError as error:
             # ENOLCK/EOPNOTSUPP and friends. The old code left this call OUTSIDE its
             # try/except, so such a filesystem turned advisory coordination into a hard
             # build failure. Degrade instead -- which is what the policy always claimed.
             # Contended is a RuntimeError, so a bounded acquire's timeout passes straight
             # through here to the caller rather than being swallowed as a degradation.
+            #
+            # SAY SO. This branch means the body is about to run with no mutual exclusion,
+            # and it stayed silent for every unrecognised errno -- which is how a missing
+            # EDEADLOCK turned Windows contention into four concurrent writers that no log,
+            # no message and no test could explain. A warning cannot make the degradation
+            # safe, but it makes the next unrecognised errno name itself instead of looking
+            # like a lock that simply did not work.
+            _warn_degraded(path, error)
             yield None
             return
         recorded = (run_id or new_run_id())[:_RUN_ID_BYTES]

--- a/tests/python/packages/cadgen/test_coordination_lock.py
+++ b/tests/python/packages/cadgen/test_coordination_lock.py
@@ -17,6 +17,7 @@ import textwrap
 import threading
 import time
 import unittest
+import warnings
 from pathlib import Path
 from unittest import mock
 
@@ -357,10 +358,22 @@ class RealBackendRegressionTests(unittest.TestCase):
             proc.wait(timeout=30)
 
 
+# The errno the real CRT reports for a region another handle holds. Taken from the module
+# under test on purpose: if the backend ever stops treating this value as contention, these
+# tests must move with it rather than quietly keep testing a value nothing produces.
+WINDOWS_LOCK_CONTENTION_ERRNO = lock.WINDOWS_LOCK_CONTENTION_ERRNO
+
+
 class _FakeMsvcrt:
     """In-process stand-in for ``msvcrt.locking``: a 1-byte region lock keyed by file
-    identity (dev+inode), non-blocking acquire raising ``EACCES`` when another handle
-    holds the region -- the exact contract the Windows backend relies on."""
+    identity (dev+inode), non-blocking acquire raising the CONTENTION errno when another
+    handle holds the region -- the exact contract the Windows backend relies on.
+
+    That errno used to be EACCES here, and EACCES is what made this fake useless for the one
+    thing it exists to catch. The real ``_locking`` reports contention as EDEADLOCK, which was
+    missing from the backend's busy set, so on Windows the loser of a race fell through to the
+    degradation branch and ran with no lock at all. Every test passed, because the fake was
+    faithful to everything except the errno that decides which branch is taken."""
 
     LK_NBLCK = 1
     LK_UNLCK = 2
@@ -374,12 +387,49 @@ class _FakeMsvcrt:
         key = (info.st_dev, info.st_ino)
         if mode == self.LK_NBLCK:
             if key in self._held:
-                raise OSError(errno.EACCES, "file being used by another process")
+                raise OSError(WINDOWS_LOCK_CONTENTION_ERRNO, "Resource deadlock avoided")
             self._held.add(key)
         elif mode == self.LK_UNLCK:
             self._held.discard(key)
         else:
             raise AssertionError(f"unexpected msvcrt mode {mode}")
+
+
+class DegradationIsAnnouncedTest(unittest.TestCase):
+    """Degrading to no lock must never be silent again.
+
+    The Windows contention errno was missing from the busy set, so a contended acquire fell
+    through to the degradation branch and the build ran unserialized. Nothing said so -- not a
+    log line, not a warning -- which is why it presented as "the lock does not work on Windows"
+    with no way to tell that from "the lock was never taken". The errno in the message is the
+    difference between those two, and it is what makes the next unrecognised one self-naming.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.lock_path = write_lock_path(Path(self._tmp.name) / "__cadgen__" / "models" / "p.step.py")
+
+    def test_an_unrecognised_lock_error_warns_and_names_the_errno(self):
+        def refuse(handle, path, **kwargs):
+            raise OSError(errno.ENOLCK, "no locks available")
+
+        with mock.patch.object(lock, "_acquire", refuse):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                with exclusive(self.lock_path) as run_id:
+                    self.assertIsNone(run_id, "a degraded acquire yields no run id")
+        messages = [str(w.message) for w in caught if issubclass(w.category, RuntimeWarning)]
+        self.assertTrue(messages, "degrading to no mutual exclusion said nothing")
+        self.assertIn("ENOLCK", messages[0], "the warning must name the errno")
+        self.assertIn("not serialized", messages[0])
+
+    def test_a_successful_acquire_is_quiet(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with exclusive(self.lock_path) as run_id:
+                self.assertTrue(run_id)
+        self.assertEqual([], [w for w in caught if issubclass(w.category, RuntimeWarning)])
 
 
 class WindowsLockBackendTests(unittest.TestCase):


### PR DESCRIPTION
`Test (Windows)` failed with **four threads inside one critical section** — `S2S1S0S3E1E0E2E3`, every thread entering before any left.

That is not a flaky test. The lock genuinely was not held, and **Windows mutual exclusion has never worked when it was actually needed.**

## Cause

`_MSVCRT_BUSY_ERRNOS` listed `EWOULDBLOCK`, `EAGAIN`, `EACCES`. The Windows CRT's `_locking` reports a region already held by another handle as **`EDEADLOCK`** — errno 36, *"Resource deadlock avoided"* — whatever the mode.

An errno not recognised as contention falls through to `exclusive()`'s degradation branch. So the **loser of a race did not wait for the winner — it proceeded with no lock at all.**

It looked fine because it only fails under real contention; an uncontended acquire never reaches the errno.

## Why it was invisible

Three things had to line up, and they did:

1. **The degradation branch was silent.** It yielded `None` and returned. A build writing an artifact directory concurrently with a peer produced no log line, no warning, nothing.
2. **The fake raised the wrong errno.** `_FakeMsvcrt` raised `EACCES` for contention — which *is* in the busy set. So every Windows-backend test exercised the branch that works and none exercised the branch that ships. The stand-in was faithful to everything except the one value that decides which branch is taken.
3. **CI had no Windows runner** until last week, so the real backend never ran at all.

## Fix

- `EDEADLOCK` joins the busy set, so contention waits instead of degrading.
- The degradation branch **warns and names the errno**. That is the only thing separating *"this filesystem cannot lock"* from *"this backend has a contention errno we do not recognise"* — and it makes the next unrecognised one self-naming.
- The fake now raises what the CRT raises, **sourced from the module under test** so the two cannot drift apart again.

## Verification

With the errno in the busy set, 28 tests pass. With it removed, **4 fail by name** — the fake finally catches the bug it was written for:

```
FAIL: test_probe_reports_held_while_a_peer_holds
FAIL: test_waiting_acquire_waits_for_the_peer
FAIL: test_bounded_wait_raises_contended
FAIL: test_nothing_locks_the_file_the_builders_read
```

One wrong turn worth recording: resolving the errno with `getattr(errno, "EDEADLOCK", None)` drops it on POSIX, **where the fake runs** — so the fix would have passed on Windows and been untestable everywhere else, which is precisely the shape of the original defect. It is named by number.

cadgen **334** (+2), full suite green.

## Note

This is why `Test (Windows)` intermittently failed on #277 (1 of 5 runs). That PR touches no lock code; it was this, surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
