### PR TITLE
test: fail the Python runner when it collects no tests

### DIFF
--- a/scripts/test/common.sh
+++ b/scripts/test/common.sh
@@ -30,8 +30,8 @@ run_python_unittest() {
   done < <(find "$REPO_ROOT/$start_dir" -name 'test*.py' -print | sort)
 
   if [ "${#test_files[@]}" -eq 0 ]; then
-    echo "No Python tests found under $start_dir"
-    return 0
+    echo "No Python tests found under $start_dir" >&2
+    return 1
   fi
 
   for path_entry in "$@"; do

--- a/tests/python/global/test_python_test_runner_fails_closed.py
+++ b/tests/python/global/test_python_test_runner_fails_closed.py
@@ -1,0 +1,68 @@
+"""The Python test runner must fail when it collects no tests.
+
+`packages/cadjs`, `packages/implicitjs`, and `viewer` all exit 1 from
+`scripts/run-tests.mjs` when their collector finds nothing. `run_python_unittest`
+in `scripts/test/common.sh` is the Python side of the same gate, so a renamed or
+emptied test directory must stop CI rather than report a group that never ran.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+from tests.python.support.paths import REPO_ROOT
+from tests.python.support.tmp_root import temporary_directory
+
+
+COMMON_SH = REPO_ROOT / "scripts" / "test" / "common.sh"
+
+PASSING_TEST = """\
+import unittest
+
+
+class Passing(unittest.TestCase):
+    def test_passes(self):
+        self.assertTrue(True)
+"""
+
+
+def run_group(start_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Invoke `run_python_unittest` on one directory, as `test-*.sh` would."""
+    relative = start_dir.relative_to(REPO_ROOT).as_posix()
+    script = (
+        "set -euo pipefail\n"
+        f'source "{COMMON_SH}"\n'
+        f'run_python_unittest "runner gate" "{relative}"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class PythonTestRunnerFailsClosed(unittest.TestCase):
+    def test_missing_directory_fails(self):
+        with temporary_directory(prefix="runner-gate-missing-") as tmp:
+            result = run_group(Path(tmp) / "does-not-exist")
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_directory_without_tests_fails(self):
+        with temporary_directory(prefix="runner-gate-empty-") as tmp:
+            result = run_group(Path(tmp))
+        self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("No Python tests found", result.stderr, result.stdout)
+
+    def test_directory_with_tests_passes(self):
+        with temporary_directory(prefix="runner-gate-collected-") as tmp:
+            (Path(tmp) / "test_collected.py").write_text(PASSING_TEST, encoding="utf-8")
+            result = run_group(Path(tmp))
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`run_python_unittest` in `scripts/test/common.sh` returns success when it finds
no test files, so a Python test group that stops being collected reports green
instead of failing the run.

The three JavaScript collectors already treat this as a failure — `packages/cadjs`,
`packages/implicitjs`, and `viewer` all end `scripts/run-tests.mjs` with:

```js
if (!tests.length) {
  console.error("No cadjs tests found.");
  process.exit(1);
}
```

`common.sh` is the Python side of the same gate and does the opposite.

The `find` diagnostic that shows up is real, but it lands in the middle of a
green run and its exit status is discarded: `find` runs inside a process
substitution, so neither `set -e` nor `pipefail` sees it. Execution then reaches
the empty branch, which returns 0 explicitly.

Four of the five call sites pass a hardcoded path with no guard —
`tests/python/packages/cadgen`, `tests/python/viewer/moveit2_server`, and
`viewer/server_py/tests` via `run_suite` in `test-python.sh`, plus
`tests/python/global` in `test-global.sh`. The fifth, the skill loop, checks `-d`
first.

`--keep-going` is affected more sharply: a group that collects nothing returns 0,
so it never enters `failed_suites` and never appears in the `FAILING SUITES`
list. The one mode whose purpose is to report every failure in a run is the one
where this failure is invisible.

**To be clear about what this is:** it has not happened. I replayed every commit
that touched `scripts/test/`, `tests/python/`, or `viewer/server_py` and checked
each `start_dir` literal against that commit's tree — the runner has never once
been pointed at a directory that did not exist. 0.4.0 is the closest call and it
was handled correctly: `tests/python/packages/cadpy` → `cadgen` and the deletion
of `cadpy_metadata` both updated `test-python.sh` in the same commit. This is a
guard against the next reorganisation, not a report of a past failure. The point
is only that if one of those moves had missed the call site, nothing would have
said so.

## Repro

```console
$ mv tests/python/global tests/python/global-renamed
$ scripts/test/test.sh; echo "exit=$?"
...
==> Global policy tests
find: /path/to/repo/tests/python/global: No such file or directory
No Python tests found under tests/python/global
exit=0
```

All 79 tests in that group silently stopped running and the suite still passed.
With this change the same command exits 1.

And in `--keep-going` mode, with a group pointed at a directory that is not
there:

```console
$ scripts/test/test-python.sh --keep-going; echo "exit=$?"
...
No Python tests found under tests/python/packages/cadgen-gone
exit=0            # and no FAILING SUITES section is printed at all
```

After this change the same run ends:

```console
==> FAILING SUITES (1)
  cadgen package Python tests
exit=1
```

## Changes

- `scripts/test/common.sh` — collecting zero test files returns 1 instead of 0,
  like the JS collectors, and the diagnostic goes to stderr.

I deliberately did not add a separate missing-directory branch. A `start_dir`
that does not exist already collects zero files and takes this same path, so a
`-d` check ahead of it would change the message and nothing else — `find` prints
its own error naming the path in that case anyway.

The `find`-in-process-substitution pattern is left as-is: with the empty
collection now failing, there is no remaining path where its discarded exit
status changes the outcome, and rewriting the collection loop would widen the
diff for no gain.

## Not changed

No current run changes. All fourteen live call sites resolve to a directory that
exists and collects at least one `test*.py`:

```
tests/python/packages/cadgen          31     tests/python/skills/gcode         1
tests/python/viewer/moveit2_server     3     tests/python/skills/implicit-cad  2
viewer/server_py/tests                11     tests/python/skills/sdf           4
tests/python/global                   14     tests/python/skills/sendcutsend   2
tests/python/skills/bambu-labs         1     tests/python/skills/srdf          3
tests/python/skills/cad               23     tests/python/skills/step-parts    2
tests/python/skills/dxf                8     tests/python/skills/urdf          3
```

`cad-viewer` is the one skill with no Python test directory, and it never reaches
the function because `test-python.sh` guards that loop with
`if [ -d "$test_dir" ]`. So the new failure cannot fire on a skill that
legitimately has no Python tests.

## Tests

Adds `tests/python/global/test_python_test_runner_fails_closed.py`, beside the
other policy tests that already shell out via `subprocess`, and using the same
`tests.python.support` helpers they do (`paths.REPO_ROOT`,
`tmp_root.temporary_directory`, so scratch dirs land in the ignored `tmp/`). It
asserts repository tooling by running bash, so `tests/python/global/` is the
right home for it in both senses — including the one `test.yml` gives for keeping
`test-global.sh` off the Windows job.

Three cases against the real `common.sh`: missing directory fails, empty
directory fails (and says so on stderr), directory containing a test passes. The
third is there so the suite cannot pass by the runner simply always failing.

Mutation-checked, since a test asserting an exit code is easy to write without
teeth — every change to the two touched lines is caught:

| Mutation | Result |
| --- | --- |
| `return 1` → `return 0` | FAILED (failures=2) |
| `>&2` dropped from the diagnostic | FAILED (failures=1) |
| unmutated | 3 tests, OK |

## Validation

Python 3.12 and Node 22, dependencies per `.github/actions/setup-deps`:

- `scripts/test/test.sh` — exits 0 before and after. Diffing the two per-group
  tables gives exactly one line: `Global policy tests` 79 → 82, the three new
  cases. Every other group is identical.
- `python -m unittest tests/python/global/test_python_test_runner_fails_closed.py`
  — 3 tests, OK
- `scripts/dev/setup-symlinks.sh --check`, `scripts/github-workflows/check-symlinks.sh`,
  `scripts/release/check-version.sh`, `node scripts/release/sync-version.mjs --check`,
  `scripts/test/test-docs.sh`, `scripts/bundle/bundle.sh --check` — all exit 0

## Not covered

A directory under `tests/python/skills/` with no matching `skills/<name>/SKILL.md`
is skipped by the loop in `test-python.sh` without ever reaching
`run_python_unittest`, so this change would not catch that one. No such directory
exists today — all ten map to a skill. Happy to add that check too if you want
it, but it is a different mechanism and I would rather keep this diff to one
thing.
