### PR TITLE
fix(gcode): interpret E-axis movement during validation

### DIFF
--- a/skills/gcode/references/gcode-validation.md
+++ b/skills/gcode/references/gcode-validation.md
@@ -12,6 +12,12 @@ Validation fails when:
 - No nozzle or bed temperature commands are present.
 - Parsed absolute `X`, `Y`, or `Z` moves exceed the wrapper profile motion bounds.
 
+An extrusion move is a `G0`, `G1`, `G2`, or `G3` motion whose interpreted `E`
+position advances. The validator tracks exact `G90`/`G91` commands and
+`M82`/`M83` extruder overrides; a later `G90`/`G91` clears the override. It also
+tracks `G92 E` position resets. Retractions and zero-distance `E` moves do not
+satisfy the extrusion check.
+
 Validation warns when:
 
 - Unknown or unsupported G-code commands are encountered.

--- a/skills/gcode/scripts/gcode_tool.py
+++ b/skills/gcode/scripts/gcode_tool.py
@@ -605,10 +605,6 @@ def parse_command(line: str) -> str:
     if not stripped:
         return ""
     first = stripped.split(None, 1)[0].upper()
-    if re.fullmatch(r"[GMT]\d+(?:\.\d+)?", first):
-        if "." in first:
-            first = first.split(".", 1)[0]
-        return first
     return first
 
 
@@ -644,6 +640,8 @@ def validate_gcode_file(path: Path, profile: GCodeProfile) -> dict[str, Any]:
         errors.append("G-code file is empty.")
 
     absolute_positioning = True
+    extruder_absolute_positioning = True
+    extruder_position = 0.0
     x_min, x_max = profile.motion_bounds_mm["x"]
     y_min, y_max = profile.motion_bounds_mm["y"]
     z_min, z_max = profile.motion_bounds_mm["z"]
@@ -659,15 +657,26 @@ def validate_gcode_file(path: Path, profile: GCodeProfile) -> dict[str, Any]:
 
         if command == "G90":
             absolute_positioning = True
+            extruder_absolute_positioning = True
         elif command == "G91":
             absolute_positioning = False
+            extruder_absolute_positioning = False
             if "Relative positioning found; XYZ bounds validation is skipped while relative mode is active." not in warnings:
                 warnings.append("Relative positioning found; XYZ bounds validation is skipped while relative mode is active.")
+        elif command == "M82":
+            extruder_absolute_positioning = True
+        elif command == "M83":
+            extruder_absolute_positioning = False
+        elif command == "G92" and "E" in tokens:
+            extruder_position = tokens["E"]
 
         if command in {"G0", "G1", "G2", "G3"}:
             stats["movement_commands"] += 1
-            if command == "G1" and "E" in tokens:
-                stats["extrusion_moves"] += 1
+            if "E" in tokens:
+                next_extruder_position = tokens["E"] if extruder_absolute_positioning else extruder_position + tokens["E"]
+                if next_extruder_position > extruder_position:
+                    stats["extrusion_moves"] += 1
+                extruder_position = next_extruder_position
             if absolute_positioning:
                 if "X" in tokens and not x_min <= tokens["X"] <= x_max:
                     errors.append(f"Line {line_number}: X={tokens['X']} is outside X motion range {x_min}..{x_max} mm.")

--- a/tests/python/skills/gcode/test_gcode_tool.py
+++ b/tests/python/skills/gcode/test_gcode_tool.py
@@ -321,6 +321,119 @@ class GCodeToolTests(unittest.TestCase):
         self.assertEqual(result["errors"], [])
         self.assertGreaterEqual(result["stats"]["extrusion_moves"], 1)
 
+    def test_gcode_validation_does_not_count_retraction_as_extrusion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile = gcode.load_profile(write_profile(root))
+            toolpath = root / "retraction_only.gcode"
+            toolpath.write_text(
+                "\n".join(
+                    [
+                        "M104 S220",
+                        "M140 S65",
+                        "G90",
+                        "M83",
+                        "G1 X10 Y10 Z0.2 F1800",
+                        "G1 X15 Y10 E0 F1200",
+                        "G1 X20 Y10 E-1 F1200",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = gcode.validate_gcode_file(toolpath, profile)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["stats"]["extrusion_moves"], 0)
+        self.assertIn("No extrusion moves found.", result["errors"])
+
+    def test_gcode_validation_tracks_extruder_position_and_modes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile = gcode.load_profile(write_profile(root))
+            toolpath = root / "mixed_extrusion_modes.gcode"
+            toolpath.write_text(
+                "\n".join(
+                    [
+                        "M104 S220",
+                        "M140 S65",
+                        "G92 E10",
+                        "M83",
+                        "G90",
+                        "G1 X10 Y10 Z0.2 E9 F1800",
+                        "G91",
+                        "G1 X1 E-1 F1200",
+                        "M82",
+                        "G1 X1 E7.5 F1200",
+                        "M83",
+                        "G2 X1 Y1 I0.5 J0 E0.2 F1200",
+                        "G1 X1 E0.1 F1200",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = gcode.validate_gcode_file(toolpath, profile)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(result["stats"]["extrusion_moves"], 2)
+
+    def test_gcode_validation_counts_forward_extrusion_for_each_motion_command(self) -> None:
+        commands = {
+            "G0": "G0 X10 E-9 F1200",
+            "G1": "G1 X10 E-9 F1200",
+            "G2": "G2 X10 Y10 I5 J0 E-9 F1200",
+            "G3": "G3 X10 Y10 I5 J0 E-9 F1200",
+        }
+        for command, movement in commands.items():
+            with self.subTest(command=command), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                profile = gcode.load_profile(write_profile(root))
+                toolpath = root / f"{command.lower()}_extrusion.gcode"
+                toolpath.write_text(
+                    "\n".join(
+                        [
+                            "M104 S220",
+                            "M140 S65",
+                            "M82",
+                            "G92 E-10",
+                            movement,
+                        ]
+                    ),
+                    encoding="utf-8",
+                )
+
+                result = gcode.validate_gcode_file(toolpath, profile)
+
+            self.assertTrue(result["ok"])
+            self.assertEqual(result["stats"]["extrusion_moves"], 1)
+
+    def test_gcode_validation_does_not_treat_decimal_subcodes_as_positioning_modes(self) -> None:
+        cases = {
+            "relative_extrusion_after_g90_1": (
+                ["G92 E10", "M83", "G90.1", "G2 X10 Y10 I5 J0 E0.2 F1200"],
+                True,
+                1,
+            ),
+            "absolute_retraction_after_g91_1": (
+                ["G92 E10", "M82", "G91.1", "G2 X10 Y10 I5 J0 E9 F1200"],
+                False,
+                0,
+            ),
+        }
+        for name, (commands, expected_ok, expected_extrusion_moves) in cases.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                profile = gcode.load_profile(write_profile(root))
+                toolpath = root / f"{name}.gcode"
+                toolpath.write_text("\n".join(["M104 S220", "M140 S65", *commands]), encoding="utf-8")
+
+                result = gcode.validate_gcode_file(toolpath, profile)
+
+                self.assertEqual(result["ok"], expected_ok)
+                self.assertEqual(result["stats"]["extrusion_moves"], expected_extrusion_moves)
+
     def test_gcode_validation_reports_empty_no_extrusion_and_out_of_bounds(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

- Fixes: Under M83 relative extrusion mode, a toolpath whose only E-axis motion is G1 E-1 is reported valid with extrusion_moves=1 instead of failing with No extrusion moves found.
- Root cause: validate_gcode_file counted every G1 command containing an E token without tracking G90/G91, M82/M83, G92 E, or the prior E position, so retractions and zero-distance moves were mistaken for forward extrusion while G0/G2/G3 extrusion was ignored. Decimal subcodes were also truncated to their base command and could spuriously change positioning mode.

## Regression evidence

- Before: `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/Users/bytedance/workspace/oss-contribution-bot/worktrees/20260816T080230Z/earthtojake--text-to-cad:/Users/bytedance/workspace/oss-contribution-bot/worktrees/20260816T080230Z/earthtojake--text-to-cad/skills/gcode/scripts /Users/bytedance/.local/bin/python3.11 -m unittest -v tests.python.skills.gcode.test_gcode_tool.GCodeToolTests.test_gcode_validation_does_not_count_retraction_as_extrusion` exited `1`

- After: `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/Users/bytedance/workspace/oss-contribution-bot/worktrees/20260816T080230Z/earthtojake--text-to-cad:/Users/bytedance/workspace/oss-contribution-bot/worktrees/20260816T080230Z/earthtojake--text-to-cad/skills/gcode/scripts /Users/bytedance/.local/bin/python3.11 -m unittest -v tests.python.skills.gcode.test_gcode_tool.GCodeToolTests.test_gcode_validation_does_not_count_retraction_as_extrusion` exited `0`

## Verification

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=/Users/bytedance/workspace/oss-contribution-bot/worktrees/20260816T080230Z/earthtojake--text-to-cad:/Users/bytedance/workspace/oss-contribution-bot/worktrees/20260816T080230Z/earthtojake--text-to-cad/skills/gcode/scripts /Users/bytedance/.local/share/uv/python/cpython-3.12-macos-aarch64-none/bin/python3.12 -m unittest -v tests.python.skills.gcode.test_gcode_tool`
- `scripts/dev/setup-symlinks.sh --check`
- `scripts/bundle/bundle.sh --check`
- `scripts/release/check-version.sh`
- `git diff --cached --check && python3.12 -m py_compile skills/gcode/scripts/gcode_tool.py tests/python/skills/gcode/test_gcode_tool.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=.:skills/gcode/scripts python3.12 -m unittest -v tests.python.skills.gcode.test_gcode_tool.GCodeToolTests.test_gcode_validation_does_not_treat_decimal_subcodes_as_positioning_modes`

## Scope

- 3 files changed, +134 / -6 lines
