### PR TITLE
bundle: call a helper that exists, so the vendored cadgen copies are actually checked

### DIFF
--- a/scripts/bundle/skills/bundle-sdf.sh
+++ b/scripts/bundle/skills/bundle-sdf.sh
@@ -85,9 +85,8 @@ fi
 if [ "$MODE" = "check" ]; then
   rm -rf "$CHECK_DIR"
   stale=0
-  vendor_python_package "$CADGEN_PACKAGE_DIR" "$CHECK_DIR/packages/cadgen"
-  check_vendored_python_package "$CADGEN_RUNTIME_DIR" "$CHECK_DIR/packages/cadgen" \
-    "skills/sdf/scripts/packages/cadgen" \
+  check_python_runtime "$CADGEN_PACKAGE_DIR" "$CADGEN_RUNTIME_DIR" \
+    "$CHECK_DIR/packages/cadgen" "skills/sdf/scripts/packages/cadgen" \
     "Run scripts/bundle/bundle-skill.sh sdf and commit the updated production package copy." \
     || stale=1
   check_snapshot || stale=1

--- a/scripts/bundle/skills/bundle-srdf.sh
+++ b/scripts/bundle/skills/bundle-srdf.sh
@@ -85,9 +85,8 @@ fi
 if [ "$MODE" = "check" ]; then
   rm -rf "$CHECK_DIR"
   stale=0
-  vendor_python_package "$CADGEN_PACKAGE_DIR" "$CHECK_DIR/packages/cadgen"
-  check_vendored_python_package "$CADGEN_RUNTIME_DIR" "$CHECK_DIR/packages/cadgen" \
-    "skills/srdf/scripts/packages/cadgen" \
+  check_python_runtime "$CADGEN_PACKAGE_DIR" "$CADGEN_RUNTIME_DIR" \
+    "$CHECK_DIR/packages/cadgen" "skills/srdf/scripts/packages/cadgen" \
     "Run scripts/bundle/bundle-skill.sh srdf and commit the updated production package copy." \
     || stale=1
   check_snapshot || stale=1

--- a/scripts/bundle/skills/bundle-urdf.sh
+++ b/scripts/bundle/skills/bundle-urdf.sh
@@ -85,9 +85,8 @@ fi
 if [ "$MODE" = "check" ]; then
   rm -rf "$CHECK_DIR"
   stale=0
-  vendor_python_package "$CADGEN_PACKAGE_DIR" "$CHECK_DIR/packages/cadgen"
-  check_vendored_python_package "$CADGEN_RUNTIME_DIR" "$CHECK_DIR/packages/cadgen" \
-    "skills/urdf/scripts/packages/cadgen" \
+  check_python_runtime "$CADGEN_PACKAGE_DIR" "$CADGEN_RUNTIME_DIR" \
+    "$CHECK_DIR/packages/cadgen" "skills/urdf/scripts/packages/cadgen" \
     "Run scripts/bundle/bundle-skill.sh urdf and commit the updated production package copy." \
     || stale=1
   check_snapshot || stale=1

--- a/tests/python/global/test_bundle_scripts_call_defined_helpers.py
+++ b/tests/python/global/test_bundle_scripts_call_defined_helpers.py
@@ -1,0 +1,91 @@
+"""Every helper a bundle script calls must actually exist.
+
+`bundle-sdf.sh` called `check_vendored_python_package`, which was never defined anywhere.
+Bash only resolves a function name when the line runs, so nothing caught it: the call sits
+behind a `MODE = check` branch that the development symlink layout skips entirely, and the one
+layout that reaches it -- the production tree on build-test/main -- turned the resulting exit
+127 into `|| stale=1`. The check reported the vendored copy as stale forever, for a reason that
+had nothing to do with the copy, and the skills' vendored cadgen went unverified instead.
+
+A typo in a shell function name is invisible until the branch runs, so check it statically.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+
+from tests.python.support.paths import repo_path
+
+
+BUNDLE_DIR = repo_path("scripts", "bundle")
+
+# The helper families the bundle scripts share. A call to something matching these prefixes is
+# expected to resolve to a definition, in the script itself or in a lib/ file it sources.
+HELPER_CALL_RE = re.compile(
+    r"^\s*((?:check|vendor|build|ensure|require|sync)_[a-z0-9_]+)\b",
+    re.MULTILINE,
+)
+DEFINITION_RE = re.compile(r"^\s*([a-z0-9_]+)\s*\(\)\s*\{", re.MULTILINE)
+
+
+def _shell_scripts() -> list:
+    return sorted(BUNDLE_DIR.rglob("*.sh"))
+
+
+def _defined_names() -> set[str]:
+    """Every function defined anywhere under scripts/bundle/.
+
+    Deliberately repo-wide rather than per-file: the scripts source their libraries through
+    `$SCRIPT_DIR` paths that are awkward to resolve statically, and a name defined nowhere is
+    the failure worth catching. A name defined in the wrong library still runs.
+    """
+    defined: set[str] = set()
+    for script in _shell_scripts():
+        defined.update(DEFINITION_RE.findall(script.read_text(encoding="utf-8")))
+    return defined
+
+
+class BundleHelperCallsResolveTest(unittest.TestCase):
+    def test_scripts_exist_to_check(self) -> None:
+        scripts = _shell_scripts()
+        self.assertTrue(scripts, "expected shell scripts under scripts/bundle/")
+        self.assertTrue(
+            any(script.name.startswith("bundle-") for script in scripts),
+            "expected per-skill bundle-<skill>.sh scripts",
+        )
+
+    def test_every_helper_call_resolves_to_a_definition(self) -> None:
+        defined = _defined_names()
+        missing: list[str] = []
+        for script in _shell_scripts():
+            text = script.read_text(encoding="utf-8")
+            for name in HELPER_CALL_RE.findall(text):
+                if name not in defined:
+                    relative = script.relative_to(repo_path())
+                    missing.append(f"{relative}: {name}")
+        self.assertEqual(
+            [],
+            sorted(set(missing)),
+            "bundle scripts call helper functions that are defined nowhere under "
+            "scripts/bundle/; bash only fails on these when the branch runs",
+        )
+
+    def test_the_known_typo_stays_gone(self) -> None:
+        # The specific name that shipped broken, pinned so it cannot come back by copy-paste.
+        # Compared as a list of filenames rather than with assertNotIn on the text, so a
+        # failure names the scripts instead of dumping every one of them.
+        offenders = [
+            script.name
+            for script in _shell_scripts()
+            if "check_vendored_python_package" in script.read_text(encoding="utf-8")
+        ]
+        self.assertEqual(
+            [],
+            offenders,
+            "these scripts call the undefined helper again; use check_python_runtime",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`bundle-sdf.sh`, `bundle-srdf.sh` and `bundle-urdf.sh` each call `check_vendored_python_package` at line 89. That function is defined nowhere.

Bash resolves a function name only when the line runs, which is why this survived. The call sits behind a `MODE = check` branch, and the development symlink layout returns before reaching it — so no one hits it locally. In the one layout that *does* reach it (the production tree on `build-test`/`main`), bash exits 127, `|| stale=1` swallows that, and the check reports the vendored copy as stale forever for a reason that has nothing to do with the copy.

**The effect wasn't a noisy check — it was an absent one.** These three skills' vendored cadgen has never actually been compared against `packages/cadgen`.

## The fix

The intended helper is `check_python_runtime` (`lib/vendor.sh:70`), which `bundle-cad.sh:109` already uses. It vendors into the tmp check dir itself, so the explicit `vendor_python_package` line above each call goes away with it.

```diff
-  vendor_python_package "$CADGEN_PACKAGE_DIR" "$CHECK_DIR/packages/cadgen"
-  check_vendored_python_package "$CADGEN_RUNTIME_DIR" "$CHECK_DIR/packages/cadgen" \
-    "skills/sdf/scripts/packages/cadgen" \
+  check_python_runtime "$CADGEN_PACKAGE_DIR" "$CADGEN_RUNTIME_DIR" \
+    "$CHECK_DIR/packages/cadgen" "skills/sdf/scripts/packages/cadgen" \
     "Run scripts/bundle/bundle-skill.sh sdf and commit the updated production package copy." \
     || stale=1
```

## Verification

Checking this in the default symlink layout proves nothing, since that layout skips the branch. Verified in **production layout**, the only one that runs this code:

- after `bundle-skill.sh sdf`, the check reports `skills/sdf/scripts/packages/cadgen is up to date` and exits 0 — previously `command not found` → exit 1
- appending one line to the vendored copy makes it fail with the diff and exit 1, so it is genuinely comparing rather than passing vacuously
- same for `srdf` and `urdf`
- full `scripts/bundle/bundle.sh --check` exits 0 in both layouts

**No committed vendored file changed**, so the broken check had not been masking real drift — it simply never ran.

## Regression test

`tests/python/global/test_bundle_scripts_call_defined_helpers.py` asserts that every `check_*` / `vendor_* `/ `build_*` / `ensure_*` / `require_*` / `sync_*` call under `scripts/bundle/` resolves to a definition somewhere in that tree. I confirmed it fails on the pre-fix scripts (naming `bundle-sdf.sh: check_vendored_python_package`) and passes after. It also pins the specific broken name so it can't return by copy-paste.

Policy suite: 85 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
