### PR TITLE
docs: list Grok Build beside Codex and Claude Code

### DIFF
--- a/docs/src/app/page.tsx
+++ b/docs/src/app/page.tsx
@@ -17,6 +17,13 @@ const pluginInstallCommands = [
     command:
       "claude plugin marketplace add earthtojake/text-to-cad\nclaude plugin install cad@text-to-cad",
   },
+  // Grok Build reads the same .claude-plugin/marketplace.json as Claude Code -- there is no
+  // separate Grok manifest -- and installs straight from the repo rather than adding a
+  // marketplace first, so it is one command, not two.
+  {
+    agent: "Grok Build",
+    command: "grok plugin install earthtojake/text-to-cad --trust",
+  },
 ];
 
 const skillGroups = [


### PR DESCRIPTION
Companion to #291, which adds Grok Build to the README. The docs site renders its plugin install commands from its own list, so the README change alone leaves texttocad.dev showing only Codex and Claude Code.

## Verified, not assumed

Ran the real CLI (`grok 1.0.3`) against a sandboxed `HOME` so the local `~/.grok` was untouched:

- `grok plugin validate .` → `Plugin manifest is valid. name: cad, version: 0.4.17` — confirms Grok reads this repo's existing `.claude-plugin/marketplace.json`; there is no separate Grok manifest.
- `grok plugin install earthtojake/text-to-cad --trust` → `Installed 1 plugin(s): cad`, with **all 11 skill directories** present as real directories, no symlinks.

## One command, not two

#291 documents `grok plugin enable cad` as a second step. Install already leaves the plugin enabled — running `enable` on a fresh install prints `Enabled plugin: cad` but changes nothing — so listing it implies an install step that is not one. The docs box is the single install command; `enable` is only needed after an explicit `disable`.

Worth reconciling #291's README block to match before both ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)