### PR TITLE
fix: npm start fails for the shipped CAD Viewer runtime

### DIFF
--- a/scripts/bundle/skills/bundle-cad-viewer.sh
+++ b/scripts/bundle/skills/bundle-cad-viewer.sh
@@ -432,6 +432,13 @@ build_runtime() {
   # tests/test_worker.py not).
   sync_dir "$VIEWER_DIR/server_py" "$target_dir/server_py"
 
+  # Node launcher (scripts/start-viewer.mjs) powers `npm start`; it is
+  # dependency-free so it works inside the bundled runtime without the dev-only
+  # helper modules (cad-python.mjs, directoryRoot.mjs).
+  if [ -d "$VIEWER_DIR/scripts" ]; then
+    sync_dir "$VIEWER_DIR/scripts" "$target_dir/scripts"
+  fi
+
   write_runtime_package_json "$target_dir"
   write_runtime_gitignore "$target_dir"
   write_runtime_requirements "$target_dir"

--- a/viewer/scripts/start-viewer.mjs
+++ b/viewer/scripts/start-viewer.mjs
@@ -1,29 +1,68 @@
 #!/usr/bin/env node
-// Thin shim: launch the Python CAD Viewer launcher (server_py.start_viewer)
-// using the project's discovered venv Python + cadgen PYTHONPATH, so `npm start`
-// can run the Python backend without the caller knowing the venv path. Reuses the
-// proven cadPythonExecutable/cadPythonEnv discovery from the STEP pipeline.
+// Self-contained `npm start` for the CAD Viewer runtime.
+//
+// Run `npm start` where the viewer runtime is installed (source checkout or the
+// bundled skill copy under scripts/viewer) and it boots the Python backend. The
+// script is intentionally dependency-free so it ships inside the bundled skill
+// (scripts/ is copied by build_runtime in scripts/bundle/skills/bundle-cad-viewer.sh);
+// the dev-only helpers it used to import (cad-python.mjs, directoryRoot.mjs) are
+// not part of the runtime distribution.
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { cadPythonExecutable, cadPythonEnv } from "./cad-python.mjs";
-import { resolveDirectoryRoot } from "./directoryRoot.mjs";
-
 const viewerRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const repoRoot = path.resolve(viewerRoot, "..");
-const python = cadPythonExecutable(repoRoot);
-const baseEnv = cadPythonEnv(repoRoot);
-// server_py lives under viewer/ — prepend it so `python -m server_py.*` resolves.
-baseEnv.PYTHONPATH = [viewerRoot, baseEnv.PYTHONPATH].filter(Boolean).join(path.delimiter);
 
-// The backend has no configured directory: a URL path IS the directory, and the bare
-// origin falls back to the process cwd. So the child's cwd must be where the USER ran
-// `npm start` (npm's INIT_CWD), not viewer/ — `npm --prefix` would otherwise make the
-// default directory the viewer's own source tree.
+// Python: explicit env override wins, then a local venv / python found on PATH.
+function findPython() {
+  const configured = String(process.env.VIEWER_CAD_PYTHON || process.env.CAD_PYTHON || "").trim();
+  if (configured) return configured;
+  const candidates = [
+    path.join(viewerRoot, ".venv", "Scripts", "python.exe"),
+    path.join(viewerRoot, ".venv", "bin", "python"),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return process.platform === "win32" ? "python" : "python3";
+}
+
+// PYTHONPATH: same sources the Python tooling uses, so `python -m server_py.*`
+// can see the bundled cadgen and this directory's server_py module.
+function buildPythonPath() {
+  const entries = [];
+  for (const key of ["VIEWER_CAD_PYTHONPATH", "CAD_PYTHONPATH", "VIEWER_CADPY_PYTHONPATH"]) {
+    const value = String(process.env[key] || "").trim();
+    if (value) entries.push(value);
+  }
+  const bundledCadgen = path.join(viewerRoot, "packages", "cadgen", "src");
+  if (existsSync(bundledCadgen) && !entries.includes(bundledCadgen)) entries.push(bundledCadgen);
+  if (process.env.PYTHONPATH) entries.push(process.env.PYTHONPATH);
+  return entries;
+}
+
+// The backend serves whatever directory the URL path names, defaulting to the
+// launcher's cwd. Respect npm's INIT_CWD (where `npm start` was run) but stay
+// inside the runtime's filesystem reach.
+function directoryRoot() {
+  const cwd = process.cwd();
+  const initCwd = process.env.INIT_CWD ? path.resolve(process.env.INIT_CWD) : "";
+  const candidate = initCwd || cwd;
+  if (!candidate) return cwd;
+  return candidate;
+}
+
+const python = findPython();
+const pythonPath = buildPythonPath();
+const env = {
+  ...process.env,
+  ...(pythonPath.length ? { PYTHONPATH: pythonPath.join(path.delimiter) } : {}),
+};
+
 const child = spawn(python, ["-m", "server_py.start_viewer", ...process.argv.slice(2)], {
-  cwd: resolveDirectoryRoot({ env: baseEnv, appRoot: viewerRoot }),
-  env: baseEnv,
+  cwd: directoryRoot(),
+  env,
   stdio: "inherit",
 });
 child.on("exit", (code, signal) => {

--- a/viewer/server_py/start_viewer.py
+++ b/viewer/server_py/start_viewer.py
@@ -37,7 +37,6 @@ else:
     from .paths import url_path_from_filesystem_path
     from .server_info import DEFAULT_VIEWER_PORT, DEFAULT_VIEWER_HOST
 
-_PROBE_TIMEOUT_S = 0.35
 _VIEWER_APP_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
@@ -53,16 +52,19 @@ def viewer_url(host: str, port: int, directory: str = "") -> str:
 
 
 def port_is_free(host: str, port: int) -> bool:
-    """True only when nothing is listening on host:port (connection refused). A
-    live listener — or an ambiguous/unreachable socket — counts as occupied, so
-    we never race a bind against another process."""
-    try:
-        with socket.create_connection((host, port), timeout=_PROBE_TIMEOUT_S):
+    """True only when nothing is listening on host:port.
+
+    Uses a bind probe rather than a connect probe: `connect` expects connection
+    refused, but on some platforms (Windows) trying to connect to a CLOSED port
+    times out instead, which made every port look occupied. Binding is the
+    ground truth here -- if we can claim the port, nothing is using it and we
+    can hand it straight to the backend."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, port))
+        except OSError:
             return False
-    except ConnectionRefusedError:
-        return True
-    except OSError:
-        return False
+    return True
 
 
 def spawn_backend(host: str, port: int):


### PR DESCRIPTION
## Problem

The shipped CAD Viewer runtime (bundled as skills/cad-viewer/scripts/viewer) has a start script that does not work:

- package.json says `npm start` runs `node scripts/start-viewer.mjs`, but build_runtime in the bundler never copies scripts/, so the file is missing from the bundle and npm start dies with module-not-found.
- start-viewer.mjs also imported two dev-only helpers (cad-python.mjs, directoryRoot.mjs) that are likewise not in the runtime.

Separately, start_viewer.py's port probe used connect() to test if a port was free. On Windows a closed local port times out instead of refusing the connection, so the probe reported every port as already in use and the server never started. Even when the launcher was present, npm start exited 1.

## Changes

- bundle-cad-viewer.sh: copy viewer/scripts/ into the runtime bundle.
- start-viewer.mjs: make it dependency-free by inlining the python-discovery and directory-root logic it used to get from the dev-only helpers, so the one file works from a source checkout and from the bundle.
- start_viewer.py: port_is_free now binds the socket (ground truth) instead of connecting; this works on every OS where connect-based probing was unreliable.

## Verification

On Windows, with the CAD venv python set via CAD_PYTHON and PYTHONPATH cleared:

```
$ npm start -- --host 127.0.0.1 --port 4613
Starting CAD Viewer at http://127.0.0.1:4613/
CAD Viewer URL: http://127.0.0.1:4613/
```

and the bundled app serves at that URL (checked / and /__cad/server). Also verified port_is_free directly: free ports return true, an in-tree bind returns false.