### PR TITLE
viewer: restore the trackpad zoom rate the r161 retune halved

### DIFF
--- a/viewer/src/client/components/CadViewer.js
+++ b/viewer/src/client/components/CadViewer.js
@@ -236,7 +236,14 @@ const DEFAULT_DAMPING_FACTOR = 0.14;
 const DEFAULT_ZOOM_SPEED = 4.5;
 const COARSE_POINTER_ZOOM_SPEED = 1.6;
 const EXPLODED_VIEW_ANIMATION_DURATION_MS = 1000;
-const ACCELERATED_WHEEL_ZOOM_SPEED = 2.5;
+// 5.0, not 2.5. The r161 upgrade removed OrbitControls' divide-by-devicePixelRatio, and I
+// retuned this against a single mouse notch without checking what else runs through it. A
+// trackpad flick does: isTrackpadLikeWheelEvent only claims deltas under 20, and momentum
+// carries an ordinary two-finger scroll well past that, so most of a gesture lands here.
+// 2.5 halved it. 5.0 restores exactly what a Retina Mac had before r161 -- 0.95^(5*d/100) is
+// the same curve as the old 0.95^(10*d/200) -- and every display now gets that same curve
+// instead of only the 2x ones.
+const ACCELERATED_WHEEL_ZOOM_SPEED = 5.0;
 const TRACKPAD_PINCH_ZOOM_SPEED = 7;
 const COARSE_POINTER_PINCH_ZOOM_SPEED = 2.4;
 const CAMERA_TRANSITION_EASING = Object.freeze({

--- a/viewer/src/client/components/viewer/wheelZoom.test.js
+++ b/viewer/src/client/components/viewer/wheelZoom.test.js
@@ -12,7 +12,7 @@ import {
 // arithmetic that OrbitControls r161+ applies, so a regression is a failing assertion rather
 // than a bug report from whoever happens to be on a 1x display.
 
-const ACCELERATED_WHEEL_ZOOM_SPEED = 2.5;
+const ACCELERATED_WHEEL_ZOOM_SPEED = 5.0;
 const TRACKPAD_PINCH_ZOOM_SPEED = 7;
 
 /** OrbitControls r161+: deltaMode is normalized to pixels, and a pinch is boosted. */
@@ -44,19 +44,55 @@ function stepFor(event) {
 
 const pct = (event) => Number((((1 - stepFor(event)) * 100)).toFixed(1));
 
+// A trackpad flick is not one small event. Momentum ramps the deltas up through the 20 that
+// isTrackpadLikeWheelEvent uses as its ceiling, so most of a real gesture is scored by the mouse
+// speed. Testing one deltaY of 4 misses that entirely, which is how a 2x trackpad slowdown shipped.
+const FLICK_DELTAS = [3, 7, 14, 26, 48, 71, 58, 39, 22, 11, 5, 2];
+
+/** Distance left after a whole gesture, as a fraction of where it started. */
+function flickRemaining(deltas) {
+  return deltas.reduce((acc, d) => acc * stepFor({ deltaY: d, deltaMode: 0 }), 1);
+}
+
+test("a trackpad flick keeps the rate a Retina Mac had before the r161 upgrade", () => {
+  // r160 computed 0.95 ^ (speed * |d| / (100 * floor(devicePixelRatio))) and used speed 10 above
+  // the trackpad cutoff, so on a 2x display the exponent was |d|/20. r161 dropped the dPR term,
+  // which is why the speed has to double to 5.0 to land on the same curve.
+  const legacyRetina = FLICK_DELTAS.reduce(
+    (acc, d) => acc * 0.95 ** ((Math.abs(d) < 20 ? 14 : 10) * Math.abs(d) / 200),
+    1
+  );
+  const now = flickRemaining(FLICK_DELTAS);
+  assert.ok(
+    Math.abs(now - legacyRetina) < 1e-9,
+    `flick should match the pre-r161 Retina rate: ${now} vs ${legacyRetina}`
+  );
+});
+
+test("the trackpad cutoff is not a cliff in zoom rate", () => {
+  // 19 takes the trackpad path, 21 the mouse path. If the two constants drift apart, a single
+  // gesture crossing that line changes speed mid-scroll, which reads as a stutter.
+  const below = 1 - stepFor({ deltaY: 19, deltaMode: 0 });
+  const above = 1 - stepFor({ deltaY: 21, deltaMode: 0 });
+  const ratio = Math.max(below, above) / Math.min(below, above);
+  assert.ok(ratio < 1.5, `rate jumps ${ratio.toFixed(2)}x across the 20 cutoff`);
+});
+
 test("a mouse notch is the same step regardless of how the browser spells it", () => {
   // Chrome/Safari report pixels; Firefox on Windows and Linux reports LINE mode, where one
   // notch is ~3 lines. Before this, those two differed by roughly 20x.
   const chrome = pct({ deltaY: 100, deltaMode: 0 });
   const firefox = pct({ deltaY: 3, deltaMode: 1 });
-  assert.equal(chrome, 12.0);
+  assert.equal(chrome, 22.6);
   // 3 lines x 16px = 48px against Chrome's 100px: three's own approximation, so they are not
   // identical -- but they are the same order, which is the whole point.
   assert.ok(firefox > 5 && firefox < chrome, `firefox step ${firefox}% should be comparable`);
 });
 
-test("one mouse notch never approaches the 10% zoom floor", () => {
-  // The reported bug: 100% -> 10% in about five notches. A notch that removes 12% needs ~45.
+test("the wheel no longer runs to the zoom floor in a handful of notches", () => {
+  // The report behind #292 was 100% to 10% in about five notches, which is what a 1x display got
+  // when r160 divided the delta by its devicePixelRatio. The bar here is the rate a Retina Mac
+  // always had, now applied everywhere: -22.6% a notch, floor at ten.
   const step = stepFor({ deltaY: 100, deltaMode: 0 });
   let zoom = 100;
   let notches = 0;
@@ -64,7 +100,7 @@ test("one mouse notch never approaches the 10% zoom floor", () => {
     zoom *= step;
     notches += 1;
   }
-  assert.ok(notches > 15, `expected a gradual descent, reached the floor in ${notches} notches`);
+  assert.ok(notches >= 9, `reached the floor in ${notches} notches`);
 });
 
 test("zoom speed no longer depends on devicePixelRatio", () => {


### PR DESCRIPTION
Fixes a regression I introduced in #295. Trackpad zoom on macOS runs at about half its old rate on `develop`.

## What I got wrong

#295 cut `ACCELERATED_WHEEL_ZOOM_SPEED` from 10 to 2.5 after the r161 upgrade removed OrbitControls' divide-by-`devicePixelRatio`. I chose that number against a single mouse notch and never checked what else runs through the constant.

A trackpad does. `isTrackpadLikeWheelEvent` only claims deltas under 20, and momentum carries an ordinary two-finger scroll well past that, so most of a real gesture is scored by the *mouse* speed:

| deltaY | path | before r161 | on develop | ratio |
| --- | --- | --- | --- | --- |
| 4 | trackpad | 1.43% | 1.43% | unchanged |
| 19 | trackpad | 6.59% | 6.59% | unchanged |
| 20 | mouse | 5.00% | 2.53% | **2.0x slower** |
| 80 | mouse | 18.55% | 9.75% | **1.9x slower** |

## Measured in the browser

One flick of realistic momentum deltas (`3, 7, 14, 26, 48, 71, 58, 39, 22, 11, 5, 2`) at 60 Hz, repeated three times, reading the zoom percent on a Retina profile:

| | flick 1 | flick 2 | flick 3 |
| --- | --- | --- | --- |
| `develop` (2.5) | 61% | 38% | 23% |
| this branch (5.0) | 44% | 19% | 10% |

## Why 5.0

Not a fresh guess. r160 scored these events as `0.95 ^ (10 * |d| / (100 * 2))` on a 2x display; r161 dropped the dPR term, so `0.95 ^ (5 * |d| / 100)` is the same curve. A Mac trackpad and a Retina mouse both return to exactly what they had before the upgrade, and every other display now gets that curve too instead of only the 2x ones.

The report behind #292 was a 1x display at -40% a notch. It lands on -22.6% here, and the display-independence that #295 fixed is untouched.

## The test that should have caught it

My test only exercised `deltaY: 4`, which sits in the one bucket that did not change, so the entire regression fell through it. Two tests close that:

- a flick of ramping deltas asserted against the pre-r161 Retina curve
- a check that the rate does not jump across the 20 cutoff, since a gesture crossing that line mid-scroll changes speed and reads as a stutter

viewer 364 passing, `bundle.sh --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
