### PR TITLE
cad_ref_syntax: strip only a leading '#' from a selector

### DIFF
--- a/packages/cadgen/src/cadgen/cad_ref_syntax.py
+++ b/packages/cadgen/src/cadgen/cad_ref_syntax.py
@@ -170,7 +170,12 @@ def parse_selector(
     inherited_occurrence_id: str = "",
     inherited_label: str = "",
 ) -> ParsedSelector | None:
-    selector = str(raw_selector or "").strip().replace("#", "", 1)
+    # Only a LEADING "#" is the token marker. str.replace() takes the first "#"
+    # anywhere, splicing "o1#f2" into the label "o1f2"; the JS parser strips /^#/
+    # and leaves the rest opaque, and the two are one language.
+    selector = str(raw_selector or "").strip()
+    if selector.startswith("#"):
+        selector = selector[1:]
     if not selector:
         return None
 

--- a/packages/cadjs/src/lib/cadRefs.parity.json
+++ b/packages/cadjs/src/lib/cadRefs.parity.json
@@ -166,6 +166,33 @@
       "ordinal": null,
       "label": "frame_rail",
       "canonical": "frame_rail"
+    },
+    {
+      "phase": 0,
+      "why": "only a LEADING '#' is the token marker; a later one is not a separator",
+      "selector": "o1#f2",
+      "selectorType": "opaque",
+      "occurrenceId": "",
+      "ordinal": null,
+      "canonical": "o1#f2"
+    },
+    {
+      "phase": 0,
+      "why": "a trailing '#' is part of the selector text, not something to drop",
+      "selector": "o1#",
+      "selectorType": "opaque",
+      "occurrenceId": "",
+      "ordinal": null,
+      "canonical": "o1#"
+    },
+    {
+      "phase": 1,
+      "why": "an interior '#' must not splice two halves into one label",
+      "selector": "eye#shank",
+      "selectorType": "opaque",
+      "occurrenceId": "",
+      "ordinal": null,
+      "canonical": "eye#shank"
     }
   ],
   "inheritanceCases": [


### PR DESCRIPTION
## What changed

`parse_selector` opened with `str(raw_selector or "").strip().replace("#", "", 1)`. `str.replace` takes the first `#` **anywhere** in the string, not the token marker at the front. `parseCadRefSelector` strips `/^#/`, so the two implementations of the one grammar disagreed on every selector carrying a second `#`:

| selector | Python | JS |
|---|---|---|
| `o1#f2` | label `o1f2` | opaque `o1#f2` |
| `eye#shank` | label `eyeshank` | opaque `eye#shank` |
| `o1#` | occurrence `o1` | opaque `o1#` |

This is reachable from a pasted ref, not just from hand-written input: `CAD_TOKEN_RE` captures the selector half as `[^\s]*`, so a doubled or mis-joined ref like `plate.stl#o1#f2` arrives at the parser intact. Python then spliced the two halves into a label. That is either a confusing failure at the resolution layer, or — if a part happens to be named `o1f2` — a confident answer about geometry the ref never asked for, which is the failure `ensure_ref_file_matches` already exists to prevent on the file half.

Python now strips only a leading `#`, matching JS. Nothing else in the grammar moved.

Three cases go into `cadRefs.parity.json`, which both suites read, so neither language can drift back:

- `o1#f2` — a later `#` is not a separator
- `o1#` — a trailing `#` is selector text, not something to drop
- `eye#shank` — an interior `#` must not splice two halves into one label

## Test plan

- Ran: `PYTHONPATH=".;packages/cadgen/src" python -m unittest tests.python.packages.cadgen.test_cad_ref_syntax_parity` — 14 passed
- Ran: `node --test src/lib/cadRefs.test.js` in `packages/cadjs` — 13 passed
- Checked: with the parser change reverted the three new cases fail (`'opaque' != 'label'`), so they are pinned to the behaviour and not to the fixture
- Not run: `test_cli_output_paths`, `test_step_export_target` (no `OCP` on this checkout — they fail to import on a clean `develop` here too)