### PR TITLE
label_refs: accept the occurrenceId row spelling, and run aliasCases in Python

### DIFF
--- a/packages/cadgen/src/cadgen/label_refs.py
+++ b/packages/cadgen/src/cadgen/label_refs.py
@@ -71,7 +71,12 @@ def build_label_aliases(rows: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     """
     ordered: list[tuple[str, str]] = []
     for row in rows:
-        occurrence_id = str(row.get("id") or "").strip()
+        # `occurrenceId` is the spelling the render package uses for the same
+        # field (cadjs/common/cadScene.js reads `part.id || part.occurrenceId`
+        # throughout), and buildLabelAliasMap accepts both. Reading only `id`
+        # here dropped those rows, so a label the viewer resolves had no alias
+        # in the CLI.
+        occurrence_id = str(row.get("id") or row.get("occurrenceId") or "").strip()
         if not occurrence_id:
             continue
         candidate = _label_candidate(row.get("name"))

--- a/packages/cadjs/src/lib/cadRefs.parity.json
+++ b/packages/cadjs/src/lib/cadRefs.parity.json
@@ -379,6 +379,25 @@
         "pressure_tube": "o1.1.1"
       },
       "ambiguous": {}
+    },
+    {
+      "phase": 1,
+      "why": "a row may carry the render package's `occurrenceId` spelling instead of `id`",
+      "rows": [
+        {
+          "occurrenceId": "o1.1",
+          "name": "eye_shank"
+        },
+        {
+          "id": "o1.2",
+          "name": "pressure_tube"
+        }
+      ],
+      "aliases": {
+        "eye_shank": "o1.1",
+        "pressure_tube": "o1.2"
+      },
+      "ambiguous": {}
     }
   ],
   "tokenCases": [

--- a/tests/python/packages/cadgen/test_cad_ref_syntax_parity.py
+++ b/tests/python/packages/cadgen/test_cad_ref_syntax_parity.py
@@ -13,6 +13,7 @@ import unittest
 
 from tests.python.support.paths import repo_path
 
+from cadgen.label_refs import build_label_aliases
 from cadgen.cad_ref_syntax import (
     build_cad_token,
     ensure_ref_file_matches,
@@ -48,6 +49,22 @@ class SelectorParityTest(unittest.TestCase):
                 self.assertEqual(case["ordinal"], parsed.ordinal)
                 self.assertEqual(case["canonical"], parsed.canonical)
                 self.assertEqual(case.get("label", ""), parsed.label)
+
+
+class AliasParityTest(unittest.TestCase):
+    """The fixture carries aliasCases for both languages, but only the JS suite ran them.
+
+    Nothing here read them, so `buildLabelAliasMap` and `build_label_aliases` could drift
+    with the fixture still green -- which is how the `occurrenceId` row spelling ended up
+    accepted by one side and dropped by the other.
+    """
+
+    def test_every_alias_case_builds_as_the_fixture_says(self) -> None:
+        for case in _fixture()["aliasCases"]:
+            with self.subTest(why=case.get("why", "")):
+                built = build_label_aliases(case["rows"])
+                self.assertEqual(case["aliases"], built["aliases"])
+                self.assertEqual(case.get("ambiguous", {}), built["ambiguous"])
 
 
 class InheritanceParityTest(unittest.TestCase):


### PR DESCRIPTION
## What changed

`buildLabelAliasMap` reads `row.id || row.occurrenceId`. That matches the render package — `cadjs/common/cadScene.js` reads `part.id || part.occurrenceId` in five places and `cadScene.test.js` fixtures key their parts that way. `build_label_aliases` read only `id`, so any row carrying the other spelling was dropped before it could claim an alias, and a label the viewer resolves had no alias in the CLI.

Differential run over the same row sets, before this change:

```
rows: [{"occurrenceId":"o1.1","name":"eye_shank"}, {"id":"o1.2","name":"pressure_tube"}]
  py: {"aliases": {"spaced": ...}}                  -> eye_shank missing
  js: {"aliases": {"eye_shank":"o1.1", ...}}
```

## Why the fixture did not catch it

`cadRefs.parity.json` says every case must hold in both languages, and it carries `aliasCases` — but nothing on the Python side ever read them. `ParityFixtureIsUsableTest` only asserts the key is non-empty, and the imports in `test_cad_ref_syntax_parity.py` stop at the selector grammar, so `build_label_aliases` was never run against the fixture at all. The alias builders could drift with the suite still green, which is exactly what happened.

This adds `AliasParityTest`, so the fixture now does for the alias map what it already does for selectors, plus the case that covers the row spelling.

## Test plan

- Ran: `PYTHONPATH=".;packages/cadgen/src" python -m unittest tests.python.packages.cadgen.test_cad_ref_syntax_parity tests.python.packages.cadgen.test_label_refs` — 35 passed
- Ran: `node --test src/lib/cadRefs.test.js` in `packages/cadjs` — 13 passed
- Checked: with the `label_refs.py` change reverted, the new alias case fails with `{'eye_shank': 'o1.1', 'pressure_tube': 'o1.2'} != {'pressure_tube': 'o1.2'}` — so the test is pinned to the behaviour, not to the fixture
- Checked: a differential run over nine row sets (duplicate names, authored `_1` collisions, nested occurrence ids, blank ids, mixed case, unaliasable names) now agrees between the two implementations on all nine
- Not run: `test_assembly_selector_refs` (no `build123d` on this checkout — it fails to import on a clean `develop` here too)