### PR TITLE
label_refs: accept the occurrenceId row spelling, and run aliasCases in Python

### DIFF
--- a/packages/cadgen/src/cadgen/label_refs.py
+++ b/packages/cadgen/src/cadgen/label_refs.py
@@ -71,7 +71,12 @@ def build_label_aliases(rows: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     """
     ordered: list[tuple[str, str]] = []
     for row in rows:
-        occurrence_id = str(row.get("id") or "").strip()
+        # `occurrenceId` is the spelling the render package uses for the same
+        # field (cadjs/common/cadScene.js reads `part.id || part.occurrenceId`
+        # throughout), and buildLabelAliasMap accepts both. Reading only `id`
+        # here dropped those rows, so a label the viewer resolves had no alias
+        # in the CLI.
+        occurrence_id = str(row.get("id") or row.get("occurrenceId") or "").strip()
         if not occurrence_id:
             continue
         candidate = _label_candidate(row.get("name"))

--- a/packages/cadjs/src/lib/cadRefs.parity.json
+++ b/packages/cadjs/src/lib/cadRefs.parity.json
@@ -379,6 +379,25 @@
         "pressure_tube": "o1.1.1"
       },
       "ambiguous": {}
+    },
+    {
+      "phase": 1,
+      "why": "a row may carry the render package's `occurrenceId` spelling instead of `id`",
+      "rows": [
+        {
+          "occurrenceId": "o1.1",
+          "name": "eye_shank"
+        },
+        {
+          "id": "o1.2",
+          "name": "pressure_tube"
+        }
+      ],
+      "aliases": {
+        "eye_shank": "o1.1",
+        "pressure_tube": "o1.2"
+      },
+      "ambiguous": {}
     }
   ],
   "tokenCases": [

--- a/tests/python/packages/cadgen/test_cad_ref_syntax_parity.py
+++ b/tests/python/packages/cadgen/test_cad_ref_syntax_parity.py
@@ -13,6 +13,7 @@ import unittest
 
 from tests.python.support.paths import repo_path
 
+from cadgen.label_refs import build_label_aliases
 from cadgen.cad_ref_syntax import (
     build_cad_token,
     ensure_ref_file_matches,
@@ -48,6 +49,22 @@ class SelectorParityTest(unittest.TestCase):
                 self.assertEqual(case["ordinal"], parsed.ordinal)
                 self.assertEqual(case["canonical"], parsed.canonical)
                 self.assertEqual(case.get("label", ""), parsed.label)
+
+
+class AliasParityTest(unittest.TestCase):
+    """The fixture carries aliasCases for both languages, but only the JS suite ran them.
+
+    Nothing here read them, so `buildLabelAliasMap` and `build_label_aliases` could drift
+    with the fixture still green -- which is how the `occurrenceId` row spelling ended up
+    accepted by one side and dropped by the other.
+    """
+
+    def test_every_alias_case_builds_as_the_fixture_says(self) -> None:
+        for case in _fixture()["aliasCases"]:
+            with self.subTest(why=case.get("why", "")):
+                built = build_label_aliases(case["rows"])
+                self.assertEqual(case["aliases"], built["aliases"])
+                self.assertEqual(case.get("ambiguous", {}), built["ambiguous"])
 
 
 class InheritanceParityTest(unittest.TestCase):


### PR DESCRIPTION
Carries #301 forward. GitHub would not let me update that branch (`user doesn't have permission to update head repository`), and `develop` requires branches to be up to date, so this is @NgoQuocViet2001's commit with `develop` merged in. Their authorship is preserved on the commit; #301 can be closed once this lands.

Reviewed on the original: the alias-parity test is the valuable part. `cadRefs.parity.json` has carried `aliasCases` since it was added and nothing on the Python side ever read them, so the two alias builders could drift with the suite green. `AliasParityTest` closes that. Reverting the `label_refs.py` change fails the new case, so it is pinned to behaviour rather than to the fixture.

One scoping note for the record: I could not reproduce the described user-facing symptom. `buildLabelAliasMap` has no production callers in JS, every Python caller feeds `id` (`attach_label_aliases` reads `index.occurrences`; `interference.py` builds `{"id": occurrence.ref}`), and `assembly.json` occurrence rows carry `id` and not `occurrenceId`. So this is a latent parity divergence on accepted input rather than an active bug. Worth taking regardless: parity is the contract, and `row.get("id") or row.get("occurrenceId")` matches the JS precedence exactly.

Verified after merging `develop`: both this and #300's leading-`#` fix coexist, 36 Python and 647 cadjs tests pass, fixture now at 21 selector and 7 alias cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)