### PR TITLE
fix(dfam-check): move __main__ guard to end of test file

### DIFF
--- a/tests/python/skills/dfam-check/test_dfam_tool.py
+++ b/tests/python/skills/dfam-check/test_dfam_tool.py
@@ -212,9 +212,6 @@ class CliTest(unittest.TestCase):
         self.assertEqual(len(payload["orientations"]["candidates"]), 6)
 
 
-if __name__ == "__main__":
-    unittest.main()
-
 
 class MultiBodyWallTest(unittest.TestCase):
     """A mating clearance is not a wall.
@@ -325,3 +322,7 @@ class ScaleHintTest(unittest.TestCase):
             path = _stl(Box(20, 20, 15), tmp, "box")
             self.assertIn("scale", _run_cli(["measure", path]))
             self.assertIn("scale", _run_cli(["orientations", path]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up from the review on #265.

The `if __name__ == "__main__": unittest.main()` block sat mid-file, with `MultiBodyWallTest`, `ResilienceTest` and `ScaleHintTest` defined below it. A direct `python test_dfam_tool.py` therefore collected only the 11 classes above the guard and still printed OK — and the 7 it skipped included the `per_body` `p05_mm` coverage from the last round.

CI runs `python -m unittest <paths>`, which imports the module, so all 18 ran there and nothing slipped through on the merged PR.

Moved the guard to the end of the file. Verified before and after:

| path | before | after |
|---|---|---|
| `python test_dfam_tool.py` | 11 tests, OK | 18 tests, OK |
| `python -m unittest <path>` | 18 tests, OK | 18 tests, OK |
| `pytest` | 18 passed | 18 passed |

Self-containment gate still passes. One file, +4/-3.
