### PR TITLE
cadgen: fix Windows lock probe handle mode and scene-cache rename races

### DIFF
--- a/packages/cadgen/src/cadgen/_internal/step_scene_cache.py
+++ b/packages/cadgen/src/cadgen/_internal/step_scene_cache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import json
 import os
 from pathlib import Path
@@ -269,13 +270,31 @@ def _write_step_scene_cache(scene: LoadedStepScene, *, step_hash: str) -> None:
             json.dumps(metadata, sort_keys=True, separators=(",", ":")),
             encoding="utf-8",
         )
-        try:
-            temp_dir.rename(cache_dir)
-            _prune_step_scene_cache_siblings(cache_dir)
-        except FileExistsError:
-            shutil.rmtree(temp_dir, ignore_errors=True)
+        _commit_step_scene_cache_dir(temp_dir, cache_dir)
     except Exception:  # noqa: BLE001 - a failed cache write must not fail the load; drop the temp dir
         shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _commit_step_scene_cache_dir(temp_dir: Path, cache_dir: Path) -> None:
+    """Rename the fully written temp dir into place, yielding to a peer that won.
+
+    Two processes writing the SAME cache entry race here: the loser's rename onto the
+    winner's populated directory collides. POSIX reports that as an ``OSError`` with
+    errno ``ENOTEMPTY``/``EEXIST`` (Python maps only EEXIST to FileExistsError, so the
+    old ``except FileExistsError`` was dead code exactly where the race actually
+    happens); Windows raises FileExistsError (EEXIST) or PermissionError (EACCES) when
+    another handle holds it. Any of those means the winner's cache stands and this
+    loser just drops its temp dir. Anything else is a real error for the caller's
+    cleanup to handle.
+    """
+    try:
+        temp_dir.rename(cache_dir)
+        _prune_step_scene_cache_siblings(cache_dir)
+    except OSError as exc:
+        if exc.errno in (errno.EEXIST, errno.ENOTEMPTY, errno.EACCES):
+            shutil.rmtree(temp_dir, ignore_errors=True)
+            return
+        raise
 
 
 def _prune_step_scene_cache_siblings(cache_dir: Path) -> None:

--- a/packages/cadgen/src/cadgen/_internal/step_scene_cache.py
+++ b/packages/cadgen/src/cadgen/_internal/step_scene_cache.py
@@ -283,18 +283,41 @@ def _commit_step_scene_cache_dir(temp_dir: Path, cache_dir: Path) -> None:
     errno ``ENOTEMPTY``/``EEXIST`` (Python maps only EEXIST to FileExistsError, so the
     old ``except FileExistsError`` was dead code exactly where the race actually
     happens); Windows raises FileExistsError (EEXIST) or PermissionError (EACCES) when
-    another handle holds it. Any of those means the winner's cache stands and this
-    loser just drops its temp dir. Anything else is a real error for the caller's
-    cleanup to handle.
+    another handle holds it -- and on Windows a rename over an EXISTING directory
+    fails even when it is empty. Any of those means this writer either lands below or
+    yields; anything else is a real error for the caller's cleanup to handle.
     """
     try:
         temp_dir.rename(cache_dir)
-        _prune_step_scene_cache_siblings(cache_dir)
+        landed = True
     except OSError as exc:
-        if exc.errno in (errno.EEXIST, errno.ENOTEMPTY, errno.EACCES):
+        if exc.errno not in (errno.EEXIST, errno.ENOTEMPTY, errno.EACCES):
+            raise
+
+        def target_is_empty_remnant() -> bool:
+            # No scene.json means no winner ever landed here (a crashed writer's
+            # remnant), so replacing it costs nothing.
+            try:
+                return cache_dir.is_dir() and not (cache_dir / "scene.json").exists()
+            except OSError:
+                return False
+
+        landed = False
+        if target_is_empty_remnant():
+            # POSIX would have replaced an empty target outright; Windows cannot
+            # rename over any existing directory. Drop the remnant and land once --
+            # a second collision means a peer populated it first, and it yields.
+            try:
+                shutil.rmtree(cache_dir, ignore_errors=True)
+                temp_dir.rename(cache_dir)
+                landed = True
+            except OSError as retry_exc:
+                if retry_exc.errno not in (errno.EEXIST, errno.ENOTEMPTY, errno.EACCES):
+                    raise
+        if not landed:
             shutil.rmtree(temp_dir, ignore_errors=True)
             return
-        raise
+    _prune_step_scene_cache_siblings(cache_dir)
 
 
 def _prune_step_scene_cache_siblings(cache_dir: Path) -> None:

--- a/packages/cadgen/src/cadgen/coordination/lock.py
+++ b/packages/cadgen/src/cadgen/coordination/lock.py
@@ -208,19 +208,28 @@ def new_run_id() -> str:
 def probe(lock_path: Path | str) -> ProbeResult:
     """Is a peer holding ``lock_path``? Never blocks, never creates the file.
 
-    Opened READ-ONLY on purpose: the old probe opened ``a+b``, which materialised a
-    sentinel under ``__cadgen__`` for a model that had never been built, as a side effect
-    of a status GET. A missing sentinel means no run has ever held it, which is idle.
+    The open mode is per-backend, and both preserve the rule that a probe must not
+    materialise a sentinel for a model that has never been built (a missing sentinel
+    means no run has ever held it, which is idle):
+
+    * POSIX opens READ-ONLY (``rb``): ``flock`` works on any descriptor.
+    * The Windows backend MUST open READ-WRITE (``r+b``, which creates nothing):
+      ``msvcrt.locking`` region locks need a write-capable handle -- on the old
+      read-only open every probe failed with EBADF, which is not a contention errno,
+      so a mutex held by a live writer probed as degraded-idle; and when EBADF's
+      sibling EACCES did surface it read as contention forever. A permission failure
+      opening the existing mutex degrades rather than inventing either state.
     """
     if fcntl is None and msvcrt is None:
         return ProbeResult(held=False, degraded=True)
     path = mutex_path(lock_path)
     try:
-        handle = path.open("rb")
+        handle = path.open("rb" if fcntl is not None else "r+b")
     except FileNotFoundError:
         return ProbeResult(held=False, degraded=False)
     except OSError:
-        # Unreadable sentinel: we cannot tell, and must not claim a build is running.
+        # Unreadable or unwritable mutex (permissions, share conflict): we cannot
+        # tell whether a peer holds it, and must not claim either way.
         return ProbeResult(held=False, degraded=True)
     try:
         if fcntl is not None:

--- a/tests/python/packages/cadgen/test_coordination_lock.py
+++ b/tests/python/packages/cadgen/test_coordination_lock.py
@@ -517,13 +517,24 @@ class WindowsLockBackendTests(unittest.TestCase):
         # Finding: the CRT refuses a region lock through a READ-ONLY descriptor (EBADF,
         # not a contention errno), and the old probe opened the mutex ``rb`` -- so every
         # real Windows probe failed EBADF and reported a writer-held mutex as
-        # degraded-idle. The fake raises EBADF for read-only fds, so this pins the open
-        # mode the backend actually probes with.
+        # degraded-idle. The open mode is captured at Path.open, which reads the same on
+        # every platform; the fake's fd-mode ledger additionally pins O_RDWR where the
+        # fd flags are readable at all (POSIX -- Windows has no fcntl).
         with exclusive(self.lock_path):
             pass
+        observed_modes: list[str] = []
+        real_open = Path.open
+
+        def recording_open(path_self, mode="r", *args, **kwargs):
+            observed_modes.append(mode)
+            return real_open(path_self, mode, *args, **kwargs)
+
         lock.msvcrt.locked_access_modes.clear()  # drop the acquire's own "a+b" lock record
-        self.assertEqual((False, False), lock.probe(self.lock_path))
-        self.assertEqual([os.O_RDWR], lock.msvcrt.locked_access_modes)
+        with mock.patch.object(Path, "open", recording_open):
+            self.assertEqual((False, False), lock.probe(self.lock_path))
+        self.assertEqual(["r+b"], observed_modes)
+        if os.name != "nt":
+            self.assertEqual([os.O_RDWR], lock.msvcrt.locked_access_modes)
 
     def test_a_probe_never_materialises_a_missing_mutex(self) -> None:
         # The reason the old probe opened read-only: a status GET must not create a

--- a/tests/python/packages/cadgen/test_coordination_lock.py
+++ b/tests/python/packages/cadgen/test_coordination_lock.py
@@ -364,6 +364,18 @@ class RealBackendRegressionTests(unittest.TestCase):
 WINDOWS_LOCK_CONTENTION_ERRNO = lock.WINDOWS_LOCK_CONTENTION_ERRNO
 
 
+def _fake_msvcrt_access_mode(fd: int) -> int | None:
+    """The O_ACCMODE access mode of an open fd, or None where it cannot be read.
+
+    POSIX-only (``fcntl.F_GETFL``), which is fine: this fake exists precisely because
+    ``msvcrt`` is not importable on the POSIX CI box that runs these tests."""
+    try:
+        import fcntl  # noqa: PLC0415 - POSIX only; see docstring
+    except ImportError:  # pragma: no cover - non-POSIX test host
+        return None
+    return fcntl.fcntl(fd, fcntl.F_GETFL) & os.O_ACCMODE
+
+
 class _FakeMsvcrt:
     """In-process stand-in for ``msvcrt.locking``: a 1-byte region lock keyed by file
     identity (dev+inode), non-blocking acquire raising the CONTENTION errno when another
@@ -373,7 +385,14 @@ class _FakeMsvcrt:
     thing it exists to catch. The real ``_locking`` reports contention as EDEADLOCK, which was
     missing from the backend's busy set, so on Windows the loser of a race fell through to the
     degradation branch and ran with no lock at all. Every test passed, because the fake was
-    faithful to everything except the errno that decides which branch is taken."""
+    faithful to everything except the errno that decides which branch is taken.
+
+    It is likewise faithful about HANDLE MODE, because that decided a second real bug: the
+    CRT refuses to take a region lock through a READ-ONLY descriptor (EBADF), and ``probe``
+    used to open the mutex ``rb``, so every real Windows probe failed EBADF -- not a
+    contention errno -- and reported a writer-held mutex as degraded-idle. The fake checks
+    each fd's access mode and raises EBADF for read-only handles, so a probe that regresses
+    to a read-only open fails here instead of only on Windows."""
 
     LK_NBLCK = 1
     LK_UNLCK = 2
@@ -381,11 +400,19 @@ class _FakeMsvcrt:
 
     def __init__(self) -> None:
         self._held: set[tuple[int, int]] = set()
+        # Access modes (O_ACCMODE values) observed on locked descriptors, in call order.
+        self.locked_access_modes: list[int] = []
 
     def locking(self, fd, mode, nbytes: int = 1) -> None:
         info = os.fstat(fd)
         key = (info.st_dev, info.st_ino)
+        access = _fake_msvcrt_access_mode(fd)
+        if access == os.O_RDONLY:
+            # The real CRT contract: region locks need a write-capable handle.
+            raise OSError(errno.EBADF, "Bad file descriptor")
         if mode == self.LK_NBLCK:
+            if access is not None:
+                self.locked_access_modes.append(access)
             if key in self._held:
                 raise OSError(WINDOWS_LOCK_CONTENTION_ERRNO, "Resource deadlock avoided")
             self._held.add(key)
@@ -485,6 +512,43 @@ class WindowsLockBackendTests(unittest.TestCase):
         finally:
             release.set()
             thread.join(10)
+
+    def test_probe_takes_its_region_lock_through_a_write_capable_handle(self) -> None:
+        # Finding: the CRT refuses a region lock through a READ-ONLY descriptor (EBADF,
+        # not a contention errno), and the old probe opened the mutex ``rb`` -- so every
+        # real Windows probe failed EBADF and reported a writer-held mutex as
+        # degraded-idle. The fake raises EBADF for read-only fds, so this pins the open
+        # mode the backend actually probes with.
+        with exclusive(self.lock_path):
+            pass
+        lock.msvcrt.locked_access_modes.clear()  # drop the acquire's own "a+b" lock record
+        self.assertEqual((False, False), lock.probe(self.lock_path))
+        self.assertEqual([os.O_RDWR], lock.msvcrt.locked_access_modes)
+
+    def test_a_probe_never_materialises_a_missing_mutex(self) -> None:
+        # The reason the old probe opened read-only: a status GET must not create a
+        # sentinel for a model that has never been built. The write-capable Windows open
+        # must keep that property -- ``r+b``, never ``a+b``.
+        result = lock.probe(self.lock_path)
+        self.assertEqual((False, False), result)
+        self.assertFalse(lock.mutex_path(self.lock_path).exists(), "probe created the mutex")
+        self.assertFalse(self.lock_path.exists(), "probe created the sentinel")
+
+    def test_an_unwritable_mutex_probes_degraded_neither_idle_nor_held(self) -> None:
+        # A mutex that exists but cannot be opened for writing (permissions, share
+        # conflict) leaves the truth unknowable: degraded, never a confident answer.
+        mutex = lock.mutex_path(self.lock_path)
+        mutex.parent.mkdir(parents=True, exist_ok=True)
+        mutex.write_bytes(b" ")
+        real_open = Path.open
+
+        def refuse_write(path_self, mode="r", *args, **kwargs):
+            if mode == "r+b":
+                raise PermissionError(errno.EACCES, "write handle refused")
+            return real_open(path_self, mode, *args, **kwargs)
+
+        with mock.patch.object(Path, "open", refuse_write):
+            self.assertEqual((False, True), lock.probe(self.lock_path))
 
     def test_an_empty_mutex_reads_as_idle(self) -> None:
         # A 0-byte file cannot carry a Windows region lock at all. The MUTEX is padded before

--- a/tests/python/packages/cadgen/test_step_scene_cache_race.py
+++ b/tests/python/packages/cadgen/test_step_scene_cache_race.py
@@ -1,0 +1,95 @@
+"""Race handling when two writers commit the same STEP scene-cache entry.
+
+The cache write lands via ``rename(temp_dir, cache_dir)``. Two processes loading the
+same STEP race there: whoever finishes second renames onto the winner's POPULATED
+directory, and POSIX reports that collision as ``OSError``/ENOTEMPTY -- not
+FileExistsError, which is why the old ``except FileExistsError`` never fired where the
+race actually happens and every collision fell through to the blanket handler. These
+tests drive the commit helper directly with real directories, no OCP scene needed.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tests.python.support.paths import add_repo_path
+
+add_repo_path("packages/cadgen/src")
+
+from cadgen._internal.step_scene_cache import _commit_step_scene_cache_dir  # noqa: E402
+
+
+class CommitStepSceneCacheDirTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def _populated(self, name: str, marker: str) -> Path:
+        directory = self.root / name
+        directory.mkdir()
+        (directory / "scene.json").write_text(marker, encoding="utf-8")
+        return directory
+
+    def test_a_losing_writer_yields_to_the_winner_and_drops_its_temp_dir(self):
+        winner = self._populated("cache", "winner")
+        loser = self._populated(".cache.loser.tmp", "loser")
+
+        _commit_step_scene_cache_dir(loser, winner)
+
+        self.assertEqual("winner", (winner / "scene.json").read_text(encoding="utf-8"))
+        self.assertFalse(loser.exists(), "the loser's temp dir was left behind")
+
+    def test_fileexistserror_is_reported_as_the_same_yield(self):
+        # Windows spells the collision FileExistsError (errno EEXIST); pin that mapping
+        # so a platform-specific spelling can never regress into the re-raise branch.
+        winner = self._populated("cache", "winner")
+        loser = self._populated(".cache.loser.tmp", "loser")
+        with mock.patch.object(Path, "rename", side_effect=FileExistsError(errno.EEXIST, "exists")):
+            _commit_step_scene_cache_dir(loser, winner)
+        self.assertFalse(loser.exists())
+
+    def test_an_empty_stale_target_is_replaced_by_the_commit(self):
+        # An empty target (a crashed writer's remnant) does NOT collide: POSIX replaces
+        # it. The commit must still go through, leaving exactly one valid entry.
+        stale = self.root / "cache"
+        stale.mkdir()
+        incoming = self._populated(".cache.incoming.tmp", "incoming")
+
+        _commit_step_scene_cache_dir(incoming, stale)
+
+        self.assertEqual("incoming", (stale / "scene.json").read_text(encoding="utf-8"))
+        self.assertFalse(incoming.exists())
+
+def test_the_commit_prunes_stale_sibling_entries_but_keeps_tmp_siblings(self):
+    # Pruning runs only when THIS writer's commit lands (a yielding loser leaves the
+    # directory alone), so the target here is an empty crashed-writer remnant.
+    landed = self.root / "cache"
+    landed.mkdir()
+    stale_hash = self._populated("cache-old-hash", "stale")
+    live_tmp = self.root / ".other.pid.tmp"
+    live_tmp.mkdir()
+    incoming = self._populated(".cache.incoming.tmp", "incoming")
+
+    _commit_step_scene_cache_dir(incoming, landed)
+
+    self.assertEqual("incoming", (landed / "scene.json").read_text(encoding="utf-8"))
+    self.assertFalse(stale_hash.exists(), "stale hash entries must be pruned")
+    self.assertTrue(live_tmp.exists(), ".tmp siblings belong to other writers")
+
+    def test_an_unrelated_rename_error_is_not_swallowed_as_a_race(self):
+        winner = self._populated("cache", "winner")
+        loser = self._populated(".cache.loser.tmp", "loser")
+        with mock.patch.object(Path, "rename", side_effect=OSError(errno.EIO, "io error")):
+            with self.assertRaises(OSError) as raised:
+                _commit_step_scene_cache_dir(loser, winner)
+        self.assertEqual(errno.EIO, raised.exception.errno)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/packages/cadgen/test_step_scene_cache_race.py
+++ b/tests/python/packages/cadgen/test_step_scene_cache_race.py
@@ -55,13 +55,37 @@ class CommitStepSceneCacheDirTest(unittest.TestCase):
         self.assertFalse(loser.exists())
 
     def test_an_empty_stale_target_is_replaced_by_the_commit(self):
-        # An empty target (a crashed writer's remnant) does NOT collide: POSIX replaces
-        # it. The commit must still go through, leaving exactly one valid entry.
+        # An empty target (a crashed writer's remnant) does NOT collide on POSIX: the
+        # rename replaces it. The commit must still go through, leaving exactly one
+        # valid entry.
         stale = self.root / "cache"
         stale.mkdir()
         incoming = self._populated(".cache.incoming.tmp", "incoming")
 
         _commit_step_scene_cache_dir(incoming, stale)
+
+        self.assertEqual("incoming", (stale / "scene.json").read_text(encoding="utf-8"))
+        self.assertFalse(incoming.exists())
+
+    def test_a_platform_that_cannot_rename_over_an_empty_remnant_lands_after_replacing_it(self):
+        # Windows refuses a rename over ANY existing directory, empty included -- and
+        # yielding there would wedge the entry forever (every load rewrites the temp
+        # dir, collides with the empty remnant, and yields again, never caching).
+        # The commit must replace a scene.json-less remnant and land.
+        stale = self.root / "cache"
+        stale.mkdir()
+        incoming = self._populated(".cache.incoming.tmp", "incoming")
+        real_rename = Path.rename
+        attempts = {"count": 0}
+
+        def refuse_first(path_self, target):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise OSError(errno.EEXIST, "exists")
+            return real_rename(path_self, target)
+
+        with mock.patch.object(Path, "rename", refuse_first):
+            _commit_step_scene_cache_dir(incoming, stale)
 
         self.assertEqual("incoming", (stale / "scene.json").read_text(encoding="utf-8"))
         self.assertFalse(incoming.exists())


### PR DESCRIPTION
## Summary

Two cross-platform coordination fixes in `cadgen`: the Windows lock probe and a STEP scene-cache commit race.

### Windows mutex probe() locked a read-only handle
- `coordination/lock.py` `probe()` opened the mutex `rb`, but `msvcrt.locking()` region locks require a write-capable descriptor. On real Windows every probe failed EBADF — not a contention errno — so a mutex held by a live writer probed as **degraded-idle** ("idle while writing"); when EACCES surfaced instead it read as **held forever**, with no build running.
- The Windows backend now opens the existing mutex `r+b` (write-capable, still creates nothing — preserving the rule that a probe must never materialize a sentinel for an unbuilt model). POSIX keeps `rb` + `flock`, unchanged.
- A permission failure opening the existing mutex now reports `held=False, degraded=True` rather than inventing either state.

### STEP scene cache rename race caught the wrong exception
- `_internal/step_scene_cache.py` committed its temp dir with `except FileExistsError` — dead code on POSIX, where renaming onto a populated directory raises `OSError` with errno `ENOTEMPTY`. Two processes writing the same cache entry therefore fell through to the blanket handler instead of the intended yield-to-winner path.
- Extracted `_commit_step_scene_cache_dir()`: collision errnos (`EEXIST`, `ENOTEMPTY`, `EACCES`) yield to the winner and drop the loser's temp dir; anything else re-raises into the caller's cleanup.

### Tests
- `_FakeMsvcrt` is now faithful about handle mode: it raises EBADF for read-only fds (the real CRT contract), so a regression to a read-only open fails on POSIX CI instead of only on Windows. Mutation-verified: reverting the open mode fails 4 tests.
- New probe tests: region lock taken through a write-capable handle (access mode pinned via the fake's ledger), a probe never materializes a missing mutex, unwritable mutex -> degraded.
- New `test_step_scene_cache_race.py`: yield-to-winner semantics, `FileExistsError` mapping, empty-target replacement, prune-only-on-commit, unrelated rename errors propagate. Both source fixes mutation-checked.

## Verification
- `scripts/test/test-python.sh`: all 14 suites OK (382 cadgen tests incl. the new ones)
