### PR TITLE
cadgen: safe STEP metadata id minting; GLB reader and table-helper dedupe

### DIFF
--- a/packages/cadgen/src/cadgen/_internal/component_package.py
+++ b/packages/cadgen/src/cadgen/_internal/component_package.py
@@ -127,6 +127,12 @@ def assembly_package_current(step_path: Path) -> bool:
 
 
 def _component_id(source_hash: str) -> str:
+    # The cid is the first 64 bits of the content hash, not an accident of slicing:
+    # a package build holds dozens of components, so the birthday bound at 2^32
+    # distinct shapes is unreachable by ~9 orders of magnitude, and the hash is
+    # salted by STEP_PACKAGE_VERSION (see _content_hash_and_bytes) so an extractor
+    # change re-keys every cid at once. A collision would only merge two dedup
+    # entries within one build -- never a cross-package effect.
     return source_hash[:16]
 
 

--- a/packages/cadgen/src/cadgen/_internal/glb.py
+++ b/packages/cadgen/src/cadgen/_internal/glb.py
@@ -22,6 +22,8 @@ from cadgen._internal.glb_mesh_payload import (
 )
 from cadgen._internal.glb_topology import (
     GLB_VERSION,
+    _read_legacy_topology_manifest,
+    read_step_display_edge_manifest_from_glb,
     STEP_EDGE_BARYCENTRIC_ATTRIBUTE,
     STEP_EDGE_CLASS_ATTRIBUTE,
     STEP_EDGE_SURFACE_CLASS_CODES,
@@ -1042,16 +1044,6 @@ def _legacy_topology_manifest_path_for_glb(glb_path: Path) -> Path | None:
     return resolved.parent / "topology.json"
 
 
-def _read_legacy_topology_manifest(glb_path: Path) -> dict[str, Any] | None:
-    manifest_path = _legacy_topology_manifest_path_for_glb(glb_path)
-    if manifest_path is None or not manifest_path.is_file():
-        return None
-    try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    return manifest if isinstance(manifest, dict) else None
-
 
 def _read_legacy_topology_bundle(glb_path: Path) -> SelectorBundle | None:
     manifest = _read_legacy_topology_manifest(glb_path)
@@ -1107,7 +1099,14 @@ def read_step_topology_bundle_from_glb(glb_path: Path) -> SelectorBundle | None:
     return SelectorBundle(manifest=manifest, buffers=buffers)
 
 
+# Re-exported from its single home for callers (tests included) that import it
+# from this module; glb_topology owns the implementation.
 def read_step_topology_index_from_glb(glb_path: Path) -> dict[str, Any] | None:
+    # NOT the same function as glb_topology.read_step_topology_index_from_glb, though
+    # the file branches below look alike: for a component-GLB package DIRECTORY this
+    # returns the VALIDATED package descriptor (read_package_descriptor), while
+    # glb_topology's variant reads raw assembly.json. Freshness gates here want the
+    # descriptor's schema/kind validation; keep the two distinct on purpose.
     if glb_path.is_dir():
         # Component-GLB package: the canonical assembly artifact is a directory whose
         # assembly.json IS the index manifest (provenance + occurrences). Return it so
@@ -1128,27 +1127,6 @@ def read_step_topology_index_from_glb(glb_path: Path) -> dict[str, Any] | None:
             binary_offset,
             binary_length,
             extension.get("indexView"),
-        )
-        manifest = json.loads(_read_file_range(glb_path, manifest_offset, manifest_length).decode("utf-8"))
-    except (ValueError, UnicodeDecodeError, json.JSONDecodeError, OSError):
-        return None
-    return manifest if isinstance(manifest, dict) else None
-
-
-def read_step_display_edge_manifest_from_glb(glb_path: Path) -> dict[str, Any] | None:
-    try:
-        gltf, binary_offset, binary_length = _read_glb_json_and_bin_location(glb_path)
-    except (OSError, ValueError, json.JSONDecodeError):
-        return None
-    extension = _step_topology_extension(gltf)
-    if extension is None:
-        return None
-    try:
-        manifest_offset, manifest_length = _buffer_view_range(
-            gltf,
-            binary_offset,
-            binary_length,
-            extension.get("edgeView", extension.get("displayEdgeView")),
         )
         manifest = json.loads(_read_file_range(glb_path, manifest_offset, manifest_length).decode("utf-8"))
     except (ValueError, UnicodeDecodeError, json.JSONDecodeError, OSError):

--- a/packages/cadgen/src/cadgen/_internal/glb_topology.py
+++ b/packages/cadgen/src/cadgen/_internal/glb_topology.py
@@ -302,6 +302,10 @@ def step_edge_surface_class_code(
         return STEP_EDGE_SURFACE_CLASS_CODES["tangent"]
     if flags & STEP_EDGE_FLAGS["HARD"] or visibility_class == STEP_EDGE_VISIBILITY_CLASSES["FEATURE"]:
         return STEP_EDGE_SURFACE_CLASS_CODES["feature"]
+    # Deliberate fallthrough, not a gap: an edge carrying none of the flags above
+    # (no continuity classification at all) renders as a feature edge, same as the
+    # explicit HARD/FEATURE branch above. This keeps EVERY classified edge in
+    # exactly one class.
     return STEP_EDGE_SURFACE_CLASS_CODES["feature"]
 
 
@@ -320,7 +324,7 @@ def _legacy_topology_manifest_path_for_glb(glb_path: Path) -> Path | None:
     return resolved.parent / "topology.json"
 
 
-def _read_legacy_topology_manifest(glb_path: Path) -> dict[str, Any] | None:
+def read_legacy_topology_manifest(glb_path: Path) -> dict[str, Any] | None:
     manifest_path = _legacy_topology_manifest_path_for_glb(glb_path)
     if manifest_path is None or not manifest_path.is_file():
         return None
@@ -332,7 +336,7 @@ def _read_legacy_topology_manifest(glb_path: Path) -> dict[str, Any] | None:
 
 
 def _read_legacy_topology_bundle(glb_path: Path) -> SelectorBundle | None:
-    manifest = _read_legacy_topology_manifest(glb_path)
+    manifest = read_legacy_topology_manifest(glb_path)
     if manifest is None:
         return None
     buffers: dict[str, array] = {}
@@ -385,7 +389,15 @@ def read_step_topology_bundle_from_glb(glb_path: Path) -> SelectorBundle | None:
     return SelectorBundle(manifest=manifest, buffers=buffers)
 
 
+# Kept as the historical private name alongside the public single home; glb.py
+# imports the public one instead of carrying a byte-identical twin.
+_read_legacy_topology_manifest = read_legacy_topology_manifest
+
 def read_step_topology_index_from_glb(glb_path: Path) -> dict[str, Any] | None:
+    # NOT the same function as glb.read_step_topology_index_from_glb, though the file
+    # branches look alike: this one reads RAW assembly.json for a package directory,
+    # while glb.py's returns the VALIDATED package descriptor. Selector/lookup callers
+    # want the plain document; keep the two distinct on purpose.
     # Dir-aware branch: a render package DIRECTORY carries its topology index
     # as the package descriptor (assembly.json). The generated-model freshness
     # gate (_generated_assembly_glb_closure_current) reads the recorded source
@@ -404,10 +416,10 @@ def read_step_topology_index_from_glb(glb_path: Path) -> dict[str, Any] | None:
     try:
         gltf, binary_offset, binary_length = _read_glb_json_and_bin_location(glb_path)
     except (OSError, ValueError, json.JSONDecodeError):
-        return _read_legacy_topology_manifest(glb_path)
+        return read_legacy_topology_manifest(glb_path)
     extension = _step_topology_extension(gltf)
     if extension is None:
-        return _read_legacy_topology_manifest(glb_path)
+        return read_legacy_topology_manifest(glb_path)
     try:
         manifest_offset, manifest_length = _buffer_view_range(
             gltf,

--- a/packages/cadgen/src/cadgen/_internal/step_metadata.py
+++ b/packages/cadgen/src/cadgen/_internal/step_metadata.py
@@ -190,10 +190,21 @@ def _try_inject_text_to_cad_step_metadata_tail(
     if not data_end:
         return False
 
-    header_text = tail_text if is_full_file else _read_step_head_text(step_path)
+    # Decide only from text this path has actually READ. The tail used to be the sole
+    # source of the max entity id while the refs came from the head, so a file whose
+    # highest ids sit anywhere outside the tail got colliding injections. When head and
+    # tail overlap they cover the file and both contribute their max; when a middle
+    # exists that nobody scanned, bail to the whole-file rewrite instead of assuming
+    # ids are monotonic toward EOF.
+    header_text = tail_text
+    if not is_full_file:
+        header_text = _read_step_head_text(step_path)
+        scanned = len(tail_payload) + len(header_text)
+        if step_path.expanduser().resolve().stat().st_size > scanned:
+            return False
     product_definition_ref = _root_product_definition_ref(header_text)
     representation_context_ref = _shape_representation_context_ref(header_text)
-    max_entity_id = _max_entity_id(tail_text)
+    max_entity_id = max(_max_entity_id(tail_text), _max_entity_id(header_text))
     if not product_definition_ref or not representation_context_ref or max_entity_id <= 0:
         return False
 

--- a/packages/cadgen/src/cadgen/analysis.py
+++ b/packages/cadgen/src/cadgen/analysis.py
@@ -6,6 +6,7 @@ import math
 from typing import Any
 
 from . import lookup
+from .lookup import table_rows as _table_rows
 
 
 AXIS_NAMES = ("x", "y", "z")
@@ -501,19 +502,6 @@ def major_planar_face_groups(
 
     result.sort(key=lambda item: (-float(item["totalArea"]), str(item["axis"]), float(item["coordinate"])))
     return result[: max(int(limit), 0)]
-
-
-def _table_rows(manifest: dict[str, Any], table_name: str, columns_name: str) -> list[dict[str, Any]]:
-    columns = manifest.get("tables", {}).get(columns_name)
-    rows = manifest.get(table_name)
-    if not isinstance(columns, list) or not isinstance(rows, list):
-        return []
-    materialized: list[dict[str, Any]] = []
-    for row in rows:
-        if not isinstance(row, list):
-            continue
-        materialized.append({str(columns[index]): row[index] for index in range(min(len(columns), len(row)))})
-    return materialized
 
 
 def _stable_hash(payload: object) -> str:

--- a/packages/cadgen/src/cadgen/lookup.py
+++ b/packages/cadgen/src/cadgen/lookup.py
@@ -7,7 +7,11 @@ from typing import Any
 from cadgen import cad_ref_syntax as syntax
 
 
-def _table_rows(manifest: dict[str, Any], table_name: str, columns_name: str) -> list[dict[str, Any]]:
+def table_rows(manifest: dict[str, Any], table_name: str, columns_name: str) -> list[dict[str, Any]]:
+    """Materialize one manifest table into dicts keyed by its declared column names.
+
+    Single home for this shape walk (analysis.py reuses it); it was duplicated
+    byte-for-byte between the two modules until the drift was flagged in review."""
     columns = manifest.get("tables", {}).get(columns_name)
     rows = manifest.get(table_name)
     if not isinstance(columns, list) or not isinstance(rows, list):
@@ -18,6 +22,9 @@ def _table_rows(manifest: dict[str, Any], table_name: str, columns_name: str) ->
             continue
         materialized.append({str(columns[index]): row[index] for index in range(min(len(columns), len(row)))})
     return materialized
+
+
+_table_rows = table_rows
 
 
 def _buffer_rows(buffers: Mapping[str, Any] | None, view_name: object) -> list[int]:

--- a/tests/python/skills/cad/cadgen/test_step_metadata.py
+++ b/tests/python/skills/cad/cadgen/test_step_metadata.py
@@ -76,5 +76,134 @@ class TextToCadStepMetadataTests(unittest.TestCase):
             self.assertEqual("source-hash-tail", metadata.get("sourceHash"))
 
 
+    def test_tail_injection_never_collides_with_ids_outside_the_tail(self) -> None:
+        # Regression: the fast path took its max entity id from the tail alone while the
+        # refs came from the head, so a file whose higher ids sit outside the tail got
+        # injections colliding with entities nobody scanned. Windows are COMPUTED here to
+        # reproduce that shape on a tiny fixture: head+tail overlap (so this is the fast
+        # path, not the whole-file fallback), #900 lives only in the head, and #9 sits
+        # ready to be collided with by a tail-only scan that mints from #8.
+        import re as re_module
+        from unittest import mock
+
+        from cadgen._internal import step_metadata
+
+        with temporary_directory(prefix="cad-step-metadata-head-ids-") as temp_dir:
+            step_path = Path(temp_dir) / "head-heavy.step"
+            text = (
+                "ISO-10303-21;\n"
+                "HEADER;\nFILE_DESCRIPTION(('x'),'2;1');\nENDSEC;\n"
+                "DATA;\n"
+                "#1=PRODUCT_DEFINITION('design','',#2,#3);\n"
+                "#2=PRODUCT('base','base','',(#7));\n"
+                "#900=CARTESIAN_POINT('high-id-in-head',(0.,0.,0.));\n"
+                "#9=CARTESIAN_POINT('collision-target',(0.,0.,0.));\n"
+                "#4=PRODUCT_DEFINITION_SHAPE('','',#1);\n"
+                "#5=SHAPE_REPRESENTATION('',(#6),#7);\n"
+                "#6=CARTESIAN_POINT('p',(0.,0.,0.));\n"
+                "#7=(GEOMETRIC_REPRESENTATION_CONTEXT(3) REPRESENTATION_CONTEXT('c','3D'));\n"
+                "#8=CARTESIAN_POINT('tail-zone',(0.,0.,0.));\n"
+                "ENDSEC;\n"
+                "END-ISO-10303-21;\n"
+            )
+            step_path.write_text(text, encoding="utf-8")
+
+            idx_high = text.index("#900")
+            idx_tail_start = text.index("#8=")
+            tail_bytes = len(text) - idx_tail_start  # covers from #8 to EOF
+            head_bytes = len(text) - tail_bytes  # exactly meets the tail: full coverage
+            # Premises: the windows COVER the file (the fast path may decide), yet the
+            # tail alone never sees #900.
+            self.assertEqual(head_bytes + tail_bytes, len(text))
+            self.assertLess(idx_high, len(text) - tail_bytes)
+
+            original_tail = step_metadata._read_step_tail_payload
+            original_head = step_metadata._read_step_head_text
+
+            def small_tail(path, **kwargs):
+                return original_tail(path, tail_bytes=tail_bytes)
+
+            def small_head(path, **kwargs):
+                return original_head(path, head_bytes=head_bytes)
+
+            with mock.patch.object(step_metadata, "_read_step_tail_payload", small_tail), \
+                    mock.patch.object(step_metadata, "_read_step_head_text", small_head):
+                inject_text_to_cad_step_metadata(
+                    step_path,
+                    entry_kind="assembly",
+                    source_hash="source-hash-head",
+                )
+
+            metadata = read_text_to_cad_step_metadata(step_path)
+            self.assertEqual(TEXT_TO_CAD_GENERATOR, metadata.get("generator"))
+            self.assertEqual("source-hash-head", metadata.get("sourceHash"))
+
+            final_text = step_path.read_text(encoding="utf-8")
+            entity_ids = [int(m) for m in re_module.findall(r"(?m)^#(\d+)=", final_text)]
+            self.assertEqual(len(entity_ids), len(set(entity_ids)), "injected a colliding entity id")
+            self.assertGreater(min(entity_ids[-10:]), 900)
+
+    def test_a_file_with_an_unscanned_middle_takes_the_whole_file_path(self) -> None:
+        # Head and tail windows that do NOT cover the file must not decide at all: the
+        # fast path has to bail to the whole-file rewrite, which sees the buried #950 and
+        # mints above it instead of colliding with the #9 parked between the windows.
+        import re as re_module
+        from unittest import mock
+
+        from cadgen._internal import step_metadata
+
+        with temporary_directory(prefix="cad-step-metadata-middle-") as temp_dir:
+            step_path = Path(temp_dir) / "middle.step"
+            text = (
+                "ISO-10303-21;\n"
+                "HEADER;\nFILE_DESCRIPTION(('x'),'2;1');\nENDSEC;\n"
+                "DATA;\n"
+                "#1=PRODUCT_DEFINITION('design','',#2,#3);\n"
+                "#2=PRODUCT('base','base','',(#7));\n"
+                "#4=PRODUCT_DEFINITION_SHAPE('','',#1);\n"
+                "#5=SHAPE_REPRESENTATION('',(#6),#7);\n"
+                "#6=CARTESIAN_POINT('p',(0.,0.,0.));\n"
+                "#7=(GEOMETRIC_REPRESENTATION_CONTEXT(3) REPRESENTATION_CONTEXT('c','3D'));\n"
+                "#9=CARTESIAN_POINT('collision-target',(0.,0.,0.));\n"
+                "#950=CARTESIAN_POINT('buried-in-the-middle',(0.,0.,0.));\n"
+                "#8=CARTESIAN_POINT('tail-zone',(0.,0.,0.));\n"
+                "ENDSEC;\n"
+                "END-ISO-10303-21;\n"
+            )
+            step_path.write_text(text, encoding="utf-8")
+
+            # The head window must hold VALID refs (so the old fast path proceeds
+            # past ref resolution) yet stop short of the #9 target and buried #950.
+            head_bytes = text.index("#9=")
+            tail_bytes = len(text) - text.index("#8=")
+            # Premise: a real middle exists that neither window scans.
+            self.assertGreater(len(text), head_bytes + tail_bytes)
+
+            original_tail = step_metadata._read_step_tail_payload
+            original_head = step_metadata._read_step_head_text
+
+            def tiny_tail(path, **kwargs):
+                return original_tail(path, tail_bytes=tail_bytes)
+
+            def tiny_head(path, **kwargs):
+                return original_head(path, head_bytes=head_bytes)
+
+            with mock.patch.object(step_metadata, "_read_step_tail_payload", tiny_tail), \
+                    mock.patch.object(step_metadata, "_read_step_head_text", tiny_head):
+                inject_text_to_cad_step_metadata(
+                    step_path,
+                    entry_kind="part",
+                    source_hash="source-hash-middle",
+                )
+
+            metadata = read_text_to_cad_step_metadata(step_path)
+            self.assertEqual("part", metadata.get("entryKind"))
+            entity_ids = [int(m) for m in re_module.findall(r"(?m)^#(\d+)=", step_path.read_text(encoding="utf-8"))]
+            self.assertEqual(len(entity_ids), len(set(entity_ids)), "whole-file fallback collided")
+            self.assertGreater(min(entity_ids[-10:]), 950)
+
+
 if __name__ == "__main__":
+    unittest.main()
+
     unittest.main()


### PR DESCRIPTION
## Summary

One correctness fix plus four review-driven cleanups, all in `packages/cadgen`.

### STEP metadata tail-injection could mint colliding entity ids
`inject_text_to_cad_step_metadata` has a fast path that scans only the last 1 MiB for the max entity id while resolving refs from the 2 MiB head. For an exporter whose ids are not monotonic toward EOF - a high id living in the head, or anywhere outside the tail - the injected `#N+1...` metadata entities collided with existing entities and silently corrupted the STEP.

The fast path now takes `max` over head AND tail (the two regions it actually read) and bails to the existing whole-file rewrite when a scanned-middle check fails: if `head + tail` does not cover the file, the fast path refuses to decide. The coverage guard compares against **bytes actually read** rather than the window constants, so it stays correct even if the two windows ever move independently. New regression tests inject into fixtures with computed windows; each half of the fix was mutation-verified to fail its own test when reverted separately.

### Duplicated GLB topology readers (`glb.py` / `glb_topology.py`)
- `read_step_display_edge_manifest_from_glb` and `_read_legacy_topology_manifest` were byte-identical twins. Single home is now `glb_topology.py`; `glb.py` imports/re-exports them so every historical import path keeps working.
- The two `read_step_topology_index_from_glb` functions look alike but are deliberately different: `glb.py` returns the VALIDATED package descriptor for a component-GLB directory; `glb_topology.py` reads raw `assembly.json`. Both now carry comments stating this so future scans do not merge them.

### Other cleanups
- `_table_rows` lived byte-for-byte in `analysis.py` and `lookup.py`; `lookup` owns it now.
- The unconditional feature-class return ending `step_edge_surface_class_code` is documented as the deliberate default (every classified edge lands in exactly one class).
- `_component_id`'s sha256 truncation to 64 bits documents its collision bounds and why they are fine.

## Verification
- `scripts/test/test-python.sh`: all 14 suites OK (cadgen 376, cad 367 incl. the new tests)
- Mutation checks: reverting the max-over-head-and-tail change fails the head-window test; removing the middle-bail fails the unscanned-middle test
