### PR TITLE
cadgen: refuse to export a generated model from its own previous STEP

### DIFF
--- a/packages/cadgen/src/cadgen/step_export_target.py
+++ b/packages/cadgen/src/cadgen/step_export_target.py
@@ -150,6 +150,13 @@ def _resolve_spec_and_scene(
     return spec, scene
 
 
+def _display_name_for(path: Path) -> str:
+    try:
+        return path.name
+    except Exception:  # noqa: BLE001 - a message must never be the thing that fails
+        return str(path)
+
+
 def _export_scene(
     fmt: str,
     spec: EntrySpec,
@@ -173,6 +180,21 @@ def _export_scene(
             )
             return out
         if spec.step_path is not None and spec.step_path.is_file():
+            # Only an IMPORTED source may be copied. A generated entry's step_path is its own
+            # previous output, so copying it here rewrites <name>.step with the geometry the
+            # last run produced while the caller reports outcome:built -- the failure in #308,
+            # where an edited generator kept exporting the old part and validate, snapshot and
+            # the Viewer all inherited it without a single error. A generated entry reaches
+            # this line only when the scene arrived without source_compound (loaded from cache
+            # rather than run), and the answer to that is to say so, not to copy.
+            if spec.source == "generated":
+                raise RuntimeError(
+                    f"{spec.source_ref}: refusing to export a generated model from its own "
+                    f"{_display_name_for(spec.step_path)} -- the scene carries no generator "
+                    "output to serialize, so the file on disk is the PREVIOUS build. Rerun "
+                    "with a fresh generation (delete the model's __cadgen__ cache if this "
+                    "persists) rather than trusting this export."
+                )
             if spec.step_path.resolve() != out.resolve():
                 shutil.copyfile(spec.step_path, out)
             return out

--- a/tests/python/packages/cadgen/test_step_export_generated_guard.py
+++ b/tests/python/packages/cadgen/test_step_export_generated_guard.py
@@ -1,0 +1,71 @@
+"""A generated model must never be exported by copying its own previous output.
+
+Regression for #308. `scripts/gen --write` reported ``outcome: built`` and rewrote
+``<name>.step`` with the geometry of the PREVIOUS build, so an edited generator kept
+producing the old part and `validate`, `snapshot` and the Viewer all inherited it with
+nothing raised. The reporter only caught it by comparing a direct ``gen_step()`` call
+against the exported file by face count.
+
+The export path takes ``scene.source_compound`` when a generator ran, and otherwise copies
+``spec.step_path``. That copy is correct for an IMPORTED source, whose ``step_path`` is the
+authored input. For a GENERATED source the same path is its own output, so the copy quietly
+reproduces stale geometry. Guarding it turns a silent wrong answer into a loud one.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tests.python.support.paths import repo_path  # noqa: F401  (path bootstrap)
+
+from cadgen.step_export_target import _export_scene
+
+
+class _Spec:
+    def __init__(self, source: str, step_path: Path) -> None:
+        self.source = source
+        self.kind = "part"
+        self.source_ref = "models/part.step.py"
+        self.step_path = step_path
+        self.color = None
+
+
+class _SceneWithoutGeneratorOutput:
+    """What the export sees when the scene came from cache rather than a fresh run."""
+
+    source_compound = None
+    source_path = ""
+    source_hash = ""
+
+
+class GeneratedStepExportGuardTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(self.enterContext(__import__("tempfile").TemporaryDirectory()))
+        self.existing = self.tmp / "part.step"
+        self.existing.write_text("ISO-10303-21;\n-- stale geometry from the previous build\n")
+        self.out = self.tmp / "out.step"
+
+    def test_a_generated_entry_refuses_to_copy_its_own_previous_output(self) -> None:
+        spec = _Spec("generated", self.existing)
+        with self.assertRaises(RuntimeError) as caught:
+            _export_scene("step", spec, _SceneWithoutGeneratorOutput(), self.out, mock.Mock())
+        message = str(caught.exception)
+        self.assertIn("refusing to export a generated model", message)
+        # The message has to name the model and say what to do, or it reads as an internal fault.
+        self.assertIn("models/part.step.py", message)
+        self.assertIn("__cadgen__", message)
+        self.assertFalse(self.out.exists(), "a refused export must leave no output behind")
+
+    def test_an_imported_entry_still_copies(self) -> None:
+        # The branch exists for imported sources, whose step_path is the authored input rather
+        # than a build product. That path stays exactly as it was.
+        spec = _Spec("imported", self.existing)
+        result = _export_scene("step", spec, _SceneWithoutGeneratorOutput(), self.out, mock.Mock())
+        self.assertEqual(self.out, result)
+        self.assertIn("stale geometry", self.out.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses #308.

## What I could and could not reproduce

I could not reproduce the stale export on 0.4.22. Three mechanisms, each building, editing to remove three holes, then rebuilding with `--write`:

| path | rebuilt STEP | direct `gen_step()` |
| --- | --- | --- |
| edit the entry `.step.py` | 9 to 6 faces | 6 |
| edit an imported helper, entry untouched | 9 to 6 faces | 6 |
| warm daemon between runs | 9 to 6 faces | 6 |

`generation_runner.py` evicts first-party modules before the generator loads, "warm worker, multi-target CLI loop, or cold process alike", so the closure-staleness class looks handled. The reporter is on 0.4.4.

## What is still wrong regardless

`_export_scene` serializes `scene.source_compound` when a generator ran, and otherwise copies `spec.step_path`:

```python
if source_compound is not None:
    export_build123d_step_file(source_compound, out, ...)
    return out
if spec.step_path is not None and spec.step_path.is_file():
    shutil.copyfile(spec.step_path, out)
    return out
```

That copy is right for an imported source, whose `step_path` is the authored input. For a generated source the same path is its own output. Any scene that arrives without `source_compound` therefore rewrites `<name>.step` from the previous build and returns success, which is the reported symptom exactly: `outcome: built`, old geometry, and `validate`, `snapshot` and the Viewer all inheriting it with nothing raised.

This guards that branch by `spec.source`. A generated entry raises and names both the model and the `__cadgen__` cache; imported sources keep the copy path untouched.

I am not claiming this is the root cause of the original report. It removes the one path that converts any such cache miss into a confident wrong answer rather than an error.

## Verification

Guard reverted, the new test fails; restored, it passes. A normal generated build still exports correctly (6 faces). Full Python suite green, `bundle.sh --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
