### PR TITLE
viewer: file sheet tab order, drop index, parameters gate, tree header

### DIFF
--- a/viewer/src/client/components/workbench/ParameterControlsSection.js
+++ b/viewer/src/client/components/workbench/ParameterControlsSection.js
@@ -13,6 +13,7 @@ import {
   FileSheetSliderField,
   FileSheetStatusText,
   FileSheetSubsection,
+  FileSheetBooleanToggle,
   FileSheetToggleRow,
   FileSheetValueInput,
   parseFileSheetNumberInput
@@ -130,115 +131,20 @@ export default function ParameterControlsSection({
         <FileSheetStatusText tone="error" className="py-2">{error}</FileSheetStatusText>
       ) : null}
 
-      {definition && showEnableToggle ? (
-        <FileSheetSubsection title="Module">
-          <FileSheetToggleRow
-            label={enableLabel}
-            checked={enabled}
-            onCheckedChange={(checked) => runtime?.onEnabledChange?.(checked)}
-            ariaLabel={enableAriaLabel || enableLabel}
-          />
-        </FileSheetSubsection>
-      ) : null}
-
-      {/* Playback is its own group above the parameters: it acts on time, not
-          on the model's inputs, and it is absent for most models. */}
-      {definition && animations.length ? (
-        <FileSheetSubsection title="Animation">
-          {animations.length > 1 ? (
-            // The section's primary control: which clip is selected reframes the
-            // transport and the time/speed rows beneath it.
-            <FileSheetSelectRow
-              stacked
-              label="Clip"
-              value={String(animationState.activeId || animations[0]?.id || "")}
-              onValueChange={(nextValue) => runtime?.onAnimationSelect?.(nextValue)}
-              disabled={!enabled}
-              ariaLabel={animationAriaLabel}
-              options={animations.map((animation) => ({
-                value: animation.id,
-                label: animation.label
-              }))}
+      {definition ? (
+        <FileSheetSubsection
+          title={title}
+          // The module gate rides this heading on the shared right-edge control axis rather
+          // than owning a "Module" section for one switch. It gates these rows and the
+          // Animation section below.
+          trailing={showEnableToggle ? (
+            <FileSheetBooleanToggle
+              checked={enabled}
+              onCheckedChange={(checked) => runtime?.onEnabledChange?.(checked)}
+              ariaLabel={enableAriaLabel || enableLabel}
             />
           ) : null}
-          {/* Transport sits under the clip it drives. "Restart" is deliberately
-              not called "Reset": it returns playback to zero, where the tab's
-              one Reset returns the parameters to their defaults. */}
-          <FileSheetButtonRow columns={2}>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className={cn(compactButtonClasses, "justify-center")}
-              onClick={() => runtime?.onAnimationPlayToggle?.()}
-              disabled={!enabled}
-              aria-label={`${animationState.playing ? "Pause" : "Play"} ${label} animation`}
-              title={`${animationState.playing ? "Pause" : "Play"} ${label} animation`}
-            >
-              {animationState.playing ? (
-                <Pause className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
-              ) : (
-                <Play className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
-              )}
-              <span>{animationState.playing ? "Pause" : "Play"}</span>
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className={cn(compactButtonClasses, "justify-center")}
-              onClick={() => runtime?.onAnimationReset?.()}
-              disabled={!enabled}
-              aria-label={`Restart ${label} animation`}
-              title="Restart"
-            >
-              <RotateCcw className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
-              <span>Restart</span>
-            </Button>
-          </FileSheetButtonRow>
-          <FileSheetToggleRow
-            label="Loop"
-            checked={animationState.loopEnabled !== false}
-            onCheckedChange={(checked) => runtime?.onAnimationLoopToggle?.(checked)}
-            disabled={!enabled}
-            ariaLabel="Loop animation playback"
-          />
-          <TimeControl
-            animationState={animationState}
-            duration={animationDuration}
-            enabled={enabled}
-            onScrub={runtime?.onAnimationScrub}
-            label={label}
-          />
-          <FileSheetSliderField
-            label="Speed"
-            value={`${formatControlNumber(animationState.speed || 1)}x`}
-            onValueCommit={(nextValue) => {
-              runtime?.onAnimationSpeedChange?.(
-                parseAnimationSpeedInput(nextValue, animationState.speed || 1)
-              );
-            }}
-            valueInputProps={{
-              disabled: !enabled,
-              ariaLabel: `${label} animation speed value`
-            }}
-          >
-            <Slider
-              className={FILE_SHEET_PRECISION_SLIDER_CLASSES}
-              value={[Number(animationState.speed) || 1]}
-              min={PARAMETER_ANIMATION_SPEED_MIN}
-              max={PARAMETER_ANIMATION_SPEED_MAX}
-              step={0.1}
-              onValueChange={(nextValue) => runtime?.onAnimationSpeedChange?.(nextValue?.[0] ?? 1)}
-              disabled={!enabled}
-              aria-label={`${label} animation speed`}
-            />
-          </FileSheetSliderField>
-        </FileSheetSubsection>
-      ) : null}
-
-      {definition ? (
-        <FileSheetSubsection title={title}>
+        >
           {!parameters.length ? (
             <FileSheetStatusText>{noParametersLabel}</FileSheetStatusText>
           ) : null}
@@ -371,6 +277,102 @@ export default function ParameterControlsSection({
               </Button>
             </FileSheetButtonRow>
           ) : null}
+        </FileSheetSubsection>
+      ) : null}
+
+      {/* Playback follows the parameters: it acts on time rather than on the model's own
+          inputs, and it is absent for most models. */}
+      {definition && animations.length ? (
+        <FileSheetSubsection title="Animation">
+          {animations.length > 1 ? (
+            // The section's primary control: which clip is selected reframes the
+            // transport and the time/speed rows beneath it.
+            <FileSheetSelectRow
+              stacked
+              label="Clip"
+              value={String(animationState.activeId || animations[0]?.id || "")}
+              onValueChange={(nextValue) => runtime?.onAnimationSelect?.(nextValue)}
+              disabled={!enabled}
+              ariaLabel={animationAriaLabel}
+              options={animations.map((animation) => ({
+                value: animation.id,
+                label: animation.label
+              }))}
+            />
+          ) : null}
+          {/* Transport sits under the clip it drives. "Restart" is deliberately
+              not called "Reset": it returns playback to zero, where the tab's
+              one Reset returns the parameters to their defaults. */}
+          <FileSheetButtonRow columns={2}>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className={cn(compactButtonClasses, "justify-center")}
+              onClick={() => runtime?.onAnimationPlayToggle?.()}
+              disabled={!enabled}
+              aria-label={`${animationState.playing ? "Pause" : "Play"} ${label} animation`}
+              title={`${animationState.playing ? "Pause" : "Play"} ${label} animation`}
+            >
+              {animationState.playing ? (
+                <Pause className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+              ) : (
+                <Play className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+              )}
+              <span>{animationState.playing ? "Pause" : "Play"}</span>
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className={cn(compactButtonClasses, "justify-center")}
+              onClick={() => runtime?.onAnimationReset?.()}
+              disabled={!enabled}
+              aria-label={`Restart ${label} animation`}
+              title="Restart"
+            >
+              <RotateCcw className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+              <span>Restart</span>
+            </Button>
+          </FileSheetButtonRow>
+          <FileSheetToggleRow
+            label="Loop"
+            checked={animationState.loopEnabled !== false}
+            onCheckedChange={(checked) => runtime?.onAnimationLoopToggle?.(checked)}
+            disabled={!enabled}
+            ariaLabel="Loop animation playback"
+          />
+          <TimeControl
+            animationState={animationState}
+            duration={animationDuration}
+            enabled={enabled}
+            onScrub={runtime?.onAnimationScrub}
+            label={label}
+          />
+          <FileSheetSliderField
+            label="Speed"
+            value={`${formatControlNumber(animationState.speed || 1)}x`}
+            onValueCommit={(nextValue) => {
+              runtime?.onAnimationSpeedChange?.(
+                parseAnimationSpeedInput(nextValue, animationState.speed || 1)
+              );
+            }}
+            valueInputProps={{
+              disabled: !enabled,
+              ariaLabel: `${label} animation speed value`
+            }}
+          >
+            <Slider
+              className={FILE_SHEET_PRECISION_SLIDER_CLASSES}
+              value={[Number(animationState.speed) || 1]}
+              min={PARAMETER_ANIMATION_SPEED_MIN}
+              max={PARAMETER_ANIMATION_SPEED_MAX}
+              step={0.1}
+              onValueChange={(nextValue) => runtime?.onAnimationSpeedChange?.(nextValue?.[0] ?? 1)}
+              disabled={!enabled}
+              aria-label={`${label} animation speed`}
+            />
+          </FileSheetSliderField>
         </FileSheetSubsection>
       ) : null}
     </div>

--- a/viewer/src/client/components/workbench/StepFileSheet.js
+++ b/viewer/src/client/components/workbench/StepFileSheet.js
@@ -598,6 +598,16 @@ export default function StepFileSheet({
   const hasAssemblyTree = isAssemblyView || elideRootTreeRow
     ? visibleRows.length > 0
     : visibleRows.some((row) => row?.hasChildren);
+  // The tree header counts what the file holds at its TOP level, the number a user reads as
+  // "how many parts is this". Not the flattened row count, which includes every expanded
+  // child and would change under them as they open nodes.
+  const topLevelPartCount = useMemo(
+    () => visibleRows.filter((row) => Number(row?.depth || 0) === 0).length,
+    [visibleRows]
+  );
+  // Show All renders only when something is hidden, so a fully visible tree keeps a header
+  // with nothing to click.
+  const hasHiddenTreeRows = hiddenTreeRowIds.size > 0;
   const hasMateRows = assemblyMateRows.length > 0;
   const showInstancesLabel = hasMateRows;
   const showMateSections = hasMateRows;
@@ -761,6 +771,26 @@ export default function StepFileSheet({
                   }
                 }}
               >
+              {hasAssemblyTree ? (
+                <div className="flex items-center justify-between gap-2 pr-1">
+                  <div className={treeGroupLabelClasses} role="presentation">
+                    Assembly
+                    <span className="ml-1.5 tabular-nums text-sidebar-foreground/35">
+                      {topLevelPartCount}
+                    </span>
+                  </div>
+                  {hasHiddenTreeRows ? (
+                    <button
+                      type="button"
+                      className="rounded-sm px-1.5 py-0.5 text-[10px] text-sidebar-foreground/50 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                      onClick={() => showAllHiddenParts?.()}
+                    >
+                      Show All
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+
               {showInstancesLabel ? (
                 <div className={treeGroupLabelClasses} role="presentation">
                   Instances
@@ -1298,7 +1328,11 @@ export default function StepFileSheet({
       )
     },
     buildStepReferenceTab({ references: selectedReferences }),
-    measurementsSection,
+    // Parameters sits directly after Reference, ahead of the readouts: it is the one tab in
+    // this strip that CHANGES the geometry, so it takes the position nearest the default.
+    // This array is what orders the tab strip; renderedFileSheetSectionIds decides which
+    // sections exist, and the two have to agree.
+    //
     // The parameters tab is the shared ParameterControlsSection; the only
     // STEP-specific part is the time control, which tracks live playback.
     buildParameterControlsTab({
@@ -1312,6 +1346,7 @@ export default function StepFileSheet({
       resetTitle: "Reset STEP parameters",
       TimeControl: StepModuleAnimationTimeControl
     }),
+    measurementsSection,
     ...themeTabs,
     // "Issues" is a diagnostic shown only when there are warnings/errors, so it trails the
     // content + display tabs as the last item in the top section (null when there are none;

--- a/viewer/src/client/workbench/fileSheetSections.js
+++ b/viewer/src/client/workbench/fileSheetSections.js
@@ -54,10 +54,13 @@ export function renderedFileSheetSectionIds(kind, options = {}) {
         ...status,
         FILE_SHEET_SECTION_IDS.STEP_TREE,
         FILE_SHEET_SECTION_IDS.STEP_REFERENCE,
-        // Measurements follows Reference: both are readouts about geometry the
+        // Parameters sits directly after Reference when the model has a sidecar: it is the
+        // one tab here that CHANGES the geometry, so it earns the position nearest the
+        // default rather than trailing the readouts.
+        ...(options.hasStepModulePanel ? [FILE_SHEET_SECTION_IDS.STEP_PARAMETERS] : []),
+        // Measurements then follows: it and Reference are both readouts about geometry the
         // user has picked, as against the Tree's inventory of what is in the file.
         FILE_SHEET_SECTION_IDS.STEP_MEASUREMENTS,
-        ...(options.hasStepModulePanel ? [FILE_SHEET_SECTION_IDS.STEP_PARAMETERS] : []),
         FILE_SHEET_SECTION_IDS.THEME_DISPLAY
       ];
     case "urdf":

--- a/viewer/src/client/workbench/fileSheetSections.test.js
+++ b/viewer/src/client/workbench/fileSheetSections.test.js
@@ -57,8 +57,11 @@ test("rendered file sheet sections include closed-by-default sections", () => {
     "status",
     "tree",
     "reference",
-    "measurements",
+    // Parameters sits directly after Reference: it is the one tab in this strip that
+    // CHANGES the geometry, so it takes the position nearest the default rather than
+    // trailing the readouts.
     "parameters",
+    "measurements",
     "display"
   ]);
   assert.deepEqual(renderedFileSheetSectionIds("srdf"), ["joints"]);

--- a/viewer/src/client/workbench/fileSheetTabLayout.js
+++ b/viewer/src/client/workbench/fileSheetTabLayout.js
@@ -183,9 +183,17 @@ export function moveFileSheetTab(arrangement, kind, sectionId, targetPane, targe
   let bottom = arrangementPaneList(arrangement, FILE_SHEET_TAB_PANES.BOTTOM).filter((value) => value !== id);
 
   const target = pane === FILE_SHEET_TAB_PANES.TOP ? top : bottom;
-  const index = Number.isFinite(Number(targetIndex))
-    ? Math.min(Math.max(Math.trunc(Number(targetIndex)), 0), target.length)
+  // targetIndex counts slots in the strip AS DISPLAYED, which still shows the tab being
+  // dragged. `target` has already had it removed, so every slot to the right of where it
+  // started has shifted left by one. Without this, dragging a tab rightwards lands it one
+  // slot further right than the drop indicator promised, and the clamp below hid it at the
+  // end of the strip -- the only position where overshooting has nowhere to go.
+  const sourceIndex = arrangementPaneList(arrangement, pane).indexOf(id);
+  const requested = Number.isFinite(Number(targetIndex))
+    ? Math.max(Math.trunc(Number(targetIndex)), 0)
     : target.length;
+  const shifted = sourceIndex >= 0 && requested > sourceIndex ? requested - 1 : requested;
+  const index = Math.min(shifted, target.length);
   target.splice(index, 0, id);
 
   const ratio = clampSplitRatio(arrangement?.ratio);

--- a/viewer/src/client/workbench/fileSheetTabLayout.test.js
+++ b/viewer/src/client/workbench/fileSheetTabLayout.test.js
@@ -243,3 +243,33 @@ test("activating measurements makes it the bottom pane's live tab", () => {
   // Activating it must not disturb whatever the other pane was showing.
   assert.equal(top.activeId, "tree");
 });
+
+test("a drop lands where the indicator promised, including the last slot", () => {
+  // The drop index counts slots in the strip AS DISPLAYED, which still shows the tab being
+  // dragged. moveFileSheetTab removes it before splicing, so every slot right of where it
+  // started has shifted left by one. Reading the index literally moved a rightward drag one
+  // slot too far, and the end-of-strip clamp hid it at the only position with nowhere to
+  // overshoot to -- which is why it surfaced as "drag to the last spot, land second-last".
+  const tabs = ["tree", "reference", "parameters", "measurements", "display"];
+  const arrangement = { split: false, top: [...tabs], bottom: [], ratio: 0.5 };
+
+  for (const id of tabs) {
+    for (let slot = 0; slot <= tabs.length; slot += 1) {
+      const want = tabs.filter((value) => value !== id);
+      const from = tabs.indexOf(id);
+      want.splice(slot > from ? slot - 1 : slot, 0, id);
+      const got = moveFileSheetTab(arrangement, "step", id, FILE_SHEET_TAB_PANES.TOP, slot).top;
+      assert.deepEqual(got, want, `dragging ${id} to slot ${slot}`);
+    }
+  }
+});
+
+test("dropping any tab past the last slot puts it last", () => {
+  const tabs = ["tree", "reference", "parameters", "measurements", "display"];
+  const arrangement = { split: false, top: [...tabs], bottom: [], ratio: 0.5 };
+  for (const id of tabs) {
+    const top = moveFileSheetTab(arrangement, "step", id, FILE_SHEET_TAB_PANES.TOP, tabs.length).top;
+    assert.equal(top[top.length - 1], id, `${id} should land last`);
+    assert.equal(top.length, tabs.length, "no tab lost or duplicated");
+  }
+});


### PR DESCRIPTION
Four file-sheet nits.

## 1. Parameters sits directly after Reference

Two places order tabs and they have to agree. `renderedFileSheetSectionIds` decides which sections exist; the `sections` array in `StepFileSheet` is what actually orders the strip. Changing only the first left the strip untouched, which the browser showed and the unit test did not.

## 2. A drop lands where the indicator promised

`computeDropIndex` counts slots in the strip AS DISPLAYED, which still shows the tab being dragged. `moveFileSheetTab` removes that tab before splicing, so every slot to the right of where it started has shifted left by one. Reading the index literally moved a rightward drag one slot too far, and the end-of-strip clamp hid the overshoot at the only position with nowhere left to go, which is why it surfaced as "drag to the last spot, land second-last".

Enumerating all 20 drag/slot pairs on a 4-tab strip, 6 landed somewhere other than where the indicator pointed:

```
before   drag A  0:ABCD  1:BACD*  2:BCAD*  3:BCDA*  4:BCDA
after    drag A  0:ABCD  1:ABCD   2:BACD   3:BCAD   4:BCDA
```

Now none do. Two tests cover it: every pair against intent, and every tab dropped past the last slot landing last.

## 3. The Parameters gate moves onto its heading

The "Module" section existed to hold one switch. `FileSheetSubsection` already takes a `trailing` control documented as "most often its gate switch", so the gate moves there, on the same right-edge axis every other row uses. Parameters also moves above Animation: playback acts on time rather than on the model's inputs and is absent for most models, so the inputs come first.

## 4. Tree header

Label left, action right, matching the Measurements header: `Assembly N` over the top-level part count, and a Show All button that renders only when something is hidden. N counts top-level rows rather than the flattened list, which would climb as nodes are expanded.

## Verified in the browser

On `planetary_gear_assembly`: the strip reads Reference, Parameters, Measure, Display. The Parameters panel has no Module section, a gate on its heading, and Animation below. The header reads `Assembly 9`, gains Show All when a part is hidden, and loses it again once cleared.

366 viewer tests pass, `bundle.sh --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
