### PR TITLE
viewer: make top and bottom views actually axis-aligned

### DIFF
--- a/viewer/src/client/components/CadViewer.js
+++ b/viewer/src/client/components/CadViewer.js
@@ -190,9 +190,8 @@ import {
   VIEW_PLANE_DEFAULT_PRESET,
   VIEW_PLANE_FACE_BY_ID,
   VIEW_PLANE_FACES,
-  VIEW_PLANE_POLE_DIRECTION_DOT_THRESHOLD,
-  VIEW_PLANE_POLE_DIRECTION_NUDGE,
   VIEW_PLANE_TRANSITION_MS,
+  viewPlaneCameraBasis,
   viewPlaneOrientationEqual,
   viewportFitScale,
   WORLD_UP
@@ -1408,31 +1407,15 @@ function transitionCameraToViewPreset(runtime, preset) {
     runtime.controls.minDistance || 0.01,
     runtime.controls.maxDistance || Infinity
   );
-  const nextDirection = new runtime.THREE.Vector3(...preset.direction);
-  if (nextDirection.lengthSq() < 1e-6) {
+  // The basis maths lives in viewportCameraKit so the "up is always world up" invariant is
+  // testable without mounting a viewer. It returns world up for EVERY preset, so the orbit
+  // axis is the same from any view.
+  const basis = viewPlaneCameraBasis(preset, WORLD_UP);
+  if (!basis) {
     return false;
   }
-  const nextUp = new runtime.THREE.Vector3(...preset.up);
-  if (nextUp.lengthSq() < 1e-6) {
-    return false;
-  }
-
-  nextDirection.normalize();
-  nextUp.normalize();
-  const worldUp = new runtime.THREE.Vector3(...WORLD_UP).normalize();
-  if (Math.abs(nextDirection.dot(worldUp)) >= VIEW_PLANE_POLE_DIRECTION_DOT_THRESHOLD) {
-    let screenUp = nextUp.clone().addScaledVector(worldUp, -nextUp.dot(worldUp));
-    if (screenUp.lengthSq() < 1e-6) {
-      screenUp = new runtime.THREE.Vector3(0, 1, 0).addScaledVector(worldUp, -worldUp.y);
-    }
-    if (screenUp.lengthSq() < 1e-6) {
-      screenUp = new runtime.THREE.Vector3(1, 0, 0);
-    }
-    screenUp.normalize();
-    const poleSign = nextDirection.dot(worldUp) >= 0 ? 1 : -1;
-    nextDirection.addScaledVector(screenUp, -poleSign * VIEW_PLANE_POLE_DIRECTION_NUDGE).normalize();
-    nextUp.copy(worldUp);
-  }
+  const nextDirection = new runtime.THREE.Vector3(...basis.direction);
+  const nextUp = new runtime.THREE.Vector3(...basis.up);
   runtime.cameraTransition = {
     startTime: performance.now(),
     durationMs: VIEW_PLANE_TRANSITION_MS,

--- a/viewer/src/client/components/viewer/viewportCameraKit.js
+++ b/viewer/src/client/components/viewer/viewportCameraKit.js
@@ -15,7 +15,20 @@ export const KEYBOARD_POLAR_EPSILON = 0.02;
 export const VIEW_PLANE_ACTIVE_DOT_THRESHOLD = 0.994;
 export const VIEW_PLANE_TRANSITION_MS = 280;
 export const VIEW_PLANE_POLE_DIRECTION_DOT_THRESHOLD = 0.9999;
-export const VIEW_PLANE_POLE_DIRECTION_NUDGE = 0.02;
+// How far off the pole a top/bottom view sits. The camera's `up` is ALWAYS world up, so the
+// orbit axis never changes; that makes looking straight down it degenerate, because `lookAt`
+// cannot build a basis when up is parallel to the view direction. This is the offset that
+// keeps the basis well defined.
+//
+// It is bounded on both sides. Below ~1e-6 it meets Spherical.makeSafe()'s own EPS, which
+// OrbitControls applies on every update, and the azimuth stops being well defined. Above about
+// 1e-3 it becomes visible: an orthographic top view projects parallel, so vertical faces that
+// should collapse to nothing acquire width. At 1e-4 the error is 0.0057 degrees, a tenth of a
+// pixel across a 1000px viewport, while sitting 100x clear of makeSafe.
+//
+// It was 0.02 (1.146 degrees, 20px across that viewport), which is what made a "top" view
+// visibly not top-down.
+export const VIEW_PLANE_POLE_DIRECTION_NUDGE = 1e-4;
 export const DEFAULT_PERSPECTIVE_DIRECTION_DOT_THRESHOLD = 0.999;
 export const DEFAULT_PERSPECTIVE_UP_DOT_THRESHOLD = 0.999;
 export const DEFAULT_VIEW_DIRECTION = Object.freeze([2.1, -1.65, 1.08]);
@@ -276,6 +289,66 @@ export function stepKeyboardOrbit(runtime, timestamp) {
     axes.azimuth * KEYBOARD_ORBIT_SPEED_RAD_PER_SEC * deltaSeconds,
     axes.polar * KEYBOARD_ORBIT_SPEED_RAD_PER_SEC * deltaSeconds
   );
+}
+
+/**
+ * The camera basis for a view-plane preset: where to sit, and which way is up.
+ *
+ * Returns `{ direction, up }` as plain arrays. `up` is ALWAYS world up, so OrbitControls
+ * orbits about the same axis from every view; a preset that declares another up (the poles
+ * declare [0,1,0]) contributes only the screen orientation, by choosing which way the pole
+ * offset leans. Lived in CadViewer, where the invariant could not be tested.
+ */
+export function viewPlaneCameraBasis(preset, worldUp = WORLD_UP) {
+  const dir = normalizeVector3(preset?.direction);
+  const declaredUp = normalizeVector3(preset?.up);
+  const axis = normalizeVector3(worldUp);
+  if (!dir || !declaredUp || !axis) {
+    return null;
+  }
+  const alignment = dot3(dir, axis);
+  if (Math.abs(alignment) < VIEW_PLANE_POLE_DIRECTION_DOT_THRESHOLD) {
+    return { direction: dir, up: axis };
+  }
+  // A pole view. Lean off the axis toward the preset's declared up, projected into the plane
+  // perpendicular to the orbit axis, so the resulting screen-up is the one the preset asked
+  // for rather than whatever lookAt's own degenerate fallback would pick.
+  let screenUp = subtractScaled3(declaredUp, axis, dot3(declaredUp, axis));
+  if (lengthSq3(screenUp) < 1e-12) {
+    screenUp = subtractScaled3([0, 1, 0], axis, axis[1]);
+  }
+  if (lengthSq3(screenUp) < 1e-12) {
+    screenUp = [1, 0, 0];
+  }
+  screenUp = normalizeVector3(screenUp);
+  const poleSign = alignment >= 0 ? 1 : -1;
+  const leaned = normalizeVector3(
+    subtractScaled3(dir, screenUp, poleSign * VIEW_PLANE_POLE_DIRECTION_NUDGE)
+  );
+  return { direction: leaned, up: axis };
+}
+
+function normalizeVector3(value) {
+  if (!Array.isArray(value) || value.length < 3) {
+    return null;
+  }
+  const x = Number(value[0]) || 0;
+  const y = Number(value[1]) || 0;
+  const z = Number(value[2]) || 0;
+  const length = Math.sqrt(x * x + y * y + z * z);
+  return length > 1e-9 ? [x / length, y / length, z / length] : null;
+}
+
+function dot3(a, b) {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+function lengthSq3(a) {
+  return a[0] * a[0] + a[1] * a[1] + a[2] * a[2];
+}
+
+function subtractScaled3(a, b, scale) {
+  return [a[0] - b[0] * scale, a[1] - b[1] * scale, a[2] - b[2] * scale];
 }
 
 export function viewPlaneOrientationEqual(a, b, epsilon = 1e-4) {

--- a/viewer/src/client/components/viewer/viewportCameraKit.test.js
+++ b/viewer/src/client/components/viewer/viewportCameraKit.test.js
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { viewportFitScale } from "./viewportCameraKit.js";
+import {
+  VIEW_PLANE_FACES,
+  viewPlaneCameraBasis,
+  viewportFitScale
+} from "./viewportCameraKit.js";
 
 // The framed area of a viewport with a top bar and no side sheets, then the same
 // window with a sheet open. Only the ratio between two scales is used, so these
@@ -54,4 +58,71 @@ test("degenerate viewports fall back instead of producing a non-finite scale", (
     const scale = viewportFitScale(metrics);
     assert.ok(Number.isFinite(scale) && scale > 0, `bad scale for ${JSON.stringify(metrics)}`);
   }
+});
+
+// --- view-plane camera basis -------------------------------------------------------------
+//
+// A "top" view that is not top-down is the bug these cover. Orthographic projects parallel,
+// so vertical faces that should collapse to nothing acquire width at even a degree of tilt;
+// the offset used to be 0.02 (1.146 degrees, 20px across a 1000px viewport).
+
+const WORLD_UP_AXIS = [0, 0, 1];
+
+function degreesFromAxis(direction, axis) {
+  const d = Math.abs(direction[0] * axis[0] + direction[1] * axis[1] + direction[2] * axis[2]);
+  return (Math.acos(Math.min(1, d)) * 180) / Math.PI;
+}
+
+test("every view-plane preset orbits about world up", () => {
+  // The invariant that lets the pole offset exist at all: `up` never varies, so OrbitControls
+  // orbits about the same axis from every view and no drag can snap the roll. A preset that
+  // declares its own up (the poles declare [0,1,0]) may steer the offset, never the axis.
+  for (const face of VIEW_PLANE_FACES) {
+    const basis = viewPlaneCameraBasis(face, WORLD_UP_AXIS);
+    assert.deepEqual(basis.up, WORLD_UP_AXIS, `${face.id} must orbit about world up`);
+  }
+});
+
+test("a declared up that is not world up still does not become the orbit axis", () => {
+  // Guards the invariant against the presets changing: even asked directly for a Y-up pole
+  // view, the basis orbits about world up and expresses the request through the offset.
+  const basis = viewPlaneCameraBasis({ direction: [0, 0, 1], up: [0, 1, 0] }, WORLD_UP_AXIS);
+  assert.deepEqual(basis.up, WORLD_UP_AXIS);
+  assert.ok(basis.direction[1] < 0, "the offset leans toward the declared screen up");
+});
+
+test("axis views are axis-aligned to well under a pixel", () => {
+  // 0.0057 degrees is a tenth of a pixel across a 1000px viewport. The four side views are
+  // exact; only the poles carry an offset at all.
+  for (const face of VIEW_PLANE_FACES) {
+    const basis = viewPlaneCameraBasis(face, WORLD_UP_AXIS);
+    const error = degreesFromAxis(basis.direction, face.direction);
+    assert.ok(error < 0.01, `${face.id} is ${error.toFixed(4)} deg off its own axis`);
+  }
+});
+
+test("the pole offset stays clear of Spherical.makeSafe", () => {
+  // OrbitControls calls makeSafe() on every update, clamping phi to [1e-6, PI-1e-6]. An offset
+  // at or below that gets clamped and the azimuth stops being well defined, so the view would
+  // drift on the first drag. Keep a wide margin.
+  const MAKE_SAFE_EPS = 1e-6;
+  for (const face of VIEW_PLANE_FACES) {
+    const basis = viewPlaneCameraBasis(face, WORLD_UP_AXIS);
+    const alignment = Math.abs(
+      basis.direction[0] * WORLD_UP_AXIS[0]
+      + basis.direction[1] * WORLD_UP_AXIS[1]
+      + basis.direction[2] * WORLD_UP_AXIS[2]
+    );
+    const phi = Math.acos(Math.min(1, alignment));   // angle off the orbit axis
+    if (phi < 1e-9) {
+      assert.fail(`${face.id} sits exactly on the orbit axis; lookAt has no basis there`);
+    }
+    assert.ok(phi > MAKE_SAFE_EPS * 10, `${face.id} phi ${phi} is too close to makeSafe EPS`);
+  }
+});
+
+test("a malformed preset is refused rather than producing a broken camera", () => {
+  assert.equal(viewPlaneCameraBasis(null, WORLD_UP_AXIS), null);
+  assert.equal(viewPlaneCameraBasis({ direction: [0, 0, 0], up: [0, 1, 0] }, WORLD_UP_AXIS), null);
+  assert.equal(viewPlaneCameraBasis({ direction: [0, 0, 1], up: [0, 0, 0] }, WORLD_UP_AXIS), null);
 });


### PR DESCRIPTION
A "top" view sat **1.146 degrees** off vertical.

```
Jump to top view       off-axis: 1.146 deg   <-- nudged
Jump to bottom view    off-axis: 1.146 deg   <-- nudged
Jump to front/back/left/right  off-axis: 0.000 deg
```

Only the two poles, which is why the report was about top-down. Orthographic projects parallel, so vertical faces that should collapse to nothing keep a visible width; the same tilt hides inside perspective's convergence.

## Cause

`VIEW_PLANE_POLE_DIRECTION_NUDGE = 0.02`, applied to the views whose direction is parallel to world up. It is not gratuitous. The camera's `up` is always world up so the orbit axis never changes, and looking straight down that axis leaves `lookAt` with no basis, so something has to lean off the pole. `atan(0.02)` is 20px of error across a 1000px viewport.

## Fix

`1e-4`: 0.0057 degrees, a tenth of a pixel on that viewport, and still 100x clear of `Spherical.makeSafe()`'s own `1e-6` clamp that OrbitControls applies on every update. Below that the azimuth stops being well defined and the view drifts on the first drag, so the constant is now bounded on both sides rather than one.

| nudge | off-axis | px @1000px | vs makeSafe EPS |
| --- | --- | --- | --- |
| 0.02 (before) | 1.1458 deg | 20.000 | 2e+4x |
| 1e-4 (after) | 0.0057 deg | 0.100 | 1e+2x |
| 1e-6 | 0.0001 deg | 0.001 | 1x, clamped |

## The exact-basis approach does not work

Setting the preset's declared basis on arrival and restoring world up on the first drag would be perfectly axis-aligned. Measured, it is worse:

```
up=[0,1,0] (declared): screenRight [1,0,0]   screenUp [0,1,0]
up=[0,0,1] (worldUp) : screenRight [0,1,0]   screenUp [-1,0,0]
roll difference: 90.0 deg
```

Swapping `up` at the pole rotates the camera 90 degrees about the view axis, so every drag from a top view would open with a visible spin. Pinning `up` to world up is what avoids that, and the offset is its price.

## Testability

The basis maths moves from `CadViewer` into `viewportCameraKit` as `viewPlaneCameraBasis`, because "up is always world up" was an invariant nobody could assert from inside a React component. Five tests cover it: the axis holds for every preset and for a preset that asks for something else, alignment is under a hundredth of a degree, the offset stays clear of `makeSafe`, and a malformed preset is refused.

Restoring `0.02` fails the alignment test; setting `0` fails the degeneracy tests. Pinned from both directions.

371 viewer tests, 647 cadjs, `bundle.sh --check` clean.

## Not verified

I could not confirm this in a running viewer. The view sphere is raycast against the WebGL canvas and synthetic clicks do not reach its handler, so the visual check is worth ten seconds from someone with a mouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
