### PR TITLE
cadgen: survive a malformed system font on Windows (#322)

### DIFF
--- a/packages/cadgen/src/cadgen/__init__.py
+++ b/packages/cadgen/src/cadgen/__init__.py
@@ -2,6 +2,23 @@
 
 from typing import TYPE_CHECKING
 
+# Before anything imports build123d, which every cadgen entry point eventually does:
+# build123d parses EVERY font in the system font folders at import time, with no
+# per-file guard, so one malformed file aborts the import and every cadgen command
+# with it (issue #322, upstream in build123d's register_folder). This hides
+# unparseable fonts from that one listing.
+#
+# It belongs here rather than in a launcher because the skill shims, the daemon's warm
+# workers and `python -m cadgen.X` children all reach cadgen by different routes, and a
+# fix that covered only one of them would leave the builds it spawns still broken.
+#
+# Cost where nothing is wrong: one str.endswith per glob call. CADGEN_FONT_GUARD=0
+# opts out.
+from cadgen._internal.font_scan import install_font_guard as _install_font_guard
+
+_install_font_guard()
+del _install_font_guard
+
 __all__ = [
     "AssemblyHelper",
     "srgb",

--- a/packages/cadgen/src/cadgen/_internal/font_scan.py
+++ b/packages/cadgen/src/cadgen/_internal/font_scan.py
@@ -1,0 +1,246 @@
+"""Name the font file that made ``import build123d`` fail.
+
+build123d parses EVERY font in the system font folders at import time:
+``build123d/text.py`` ends with ``available_fonts = FontManager().available_fonts``,
+whose ``__init__`` calls ``register_system_fonts() -> register_folder() ->
+register_font()``, and ``register_font`` hands each file straight to
+``fontTools.ttLib.TTFont`` with no per-file guard. One malformed file therefore takes
+down ``import build123d`` itself, and with it every cadgen command -- on Windows,
+where that scan is the one platform build123d runs it on (OCCT does not pick up user
+fonts there).
+
+The failure a user sees is ``TTLibError: Not a TrueType or OpenType font (bad
+sfntVersion)``, which names no file. There is nothing to fix here: the guard belongs
+in build123d's ``register_folder`` loop, and until it lands the only recovery is to
+move the offending file out of the font folder. So this module does the one useful
+thing available downstream -- it finds the file and says so.
+
+Deliberately NOT a workaround. Patching around it downstream needs
+``fontTools.ttLib.TTFont`` replaced before build123d binds it, and a stand-in that
+survives ``_get_font_faces`` would register an empty-named ``Font_SystemFont`` into
+OCCT's global font manager. A clear error beats a silently poisoned font table.
+
+Reading four bytes per file, this never parses a font, so it cannot fail the way the
+thing it is diagnosing does.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+
+# The first four bytes of a valid sfnt container. build123d globs ttf/otf/ttc, so
+# these are the tags those extensions can legitimately carry.
+_SFNT_MAGIC = (
+    b"\x00\x01\x00\x00",  # TrueType outlines
+    b"OTTO",              # CFF outlines
+    b"true",              # older Apple TrueType
+    b"typ1",              # Type 1 in an sfnt wrapper
+    b"ttcf",              # TrueType Collection
+)
+
+_FONT_EXTENSIONS = (".ttf", ".otf", ".ttc")
+
+
+def system_font_dirs() -> list[str]:
+    """The folders build123d scans, mirrored from ``register_system_fonts``.
+
+    Kept in the same order so the report matches the order the scan would hit them.
+    ``os.getlogin()`` is what build123d uses for the per-user Windows folder; it
+    raises with no controlling terminal, so the fallback keeps the diagnostic alive
+    where the thing it describes still runs.
+    """
+    if platform.system() == "Windows":
+        try:
+            user = os.getlogin()
+        except OSError:
+            user = os.environ.get("USERNAME", "")
+        dirs = ["C:/Windows/Fonts"]
+        if user:
+            dirs.append(f"C:/Users/{user}/AppData/Local/Microsoft/Windows/Fonts")
+        return dirs
+    if platform.system() == "Darwin":
+        return ["/System/Library/Fonts", "/Library/Fonts"]
+    return ["/system/fonts", "/usr/share/fonts", "/usr/local/share/fonts"]
+
+
+def unparseable_fonts(dirs: list[str] | None = None) -> list[str]:
+    """Font files whose sfnt header is not one build123d's parser can read.
+
+    Non-recursive, matching ``register_folder``'s single-level glob: a file build123d
+    never opens is not a file that can have broken the import.
+    """
+    bad: list[str] = []
+    for directory in system_font_dirs() if dirs is None else dirs:
+        try:
+            names = sorted(os.listdir(directory))
+        except OSError:
+            continue
+        for name in names:
+            if not name.lower().endswith(_FONT_EXTENSIONS):
+                continue
+            path = os.path.join(directory, name)
+            try:
+                with open(path, "rb") as handle:
+                    header = handle.read(4)
+            except OSError:
+                # Unreadable is a different problem, and build123d would raise its own
+                # error for it; only claim the ones we can positively identify.
+                continue
+            if header not in _SFNT_MAGIC:
+                bad.append(path)
+    return bad
+
+
+# build123d's register_folder globs `"*" + ext` with NO dot, so the patterns it passes
+# end in a bare "ttf"/"otf"/"ttc". Matching on ".ttf" here silently disables the guard,
+# which is exactly how the first version of it did nothing.
+_GLOB_PATTERN_SUFFIXES = ("ttf", "otf", "ttc")
+
+_ENV_DISABLE = "CADGEN_FONT_GUARD"
+
+skipped_fonts: list[str] = []
+
+
+def _font_parses(path: str) -> bool:
+    """Whether build123d could read this file.
+
+    The name table is read, not just the file opened: ``TTFont`` is lazy, so a broken
+    table directory behind a valid sfnt header constructs fine and fails later, inside
+    ``_get_font_faces``, whose first act is ``ft_font["name"].names``.
+    """
+    try:
+        from fontTools.ttLib import TTFont, ttCollection
+    except ImportError:
+        # No fontTools means no font scan to protect; let everything through.
+        return True
+    try:
+        if os.path.splitext(path)[1].strip(".").lower() == "ttc":
+            fonts = list(ttCollection.TTCollection(path))
+        else:
+            fonts = [TTFont(path)]
+        for font in fonts:
+            font["name"].names
+    except Exception:  # noqa: BLE001 - any parse failure is one build123d would hit
+        return False
+    return True
+
+
+def install_font_guard() -> bool:
+    """Hide fonts build123d cannot parse from the scan it runs at import time.
+
+    ``register_folder`` lists a folder with ``glob.glob`` and hands every result
+    straight to ``fontTools``. ``glob`` is resolved on the module object at call time,
+    so filtering that one listing keeps an unparseable file from ever being opened --
+    the file is skipped, the rest of the folder still registers, and nothing malformed
+    reaches OCCT's font table.
+
+    This is the seam because it is the only point between "list the files" and "open
+    one". Replacing ``TTFont`` instead cannot work: a stand-in has to survive
+    ``_get_font_faces``, and one with an empty name table registers an empty-named
+    ``Font_SystemFont`` into OCCT's global manager.
+
+    Returns True when the guard is installed. Idempotent, and a no-op when
+    ``CADGEN_FONT_GUARD=0``.
+    """
+    if os.environ.get(_ENV_DISABLE) == "0":
+        return False
+
+    import glob
+
+    if getattr(glob.glob, "_cadgen_font_guard", False):
+        return True
+
+    real_glob = glob.glob
+
+    def guarded_glob(pathname, *args, **kwargs):
+        results = real_glob(pathname, *args, **kwargs)
+        # One string check for every other glob in the process. Only a font listing
+        # pays for a parse, and only build123d asks for one.
+        if not str(pathname).lower().endswith(_GLOB_PATTERN_SUFFIXES):
+            return results
+        keep = []
+        for path in results:
+            if _font_parses(path):
+                keep.append(path)
+            elif path not in skipped_fonts:
+                skipped_fonts.append(path)
+        return keep
+
+    guarded_glob._cadgen_font_guard = True  # type: ignore[attr-defined]
+    glob.glob = guarded_glob  # type: ignore[assignment]
+    return True
+
+
+def skipped_fonts_warning() -> str:
+    """A one-line note for fonts the guard dropped, or "" when it dropped none."""
+    if not skipped_fonts:
+        return ""
+    listed = ", ".join(skipped_fonts[:3])
+    more = f" (and {len(skipped_fonts) - 3} more)" if len(skipped_fonts) > 3 else ""
+    return (
+        f"cadgen skipped {len(skipped_fonts)} unreadable font file(s) so build123d could "
+        f"import: {listed}{more}"
+    )
+
+
+def is_font_scan_failure(exc: BaseException) -> bool:
+    """True when this exception came out of fontTools during a font scan.
+
+    Matched on the exception's defining module rather than by importing fontTools to
+    compare classes: this runs on an error path, and importing to diagnose an import
+    failure is how a diagnostic becomes a second traceback.
+    """
+    for error in (exc, *_causes(exc)):
+        if type(error).__module__.split(".")[0] == "fontTools":
+            return True
+    return False
+
+
+def _causes(exc: BaseException) -> list[BaseException]:
+    seen: list[BaseException] = []
+    current = exc
+    while True:
+        current = current.__cause__ or current.__context__
+        if current is None or current in seen:
+            return seen
+        seen.append(current)
+
+
+def font_scan_failure_message(exc: BaseException, dirs: list[str] | None = None) -> str:
+    """An actionable message for a font-scan import failure, or "" for anything else."""
+    if not is_font_scan_failure(exc):
+        return ""
+
+    lines = [
+        "cadgen could not import build123d: a font file on this machine failed to parse.",
+        "",
+        f"  {type(exc).__name__}: {exc}",
+        "",
+        "build123d parses every font in the system font folders when it is imported, and",
+        "one unreadable file aborts the import (and so every cadgen command). This is a",
+        "build123d bug, not a problem with your model or your install.",
+    ]
+
+    bad = unparseable_fonts(dirs)
+    if bad:
+        lines += ["", "Files with an invalid font header:"]
+        lines += [f"  {path}" for path in bad[:10]]
+        if len(bad) > 10:
+            lines.append(f"  ... and {len(bad) - 10} more")
+        lines += [
+            "",
+            "Move or rename the file(s) above out of the font folder and rerun. They are",
+            "not fonts any application can use, so nothing else loses a font by it.",
+        ]
+    else:
+        searched = ", ".join(system_font_dirs() if dirs is None else dirs)
+        lines += [
+            "",
+            f"No file with an invalid header was found in {searched}, so the bad font is",
+            "malformed past its first four bytes. This finds it by parsing each one the",
+            "way build123d does:",
+            "",
+            "  python -m cadgen.check_fonts",
+        ]
+    return "\n".join(lines)

--- a/packages/cadgen/src/cadgen/check_fonts.py
+++ b/packages/cadgen/src/cadgen/check_fonts.py
@@ -1,0 +1,99 @@
+"""Find the font file that breaks ``import build123d``.
+
+build123d parses every font in the system font folders at import time and has no
+per-file guard, so one malformed file aborts the import and every cadgen command with
+it. The resulting error names no file. This parses the same folders the same way and
+prints the ones that fail.
+
+Run: python -m cadgen.check_fonts [DIR ...]
+
+Exits 0 when every font parses, 1 when any file fails, 2 when fontTools is missing.
+Reads fonts and nothing else -- it never moves or edits a file, because the folder it
+is pointed at on Windows is a system folder.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from cadgen._internal.font_scan import system_font_dirs
+
+
+def _font_paths(directory: str) -> list[str]:
+    """The files build123d's ``register_folder`` would open.
+
+    Listed with ``os.listdir`` and NOT ``glob.glob``, which is the whole point: cadgen
+    installs a guard over ``glob.glob`` that hides unparseable fonts so build123d can
+    import. A checker built on the filtered listing would report a clean folder on
+    precisely the machine it exists to diagnose.
+    """
+    try:
+        names = os.listdir(os.path.normpath(directory))
+    except OSError:
+        return []
+    return sorted(
+        os.path.join(os.path.normpath(directory), name)
+        for name in names
+        if name.lower().endswith((".ttf", ".otf", ".ttc"))
+    )
+
+
+def check(dirs: list[str] | None = None) -> list[tuple[str, str]]:
+    """Parse every font in `dirs`; return (path, error) for each one that fails.
+
+    The name table is read, not just the file opened. ``TTFont(path)`` is lazy: it
+    validates the sfnt header and defers the tables, so a file with a plausible
+    header but a broken table directory constructs fine here and then fails inside
+    build123d's ``_get_font_faces``, whose first act is ``ft_font["name"].names``. A
+    check that stopped at construction would report a clean sweep on exactly the
+    machine that cannot import build123d.
+    """
+    from fontTools.ttLib import TTFont, ttCollection
+
+    failures: list[tuple[str, str]] = []
+    for directory in dirs or system_font_dirs():
+        for path in _font_paths(directory):
+            try:
+                if os.path.splitext(path)[1].strip(".").lower() == "ttc":
+                    fonts = list(ttCollection.TTCollection(path))
+                else:
+                    fonts = [TTFont(path)]
+                for font in fonts:
+                    font["name"].names
+            except Exception as exc:  # noqa: BLE001 - reporting, not handling
+                failures.append((path, f"{type(exc).__name__}: {exc}"))
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    dirs = argv or system_font_dirs()
+
+    try:
+        failures = check(dirs)
+    except ImportError:
+        sys.stderr.write(
+            "fontTools is not installed, so the fonts cannot be checked.\n"
+            "Install the CAD requirements first: pip install cadgen\n"
+        )
+        return 2
+
+    sys.stdout.write(f"Checked fonts in: {', '.join(dirs)}\n")
+    if not failures:
+        sys.stdout.write("Every font parsed. None of them is breaking the import.\n")
+        return 0
+
+    sys.stdout.write(f"\n{len(failures)} font file(s) failed to parse:\n")
+    for path, error in failures:
+        sys.stdout.write(f"  {path}\n      {error}\n")
+    sys.stdout.write(
+        "\nMove or rename these out of the font folder and rerun. build123d parses\n"
+        "every font when it is imported, so one unreadable file blocks every cadgen\n"
+        "command until it is out of the way.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/python/packages/cadgen/test_font_scan.py
+++ b/tests/python/packages/cadgen/test_font_scan.py
@@ -1,0 +1,235 @@
+"""Naming the font file that breaks `import build123d` (issue #322).
+
+build123d parses every font in the system font folders at import time with no
+per-file guard, so one malformed file aborts the import and every cadgen command with
+it, raising a fontTools error that names no file.
+
+cadgen filters that one folder listing so the bad file is never opened (`GlobGuard`).
+The rest is what happens when the guard is off or did not catch it: a message naming
+the file (`FailureRecognition`) and a checker that finds it (`CheckFontsCommand`).
+The permanent fix belongs upstream, in `register_folder`.
+"""
+
+from __future__ import annotations
+
+import io
+import contextlib
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from cadgen import check_fonts  # noqa: E402
+from cadgen._internal import font_scan  # noqa: E402
+
+# A real TrueType header, and a file that only looks like one.
+VALID_TTF_HEADER = b"\x00\x01\x00\x00"
+VALID_OTF_HEADER = b"OTTO"
+
+
+class _FontDir:
+    """A folder of font-named files, none of which has to be a real font."""
+
+    def __enter__(self):
+        self._tmp = tempfile.TemporaryDirectory(prefix="tmp-cadgen-fonts-")
+        self.path = pathlib.Path(self._tmp.name)
+        return self
+
+    def __exit__(self, *exc):
+        self._tmp.cleanup()
+        return False
+
+    def write(self, name: str, data: bytes) -> str:
+        target = self.path / name
+        target.write_bytes(data)
+        return str(target)
+
+
+class HeaderScan(unittest.TestCase):
+    """`unparseable_fonts` reads four bytes; it must never parse a font itself."""
+
+    def test_a_file_with_no_sfnt_magic_is_reported(self):
+        with _FontDir() as fonts:
+            bad = fonts.write("broken.ttf", b"this is not a font at all")
+            self.assertEqual(font_scan.unparseable_fonts([str(fonts.path)]), [bad])
+
+    def test_valid_headers_are_left_alone(self):
+        with _FontDir() as fonts:
+            fonts.write("truetype.ttf", VALID_TTF_HEADER + b"rest")
+            fonts.write("opentype.otf", VALID_OTF_HEADER + b"rest")
+            fonts.write("collection.ttc", b"ttcf" + b"rest")
+            self.assertEqual(font_scan.unparseable_fonts([str(fonts.path)]), [])
+
+    def test_non_font_files_are_not_examined(self):
+        # register_folder globs ttf/otf/ttc only, so anything else cannot be the cause.
+        with _FontDir() as fonts:
+            fonts.write("notes.txt", b"not a font")
+            fonts.write("image.png", b"\x89PNG")
+            self.assertEqual(font_scan.unparseable_fonts([str(fonts.path)]), [])
+
+    def test_a_missing_directory_is_not_an_error(self):
+        # The diagnostic runs on an error path; it may not raise a second error.
+        self.assertEqual(font_scan.unparseable_fonts(["/no/such/font/directory"]), [])
+
+    def test_the_scan_is_not_recursive(self):
+        # register_folder's glob is single-level, so a file it never opens is not a
+        # file that can have broken the import.
+        with _FontDir() as fonts:
+            nested = fonts.path / "nested"
+            nested.mkdir()
+            (nested / "broken.ttf").write_bytes(b"not a font")
+            self.assertEqual(font_scan.unparseable_fonts([str(fonts.path)]), [])
+
+
+class GlobGuard(unittest.TestCase):
+    """The fix: hide unparseable fonts from the listing build123d hands to fontTools."""
+
+    def setUp(self):
+        import glob
+
+        self._real_glob = glob.glob
+        font_scan.skipped_fonts.clear()
+        self.addCleanup(setattr, glob, "glob", self._real_glob)
+        self.addCleanup(font_scan.skipped_fonts.clear)
+
+    def test_it_filters_a_font_folder_listing(self):
+        import glob
+
+        with _FontDir() as fonts:
+            bad = fonts.write("broken.ttf", b"not a font")
+            font_scan.install_font_guard()
+            # build123d globs "*" + ext, with no dot -- the pattern shape matters.
+            kept = glob.glob(os.path.join(str(fonts.path), "*ttf"))
+        self.assertEqual(kept, [])
+        self.assertEqual(font_scan.skipped_fonts, [bad])
+
+    def test_a_lazily_broken_font_is_filtered_too(self):
+        import glob
+
+        with _FontDir() as fonts:
+            bad = fonts.write("plausible.otf", VALID_OTF_HEADER + b"garbage")
+            font_scan.install_font_guard()
+            kept = glob.glob(os.path.join(str(fonts.path), "*otf"))
+        self.assertEqual(kept, [])
+        self.assertEqual(font_scan.skipped_fonts, [bad])
+
+    def test_non_font_globs_are_untouched(self):
+        import glob
+
+        with _FontDir() as fonts:
+            fonts.write("notes.txt", b"hello")
+            font_scan.install_font_guard()
+            kept = glob.glob(os.path.join(str(fonts.path), "*.txt"))
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(font_scan.skipped_fonts, [])
+
+    def test_installing_twice_does_not_stack_wrappers(self):
+        import glob
+
+        font_scan.install_font_guard()
+        once = glob.glob
+        font_scan.install_font_guard()
+        self.assertIs(glob.glob, once)
+
+    def test_it_can_be_switched_off(self):
+        import glob
+
+        with mock.patch.dict(os.environ, {"CADGEN_FONT_GUARD": "0"}):
+            self.assertFalse(font_scan.install_font_guard())
+        self.assertIs(glob.glob, self._real_glob)
+
+    def test_the_warning_names_what_was_dropped(self):
+        self.assertEqual(font_scan.skipped_fonts_warning(), "")
+        font_scan.skipped_fonts.append("/fonts/broken.ttf")
+        self.assertIn("/fonts/broken.ttf", font_scan.skipped_fonts_warning())
+
+
+class FailureRecognition(unittest.TestCase):
+    def test_a_fonttools_error_is_recognised(self):
+        from fontTools.ttLib import TTLibError
+
+        self.assertTrue(font_scan.is_font_scan_failure(TTLibError("bad sfntVersion")))
+
+    def test_a_wrapped_fonttools_error_is_recognised(self):
+        from fontTools.ttLib import TTLibError
+
+        try:
+            try:
+                raise TTLibError("bad sfntVersion")
+            except TTLibError as inner:
+                raise ImportError("build123d failed") from inner
+        except ImportError as outer:
+            self.assertTrue(font_scan.is_font_scan_failure(outer))
+
+    def test_an_unrelated_error_is_not(self):
+        self.assertFalse(font_scan.is_font_scan_failure(ModuleNotFoundError("no OCP")))
+        self.assertEqual(font_scan.font_scan_failure_message(ValueError("nope")), "")
+
+    def test_the_message_names_the_file_and_the_cause(self):
+        from fontTools.ttLib import TTLibError
+
+        with _FontDir() as fonts:
+            bad = fonts.write("broken.ttf", b"not a font")
+            message = font_scan.font_scan_failure_message(
+                TTLibError("bad sfntVersion"), dirs=[str(fonts.path)]
+            )
+        self.assertIn(bad, message)
+        self.assertIn("build123d bug", message)
+        self.assertIn("Move or rename", message)
+
+    def test_the_message_still_helps_when_no_bad_header_is_found(self):
+        # A font can be malformed past its first four bytes, which the header scan
+        # cannot see. The message has to point somewhere real rather than stop.
+        from fontTools.ttLib import TTLibError
+
+        with _FontDir() as fonts:
+            fonts.write("plausible.otf", VALID_OTF_HEADER + b"garbage")
+            message = font_scan.font_scan_failure_message(
+                TTLibError("bad sfntVersion"), dirs=[str(fonts.path)]
+            )
+        self.assertIn("cadgen.check_fonts", message)
+
+
+class CheckFontsCommand(unittest.TestCase):
+    def test_it_catches_a_font_that_only_fails_once_a_table_is_read(self):
+        # The regression this guards: TTFont(path) is LAZY. A file with a valid sfnt
+        # header but a broken table directory constructs without complaint and then
+        # fails inside build123d's _get_font_faces, whose first act is
+        # ft_font["name"].names. A check that stopped at construction would report a
+        # clean sweep on the exact machine that cannot import build123d.
+        with _FontDir() as fonts:
+            plausible = fonts.write("plausible.otf", VALID_OTF_HEADER + b"garbage")
+            failures = check_fonts.check([str(fonts.path)])
+        self.assertEqual([path for path, _ in failures], [plausible])
+
+    def test_it_reports_a_file_with_no_sfnt_magic(self):
+        with _FontDir() as fonts:
+            bad = fonts.write("broken.ttf", b"not a font")
+            failures = check_fonts.check([str(fonts.path)])
+        self.assertEqual([path for path, _ in failures], [bad])
+
+    def test_an_empty_folder_passes(self):
+        with _FontDir() as fonts:
+            self.assertEqual(check_fonts.check([str(fonts.path)]), [])
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                code = check_fonts.main([str(fonts.path)])
+        self.assertEqual(code, 0)
+        self.assertIn("Every font parsed", out.getvalue())
+
+    def test_a_bad_font_exits_nonzero_and_names_it(self):
+        with _FontDir() as fonts:
+            bad = fonts.write("broken.ttf", b"not a font")
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                code = check_fonts.main([str(fonts.path)])
+        self.assertEqual(code, 1)
+        self.assertIn(bad, out.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the crash in #322: on Windows, one malformed file in `C:\Windows\Fonts` takes
down `import build123d`, and with it every cadgen command — `gen`, `inspect` and
`snapshot` all failed identically for the reporter.

## The bug

build123d parses **every** font in the system font folders when it is imported.
`text.py` ends with `available_fonts = FontManager().available_fonts`, whose
`__init__` calls `register_system_fonts() → register_folder() → register_font()`, and
`register_font` hands each file straight to `fontTools.ttLib.TTFont` with no per-file
guard. Windows-only in practice: that scan runs under `platform.system() == "Windows"`,
because OCCT does not pick up user fonts there.

It is an upstream bug and I confirmed it is **unfixed**: 0.11.1 is the current release,
and `gumyr/build123d`'s `dev` branch still has the unguarded loop. Waiting for a
release helps nobody today.

## The fix

The seam is `glob`. `register_folder` *lists* the folder with `glob.glob` and only then
opens what it found, and `glob` is resolved on the module object at call time — so
filtering that one listing keeps an unparseable file from ever being opened. The bad
file is skipped, the rest of the folder still registers, and nothing malformed reaches
OCCT's font table.

It goes in `cadgen/__init__.py` rather than a launcher because the skill shims, the
warm daemon's workers and `python -m cadgen.X` children all reach cadgen by different
routes. A fix in any one of them would leave the builds it spawns still broken.

Cost where nothing is wrong is one `str.endswith` per glob call, unmeasurable next to
the glob itself. `CADGEN_FONT_GUARD=0` opts out.

**Replacing `TTFont` instead cannot work**, which is worth recording because it is the
obvious first idea: a stand-in has to survive `_get_font_faces`, and one with an empty
name table registers an empty-named `Font_SystemFont` into OCCT's global manager.
Silently poisoning the font table is worse than the crash.

## Also here

Skipped files are reported rather than dropped quietly — a font vanishing from a
machine is its own confusing bug report — and `python -m cadgen.check_fonts [DIR ...]`
finds them on demand. `font_scan_failure_message` names the file for a font failure the
guard did not cover.

## Three traps, each now a test

- `register_folder` globs `"*" + ext` with **no dot**, so its patterns end in a bare
  `ttf`. My first guard matched `".ttf"` and silently did nothing — it looked like the
  approach had failed.
- `TTFont(path)` is **lazy**. It validates the sfnt header and defers the tables, so a
  broken table directory behind a valid header constructs fine and fails later. A check
  stopping at construction called a folder clean that does break the import.
- `check_fonts` lists with `os.listdir`, not `glob.glob`. Built on the guarded listing
  it reported a clean folder on exactly the machine it exists to diagnose.

## Verification

With the guard installed, build123d's scan completes over a folder holding both a
bad-magic file and a lazily-broken one, registering the good font and skipping the
other two. 20 new tests; full Python suite green (14 suites).

The permanent fix still belongs upstream, in `register_folder` — this only protects
cadgen's own processes, not other scripts on the same machine that import build123d.

Reported-by: @13thrule
