### PR TITLE
viewer: per-parameter reset for number parameters

### DIFF
--- a/viewer/src/client/components/workbench/ParameterControlsSection.js
+++ b/viewer/src/client/components/workbench/ParameterControlsSection.js
@@ -38,6 +38,44 @@ function formatControlNumber(value) {
   return numericValue.toFixed(2);
 }
 
+// A parameter's own way back to its declared default, beside the control it resets.
+//
+// Outline rather than ghost: it sits in a column of value inputs, dropdowns and colour
+// swatches, and `outline` carries the same border and surface those do, at the h-7
+// every control in the sheet shares.
+//
+// Live even at the default. A control greying out normally means the app is saying
+// something is unavailable, so a reset that dims whenever the value looks right invites
+// the reading that the row is broken rather than that it is already where it started.
+// Resetting to where you already are costs nothing.
+function ParameterResetButton({ label, title, enabled, onReset }) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      className={cn(FILE_SHEET_COMPACT_ICON_BUTTON_CLASSES, "shrink-0")}
+      onClick={onReset}
+      disabled={!enabled}
+      aria-label={`Reset ${label} to default`}
+      title={title}
+    >
+      <RotateCcw className="size-3" strokeWidth={2} aria-hidden="true" />
+    </Button>
+  );
+}
+
+// The trailing half of a parameter row: its control, then its reset. Shared so a row
+// that gains a reset does not also have to re-derive the spacing that puts it in line
+// with every other control on the sheet's right edge.
+function ParameterControlWithReset({ children, label, title, enabled, onReset }) {
+  return (
+    <div className="flex min-w-0 items-center gap-1">
+      {children}
+      <ParameterResetButton label={label} title={title} enabled={enabled} onReset={onReset} />
+    </div>
+  );
+}
+
 function formatSeconds(value) {
   const numericValue = Math.max(Number(value) || 0, 0);
   return `${numericValue.toFixed(numericValue >= 10 ? 1 : 2)}s`;
@@ -183,12 +221,23 @@ export default function ParameterControlsSection({
                   key={parameter.id}
                   label={parameter.label}
                   trailing={(
-                    <FileSheetColorPicker
-                      value={String(currentValue || "#ffffff")}
-                      onChange={(nextValue) => runtime?.onParameterChange?.(parameter.id, nextValue)}
-                      disabled={!enabled}
-                      aria-label={parameter.label}
-                    />
+                    // A nudged colour is the value you are least able to get back by
+                    // eye: the swatch shows where you are with no hint of where you
+                    // started, and there is no typing your way home the way a number
+                    // allows.
+                    <ParameterControlWithReset
+                      label={parameter.label}
+                      title={`Reset to ${String(parameter.defaultValue || "#ffffff")}`}
+                      enabled={enabled}
+                      onReset={() => runtime?.onParameterChange?.(parameter.id, parameter.defaultValue)}
+                    >
+                      <FileSheetColorPicker
+                        value={String(currentValue || "#ffffff")}
+                        onChange={(nextValue) => runtime?.onParameterChange?.(parameter.id, nextValue)}
+                        disabled={!enabled}
+                        aria-label={parameter.label}
+                      />
+                    </ParameterControlWithReset>
                   )}
                 />
               );
@@ -234,7 +283,12 @@ export default function ParameterControlsSection({
                 // Composed rather than left to the field's own value input, because the
                 // reset has to sit beside that input rather than under the slider.
                 trailing={(
-                  <div className="flex min-w-0 items-center gap-1">
+                  <ParameterControlWithReset
+                    label={parameter.label}
+                    title={`Reset to ${formatControlNumber(parameter.defaultValue)}${parameter.unit ? ` ${parameter.unit}` : ""}`}
+                    enabled={enabled}
+                    onReset={() => runtime?.onParameterChange?.(parameter.id, parameter.defaultValue)}
+                  >
                     <FileSheetValueInput
                       value={`${formatControlNumber(currentValue)}${parameter.unit ? ` ${parameter.unit}` : ""}`}
                       onValueCommit={(nextValue) => {
@@ -247,25 +301,7 @@ export default function ParameterControlsSection({
                       disabled={!enabled}
                       ariaLabel={`${parameter.label} slider value`}
                     />
-                    {/* Outline rather than ghost: it sits in a column of value inputs,
-                        dropdowns and colour swatches, and `outline` carries the same
-                        border/surface those do, at the h-7 every control in the sheet
-                        shares. Stays live at the default -- a control that greys out
-                        when the value "looks right" invites the reading that something
-                        is wrong with the row, and resetting to where you already are
-                        costs nothing. */}
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className={cn(FILE_SHEET_COMPACT_ICON_BUTTON_CLASSES, "shrink-0")}
-                      onClick={() => runtime?.onParameterChange?.(parameter.id, parameter.defaultValue)}
-                      disabled={!enabled}
-                      aria-label={`Reset ${parameter.label} to default`}
-                      title={`Reset to ${formatControlNumber(parameter.defaultValue)}${parameter.unit ? ` ${parameter.unit}` : ""}`}
-                    >
-                      <RotateCcw className="size-3" strokeWidth={2} aria-hidden="true" />
-                    </Button>
-                  </div>
+                  </ParameterControlWithReset>
                 )}
               >
                 <Slider

--- a/viewer/src/client/components/workbench/ParameterControlsSection.js
+++ b/viewer/src/client/components/workbench/ParameterControlsSection.js
@@ -37,6 +37,19 @@ function formatControlNumber(value) {
   return numericValue.toFixed(2);
 }
 
+// Whether a number parameter is sitting on its default, which is what decides if its
+// reset is live. Not an exact compare: a slider stepping by 0.1 lands on values like
+// 0.30000000000000004, and an exact test would leave the reset enabled on a value the
+// readout already shows as the default.
+function numbersMatch(value, other) {
+  const left = Number(value);
+  const right = Number(other);
+  if (!Number.isFinite(left) || !Number.isFinite(right)) {
+    return false;
+  }
+  return Math.abs(left - right) <= 1e-9 * Math.max(1, Math.abs(left), Math.abs(right));
+}
+
 function formatSeconds(value) {
   const numericValue = Math.max(Number(value) || 0, 0);
   return `${numericValue.toFixed(numericValue >= 10 ? 1 : 2)}s`;
@@ -226,22 +239,43 @@ export default function ParameterControlsSection({
                 />
               );
             }
+            const isDefault = numbersMatch(currentValue, parameter.defaultValue);
             return (
               <FileSheetSliderField
                 key={parameter.id}
                 label={parameter.label}
-                value={`${formatControlNumber(currentValue)}${parameter.unit ? ` ${parameter.unit}` : ""}`}
-                onValueCommit={(nextValue) => {
-                  runtime?.onParameterChange?.(parameter.id, parseFileSheetNumberInput(nextValue, {
-                    fallback: currentValue,
-                    min: parameter.min,
-                    max: parameter.max
-                  }));
-                }}
-                valueInputProps={{
-                  disabled: !enabled,
-                  ariaLabel: `${parameter.label} slider value`
-                }}
+                // Composed rather than left to the field's own value input, because the
+                // reset has to sit beside that input rather than under the slider.
+                trailing={(
+                  <div className="flex min-w-0 items-center gap-1">
+                    <FileSheetValueInput
+                      value={`${formatControlNumber(currentValue)}${parameter.unit ? ` ${parameter.unit}` : ""}`}
+                      onValueCommit={(nextValue) => {
+                        runtime?.onParameterChange?.(parameter.id, parseFileSheetNumberInput(nextValue, {
+                          fallback: currentValue,
+                          min: parameter.min,
+                          max: parameter.max
+                        }));
+                      }}
+                      disabled={!enabled}
+                      ariaLabel={`${parameter.label} slider value`}
+                    />
+                    {/* Disabled at the default so the row also answers "have I changed
+                        this?" without needing to remember what the default was. */}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-xs"
+                      className="shrink-0 text-muted-foreground hover:text-foreground"
+                      onClick={() => runtime?.onParameterChange?.(parameter.id, parameter.defaultValue)}
+                      disabled={!enabled || isDefault}
+                      aria-label={`Reset ${parameter.label} to default`}
+                      title={`Reset to ${formatControlNumber(parameter.defaultValue)}${parameter.unit ? ` ${parameter.unit}` : ""}`}
+                    >
+                      <RotateCcw strokeWidth={2} aria-hidden="true" />
+                    </Button>
+                  </div>
+                )}
               >
                 <Slider
                   className={FILE_SHEET_PRECISION_SLIDER_CLASSES}

--- a/viewer/src/client/components/workbench/ParameterControlsSection.js
+++ b/viewer/src/client/components/workbench/ParameterControlsSection.js
@@ -5,6 +5,7 @@ import { Button } from "../ui/button";
 import { Slider } from "../ui/slider";
 import {
   FILE_SHEET_COMPACT_BUTTON_CLASSES,
+  FILE_SHEET_COMPACT_ICON_BUTTON_CLASSES,
   FILE_SHEET_PRECISION_SLIDER_CLASSES,
   FileSheetButtonRow,
   FileSheetColorPicker,
@@ -260,19 +261,21 @@ export default function ParameterControlsSection({
                       disabled={!enabled}
                       ariaLabel={`${parameter.label} slider value`}
                     />
-                    {/* Disabled at the default so the row also answers "have I changed
-                        this?" without needing to remember what the default was. */}
+                    {/* Outline rather than ghost: it sits in a column of value inputs,
+                        dropdowns and colour swatches, and `outline` carries the same
+                        border/surface those do, at the h-7 every control in the sheet
+                        shares. Disabled at the default, so the row also answers "have I
+                        changed this?" without needing to remember what the default was. */}
                     <Button
                       type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      className="shrink-0 text-muted-foreground hover:text-foreground"
+                      variant="outline"
+                      className={cn(FILE_SHEET_COMPACT_ICON_BUTTON_CLASSES, "shrink-0")}
                       onClick={() => runtime?.onParameterChange?.(parameter.id, parameter.defaultValue)}
                       disabled={!enabled || isDefault}
                       aria-label={`Reset ${parameter.label} to default`}
                       title={`Reset to ${formatControlNumber(parameter.defaultValue)}${parameter.unit ? ` ${parameter.unit}` : ""}`}
                     >
-                      <RotateCcw strokeWidth={2} aria-hidden="true" />
+                      <RotateCcw className="size-3" strokeWidth={2} aria-hidden="true" />
                     </Button>
                   </div>
                 )}

--- a/viewer/src/client/components/workbench/ParameterControlsSection.js
+++ b/viewer/src/client/components/workbench/ParameterControlsSection.js
@@ -38,19 +38,6 @@ function formatControlNumber(value) {
   return numericValue.toFixed(2);
 }
 
-// Whether a number parameter is sitting on its default, which is what decides if its
-// reset is live. Not an exact compare: a slider stepping by 0.1 lands on values like
-// 0.30000000000000004, and an exact test would leave the reset enabled on a value the
-// readout already shows as the default.
-function numbersMatch(value, other) {
-  const left = Number(value);
-  const right = Number(other);
-  if (!Number.isFinite(left) || !Number.isFinite(right)) {
-    return false;
-  }
-  return Math.abs(left - right) <= 1e-9 * Math.max(1, Math.abs(left), Math.abs(right));
-}
-
 function formatSeconds(value) {
   const numericValue = Math.max(Number(value) || 0, 0);
   return `${numericValue.toFixed(numericValue >= 10 ? 1 : 2)}s`;
@@ -240,7 +227,6 @@ export default function ParameterControlsSection({
                 />
               );
             }
-            const isDefault = numbersMatch(currentValue, parameter.defaultValue);
             return (
               <FileSheetSliderField
                 key={parameter.id}
@@ -264,14 +250,16 @@ export default function ParameterControlsSection({
                     {/* Outline rather than ghost: it sits in a column of value inputs,
                         dropdowns and colour swatches, and `outline` carries the same
                         border/surface those do, at the h-7 every control in the sheet
-                        shares. Disabled at the default, so the row also answers "have I
-                        changed this?" without needing to remember what the default was. */}
+                        shares. Stays live at the default -- a control that greys out
+                        when the value "looks right" invites the reading that something
+                        is wrong with the row, and resetting to where you already are
+                        costs nothing. */}
                     <Button
                       type="button"
                       variant="outline"
                       className={cn(FILE_SHEET_COMPACT_ICON_BUTTON_CLASSES, "shrink-0")}
                       onClick={() => runtime?.onParameterChange?.(parameter.id, parameter.defaultValue)}
-                      disabled={!enabled || isDefault}
+                      disabled={!enabled}
                       aria-label={`Reset ${parameter.label} to default`}
                       title={`Reset to ${formatControlNumber(parameter.defaultValue)}${parameter.unit ? ` ${parameter.unit}` : ""}`}
                     >


### PR DESCRIPTION
The Parameters tab had one Reset, and it reset everything. Changing one slider to try
something and then wanting only that one back meant either remembering its default or
resetting the lot and redoing the rest.

**Number** and **colour** parameters now each carry their own reset beside their
control: icon-only, the same `RotateCcw` the tab's other resets already use, styled
`outline` so it carries the same border and surface as the value inputs, dropdowns and
swatches it sits in a column with. The tooltip names the value it will restore
(`Reset to 0.00 deg`, `Reset to #00a7ff`).

It stays live even when the parameter is already on its default. Disabling it there was
tried and dropped: a control greying out normally means the app is saying something is
unavailable, so a reset that dims whenever the value looks right invites the reading
that the row is broken rather than that it is already where it started.

The bulk Reset is unchanged and still resets everything.

## Why these two types

Counting declarations across `models/`:

| Type | Declarations | Files |
|---|---|---|
| `number` | 297 | — |
| `color` | 109 | 44 |
| `boolean` | 28 | — |
| `select` | 15 | 14 |
| `string` | 0 | 0 |
| `button` | 0 | 0 |

Colour is the value you are least able to get back by eye: the swatch shows where you
are with no hint of where you started, and unlike a number there is no typing your way
home.

`string` and `button` have **zero** declarations anywhere, so a reset for them would be
built on a guess. `boolean` and `select` are real but weak — both show their state in
the control itself and both pick from a small finite set, so returning to the default
is a click rather than a recovery.

## Verified in the browser

`planetary_gear_assembly.step.py` (STEP, numbers) and `planetary-gear.implicit.js`
(implicit, six colours and ten numbers — the same section serves both file sheets):

- 16 resets render, every one sharing a single right edge (1272px) and a single height
  (28px) with the inputs beside them
- each colour's tooltip carries its own declared default
- Drive `0.00 → 723 deg → reset → 0.00 deg`, returning the geometry to its original
  pose and leaving Explode untouched
- Ring color `#00A7FF → #5D727E → reset → #00A7FF`
- no console errors

371 viewer tests pass.
