### PR TITLE
fix(dxf): read the arc angle keys the parsers actually emit

### DIFF
--- a/skills/cad-viewer/scripts/viewer/packages/cadjs/src/lib/dxf/buildDrawingLines.js
+++ b/skills/cad-viewer/scripts/viewer/packages/cadjs/src/lib/dxf/buildDrawingLines.js
@@ -38,14 +38,28 @@ function sampleArc(target, arc, elevation, requested) {
   if (!Number.isFinite(radius) || radius <= 0) {
     return;
   }
-  const start = Number(arc.startAngle ?? arc.start_angle ?? 0);
-  const end = Number(arc.endAngle ?? arc.end_angle ?? 0);
-  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+  // parseDxf and drawing_render.py both emit startAngleDeg/sweepAngleDeg.
+  // Reading only startAngle/endAngle left start and end at 0 for every real
+  // arc, so sweep came out 0, the wrap below turned it into a full turn, and
+  // each arc was drawn as a complete circle.
+  const start = Number(arc.startAngleDeg ?? arc.startAngle ?? arc.start_angle ?? 0);
+  if (!Number.isFinite(start)) {
     return;
   }
   // Angles arrive in degrees, counter-clockwise, as DXF stores them.
   const startRadians = (start * Math.PI) / 180;
-  let sweep = ((end - start) * Math.PI) / 180;
+  let sweep;
+  const sweepDeg = Number(arc.sweepAngleDeg ?? arc.sweep_angle_deg);
+  if (Number.isFinite(sweepDeg) && sweepDeg !== 0) {
+    // Both producers guarantee a non-zero sweep in (0, 360].
+    sweep = (sweepDeg * Math.PI) / 180;
+  } else {
+    const end = Number(arc.endAngle ?? arc.end_angle ?? 0);
+    if (!Number.isFinite(end)) {
+      return;
+    }
+    sweep = ((end - start) * Math.PI) / 180;
+  }
   if (sweep <= 0) {
     sweep += Math.PI * 2;
   }

--- a/skills/cad-viewer/scripts/viewer/packages/cadjs/src/lib/dxf/buildDrawingLines.test.mjs
+++ b/skills/cad-viewer/scripts/viewer/packages/cadjs/src/lib/dxf/buildDrawingLines.test.mjs
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildDxfDrawingLineGroups } from "./buildDrawingLines.js";
+
+function xRange(positions) {
+  const xs = [];
+  for (let i = 0; i < positions.length; i += 3) {
+    xs.push(positions[i]);
+  }
+  return [Math.min(...xs), Math.max(...xs)];
+}
+
+function firstGroup(arcs) {
+  const out = buildDxfDrawingLineGroups({ geometry: { arcs, lines: [], circles: [] } });
+  return out.layers[0];
+}
+
+// parseDxf and drawing_render.py both emit startAngleDeg/sweepAngleDeg.
+// Reading only startAngle/endAngle left both at 0, so every arc swept a
+// full turn and drew a complete circle.
+test("a quarter arc in parser keys stays a quarter arc", () => {
+  const group = firstGroup([
+    { layer: "DIMS", center: [0, 0], radius: 10, startAngleDeg: 0, sweepAngleDeg: 90 },
+  ]);
+  const [minX, maxX] = xRange(group.positions);
+
+  assert.ok(minX >= -0.001, `expected the arc to stay in x >= 0, got minX ${minX}`);
+  assert.ok(Math.abs(maxX - 10) < 0.001);
+});
+
+test("a full circle in parser keys still closes", () => {
+  const group = firstGroup([
+    { layer: "DIMS", center: [0, 0], radius: 10, startAngleDeg: 0, sweepAngleDeg: 360 },
+  ]);
+  const [minX, maxX] = xRange(group.positions);
+
+  assert.ok(Math.abs(minX + 10) < 0.001);
+  assert.ok(Math.abs(maxX - 10) < 0.001);
+});
+
+test("the legacy start/end angle shape is still honoured", () => {
+  const group = firstGroup([
+    { layer: "DIMS", center: [0, 0], radius: 10, startAngle: 0, endAngle: 90 },
+  ]);
+  const [minX, maxX] = xRange(group.positions);
+
+  assert.ok(minX >= -0.001);
+  assert.ok(Math.abs(maxX - 10) < 0.001);
+});
+
+test("an arc with no angles at all still yields a closed circle", () => {
+  const group = firstGroup([{ layer: "DIMS", center: [0, 0], radius: 10 }]);
+  const [minX, maxX] = xRange(group.positions);
+
+  assert.ok(Math.abs(minX + 10) < 0.001);
+  assert.ok(Math.abs(maxX - 10) < 0.001);
+});


### PR DESCRIPTION
## The bug

Every DXF `ARC` renders as a **complete circle** in the drawing view.

`sampleArc` reads `arc.startAngle` / `arc.endAngle`. Neither producer emits those keys — `parseDxf.js` and `drawing_render.py` both emit `startAngleDeg` and `sweepAngleDeg`. So `start` and `end` both fall back to `0`, `sweep` comes out `0`, and the wrap immediately below turns that into a full turn:

```js
let sweep = ((end - start) * Math.PI) / 180;   // 0
if (sweep <= 0) {
  sweep += Math.PI * 2;                        // 360°
}
```

A 90° arc at the origin, radius 10 — the payload `parseDxf` produces for `code 50 = 0`, `code 51 = 90`:

```
before   48 segments, last point back on the first, x spans -10.00 .. 10.00
after    12 segments, x spans   0.00 .. 10.00
```

Bounds are wrong too, since `drawingLineBounds` measures the sampled points — a quarter arc reports the full circle's extent.

## The fix

Prefer `startAngleDeg`, and derive the sweep from `sweepAngleDeg`, which both producers guarantee non-zero in `(0, 360]`.

The end-angle path stays as the fallback, so `sampleCircle`'s `{ startAngle: 0, endAngle: 360 }` call and any legacy payload keep working unchanged — including the `sweep <= 0` wrap that makes a bare arc with no angles still close into a circle.

## Tests

`packages/cadjs` had no tests, and `scripts/run-tests.mjs` exits with *"No cadjs tests found."* — so this adds the first ones, at the path that runner already collects.

They assert the sampled geometry rather than the key names, which is what actually drifted here:

| test | asserts |
|---|---|
| a quarter arc in parser keys stays a quarter arc | x stays ≥ 0 |
| a full circle in parser keys still closes | x spans −10..10 |
| the legacy start/end angle shape is still honoured | x stays ≥ 0 |
| an arc with no angles at all still yields a closed circle | x spans −10..10 |

```
after   ℹ pass 4   ℹ fail 0
before  ℹ pass 3   ℹ fail 1   ✖ a quarter arc in parser keys stays a quarter arc
```

Only the case that was broken fails on `main`; the three control cases pass either way, which is what makes the fallback safe.