### PR TITLE
fix(dxf): stop MTEXT paragraph properties leaking into engraved text

### DIFF
--- a/skills/cad-viewer/scripts/viewer/packages/cadjs/src/lib/dxf/parseDxf.js
+++ b/skills/cad-viewer/scripts/viewer/packages/cadjs/src/lib/dxf/parseDxf.js
@@ -679,9 +679,12 @@ const NON_GEOMETRIC_ENTITY_TYPES = new Set([
 export function stripMtextFormatting(raw) {
   let text = String(raw ?? "");
   // \P is a paragraph break, \~ a hard space; \\ and \{ \} escape literals.
-  text = text.replace(/\\P/gi, "\n").replace(/\\~/g, " ");
-  // Inline property runs: \f...; \H...; \C...; \T...; \Q...; \W...; \A...; — command up to ;
-  text = text.replace(/\\[fFhHcCtTqQwWaA][^;]*;/g, "");
+  // Case-sensitive: lowercase \p is paragraph PROPERTIES (\pxqc;), a different
+  // command. Matching it here consumed only the two characters and left its
+  // payload behind, so \pxqc;PART A engraved as "xqc;PART A".
+  text = text.replace(/\\P/g, "\n").replace(/\\~/g, " ");
+  // Inline property runs: \f...; \H...; \C...; \T...; \Q...; \W...; \A...; \p...; — command up to ;
+  text = text.replace(/\\[fFhHcCtTqQwWaAp][^;]*;/g, "");
   // Stacking \S...^...; renders as the plain parts.
   text = text.replace(/\\S([^^;]*)\^([^;]*);/g, "$1/$2");
   // Grouping braces are structure, not content.

--- a/skills/cad-viewer/scripts/viewer/packages/cadjs/src/lib/dxf/stripMtextFormatting.test.mjs
+++ b/skills/cad-viewer/scripts/viewer/packages/cadjs/src/lib/dxf/stripMtextFormatting.test.mjs
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { stripMtextFormatting } from "./parseDxf.js";
+
+const BS = String.fromCharCode(92);
+
+// \p is paragraph PROPERTIES; \P is a paragraph BREAK. Matching \P
+// case-insensitively consumed only the two characters of \p and left its
+// payload in the engraved text.
+test("paragraph properties are removed whole", () => {
+  assert.equal(stripMtextFormatting(`${BS}pxqc;PART A`), "PART A");
+  assert.equal(stripMtextFormatting(`${BS}pxi-2,l2,t2;Item`), "Item");
+});
+
+test("a paragraph break is still a newline", () => {
+  assert.equal(stripMtextFormatting(`Line1${BS}PLine2`), "Line1\nLine2");
+});
+
+test("other inline property runs are unaffected", () => {
+  assert.equal(stripMtextFormatting(`${BS}H2.5x;BIG`), "BIG");
+  assert.equal(stripMtextFormatting(`${BS}C1;RED`), "RED");
+});
+
+test("plain text passes through", () => {
+  assert.equal(stripMtextFormatting("plain"), "plain");
+});


### PR DESCRIPTION
## The bug

The paragraph-break replace carries the `i` flag:

```js
text = text.replace(/\\P/gi, "\n").replace(/\\~/g, " ");
```

`\P` is a paragraph **break**. Lowercase `\p` is paragraph **properties** — a different command that carries a payload up to a semicolon (`\pxqc;`, `\pxi-2,l2,t2;`). Because `p` is also absent from the inline-property class on the next line, the replace consumes only the two characters and leaves the rest in the text:

```
\pxqc;PART A        ->  "xqc;PART A"        (want "PART A")
\pxi-2,l2,t2;Item   ->  "xi-2,l2,t2;Item"   (want "Item")
```

Any MTEXT carrying a paragraph alignment or indent engraves the command payload. Centred titles (`\pxqc;`) and indented notes are the everyday cases, so this shows up on ordinary drawings rather than exotic ones.

## The fix

Make the break case-sensitive and add `p` to the property-run class:

```js
text = text.replace(/\\P/g, "\n").replace(/\\~/g, " ");
text = text.replace(/\\[fFhHcCtTqQwWaAp][^;]*;/g, "");
```

Order already works in favour of this: the `\P` replace runs first, so no uppercase `\P` survives to be eaten by the property run.

## Verified

```
"\pxqc;PART A"        -> "PART A"          OK
"\pxi-2,l2,t2;Item"   -> "Item"            OK
"Line1\PLine2"        -> "Line1\nLine2"    OK   (break still a newline)
"\H2.5x;BIG"          -> "BIG"             OK
"plain"               -> "plain"           OK
```

## Tests

Added `src/lib/dxf/stripMtextFormatting.test.mjs`, covering the properties command, the break, the other property runs, and plain text.

```
after   ℹ pass 4   ℹ fail 0
before  ℹ pass 3   ℹ fail 1   ✖ paragraph properties are removed whole
```

Only the broken case fails on `main` — the paragraph-break and other-property tests pass either way, which is what makes the case-sensitivity change safe.

Sits alongside the arc-sampling fix in #326; the two touch different files and can land in either order.