### PR TITLE
urdf: enforce the inertia magnitude-plausibility gate from inertials.md

### DIFF
--- a/skills/urdf/scripts/urdf/source.py
+++ b/skills/urdf/scripts/urdf/source.py
@@ -450,6 +450,7 @@ def _validate_link_inertials(
             return mass
         values[key] = parsed
     _validate_inertia_tensor(link_name, values, result, display, path=f"{inertial_path}/inertia")
+    _validate_inertia_magnitude(link_element, link_name, mass, values, result, display, path=f"{inertial_path}/inertia")
     return mass
 
 
@@ -493,6 +494,115 @@ def _validate_inertia_tensor(
             f"{display} link {link_name!r} inertia violates triangle inequalities",
             path=path,
             hint="Principal moments must satisfy l1 + l2 >= l3 for a physical rigid body.",
+        )
+
+
+_MAGNITUDE_CHECK_FACTOR = 10.0
+
+
+def _link_primitive_geometry(link_element: ET.Element) -> tuple[str, ET.Element] | None:
+    """The link's collision (preferred) or visual primitive geometry element,
+    if it unambiguously resolves to exactly one box/cylinder/sphere. Returns
+    None for mesh geometry (no independent size without loading the file),
+    multiple visual/collision blocks, or missing geometry -- those cases are
+    reported elsewhere by `_validate_link_geometry` and are not this
+    function's job to re-diagnose."""
+    for parent_tag in ("collision", "visual"):
+        parents = link_element.findall(parent_tag)
+        if len(parents) != 1:
+            continue
+        geometry = parents[0].find("geometry")
+        if geometry is None:
+            continue
+        children = list(geometry)
+        if len(children) != 1:
+            continue
+        if children[0].tag in ("box", "cylinder", "sphere"):
+            return children[0].tag, children[0]
+    return None
+
+
+def _primitive_inertia_diagonal(tag: str, geometry_element: ET.Element, mass: float) -> tuple[float, float, float] | None:
+    """A uniform-density primitive of this shape/mass's own diagonal inertia,
+    axis-aligned to the link frame -- the same closed-form formulas already
+    published in references/inertials.md's "Closed-Form Formulas" section.
+    Reads its own attributes directly (not via the `_positive_*_attr`
+    helpers) so a malformed value here is silently skipped rather than
+    double-reported; `_validate_geometry_element` already reports malformed
+    primitive dimensions on its own pass."""
+    try:
+        if tag == "box":
+            x, y, z = (float(part) for part in geometry_element.attrib["size"].split())
+            if x <= 0 or y <= 0 or z <= 0:
+                return None
+            return (
+                mass * (y**2 + z**2) / 12,
+                mass * (x**2 + z**2) / 12,
+                mass * (x**2 + y**2) / 12,
+            )
+        if tag == "cylinder":
+            r = float(geometry_element.attrib["radius"])
+            l = float(geometry_element.attrib["length"])
+            if r <= 0 or l <= 0:
+                return None
+            i_perp = mass * (3 * r**2 + l**2) / 12
+            return (i_perp, i_perp, mass * r**2 / 2)
+        if tag == "sphere":
+            r = float(geometry_element.attrib["radius"])
+            if r <= 0:
+                return None
+            i = 2 * mass * r**2 / 5
+            return (i, i, i)
+    except (KeyError, ValueError):
+        return None
+    return None
+
+
+def _validate_inertia_magnitude(
+    link_element: ET.Element,
+    link_name: str,
+    mass: float,
+    values: dict[str, float],
+    result: ValidationResult,
+    display: str,
+    *,
+    path: str,
+) -> None:
+    """references/inertials.md documents this as "Sanity Gate" 3 ("Magnitude
+    plausibility... within roughly an order of magnitude of m*d^2/10... A 0.5
+    kg, 10 cm part with ixx = 2.0 kg*m^2 is wrong by ~1000x") but nothing
+    enforced it -- that exact example passed validation with zero findings.
+    When collision/visual geometry is a primitive with known dimensions, the
+    same order-of-magnitude comparison the doc already describes by hand is
+    checkable automatically; mesh-backed links still rely on the manual gate
+    plus a helper script, exactly as documented, since no independent size is
+    available here without loading the mesh file."""
+    if mass <= 0.0:
+        return
+    primitive = _link_primitive_geometry(link_element)
+    if primitive is None:
+        return
+    tag, geometry_element = primitive
+    expected = _primitive_inertia_diagonal(tag, geometry_element, mass)
+    if expected is None:
+        return
+    declared = (values["ixx"], values["iyy"], values["izz"])
+    if any(
+        e > 0 and (d > e * _MAGNITUDE_CHECK_FACTOR or d < e / _MAGNITUDE_CHECK_FACTOR)
+        for e, d in zip(expected, declared)
+    ):
+        result.add(
+            "warning",
+            "magnitude_implausible_for_primitive",
+            f"{display} link {link_name!r} inertia is more than {_MAGNITUDE_CHECK_FACTOR:g}x off "
+            f"from what its own {tag} collision/visual geometry and mass would produce",
+            path=path,
+            hint=(
+                f"Expected roughly ixx={expected[0]:.3g} iyy={expected[1]:.3g} izz={expected[2]:.3g} "
+                f"kg*m^2 for a solid {tag} of this size and mass; a real part is hollow/irregular so "
+                f"some difference is normal, but an order-of-magnitude gap usually means a unit bug "
+                f"(mm vs m, a dropped density, or a stale scale factor)."
+            ),
         )
 
 

--- a/tests/python/skills/urdf/test_source.py
+++ b/tests/python/skills/urdf/test_source.py
@@ -325,6 +325,81 @@ class UrdfSourceTests(unittest.TestCase):
             read_urdf_source(source_path)
         self.assertTrue(any("triangle" in str(warning.message) for warning in caught))
 
+    def test_read_urdf_source_warns_on_inertia_magnitude_implausible_for_box(self) -> None:
+        # references/inertials.md's own "Sanity Gate" example: a 0.5 kg,
+        # 10 cm box with ixx = 2.0 kg*m^2 is wrong by ~1000x.
+        source_path = self._write_urdf(
+            "robot",
+            """
+            <robot name="sample-robot">
+              <link name="base_link">
+                <inertial>
+                  <mass value="0.5" />
+                  <inertia ixx="2.0" ixy="0" ixz="0" iyy="2.0" iyz="0" izz="2.0" />
+                </inertial>
+                <visual>
+                  <geometry><box size="0.1 0.1 0.1" /></geometry>
+                </visual>
+              </link>
+            </robot>
+            """,
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", UrdfSourceWarning)
+            read_urdf_source(source_path)
+        self.assertTrue(any("more than 10x off" in str(warning.message) for warning in caught))
+
+    def test_read_urdf_source_accepts_inertia_matching_box_geometry(self) -> None:
+        source_path = self._write_urdf(
+            "robot",
+            """
+            <robot name="sample-robot">
+              <link name="base_link">
+                <inertial>
+                  <mass value="0.5" />
+                  <inertia ixx="0.000833" ixy="0" ixz="0" iyy="0.000833" iyz="0" izz="0.000833" />
+                </inertial>
+                <visual>
+                  <geometry><box size="0.1 0.1 0.1" /></geometry>
+                </visual>
+              </link>
+            </robot>
+            """,
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", UrdfSourceWarning)
+            read_urdf_source(source_path)
+        self.assertFalse(any("more than 10x off" in str(warning.message) for warning in caught))
+
+    def test_read_urdf_source_skips_magnitude_check_for_mesh_geometry(self) -> None:
+        # No independent size is available for a mesh without loading the
+        # file, so the magnitude check should not fire here even though this
+        # inertia is just as implausible as the box case above.
+        mesh_path = self._write_mesh("base")
+        source_path = self._write_urdf(
+            "robot",
+            f"""
+            <robot name="sample-robot">
+              <link name="base_link">
+                <inertial>
+                  <mass value="0.5" />
+                  <inertia ixx="2.0" ixy="0" ixz="0" iyy="2.0" iyz="0" izz="2.0" />
+                </inertial>
+                <visual>
+                  <geometry><mesh filename="{mesh_path.as_posix()}" /></geometry>
+                </visual>
+              </link>
+            </robot>
+            """,
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", UrdfSourceWarning)
+            read_urdf_source(source_path)
+        self.assertFalse(any("more than 10x off" in str(warning.message) for warning in caught))
+
     def test_read_urdf_source_rejects_invalid_origin_vector(self) -> None:
         source_path = self._write_urdf(
             "robot",


### PR DESCRIPTION
## Summary

`skills/urdf/references/inertials.md` documents five inertial "Sanity Gates" a human should check before accepting an `<inertial>` block. Three of the five are already enforced by `scripts/validate` (`_validate_inertia_tensor` in `skills/urdf/scripts/urdf/source.py`): positive diagonal, positive semidefiniteness via a real closed-form eigenvalue solve, and the triangle inequality on principal moments. That's genuinely more rigorous than I expected going in.

Gate 3, magnitude plausibility, is documented with a worked example but has no code behind it:

> Magnitude plausibility: for a part with characteristic size `d` and mass `m`, diagonal terms should be within roughly an order of magnitude of `m·d²/10`. A 0.5 kg, 10 cm part with `ixx = 2.0` kg·m² is wrong by ~1000×.

That exact example passes `scripts/validate --strict` today with zero findings.

## Fix

When a link's `<collision>` (preferred) or `<visual>` geometry resolves to a single `box`/`cylinder`/`sphere` primitive, cross-check the declared `<mass>`/`<inertia>` against the closed-form formula for that exact primitive shape — the same formulas already published in `inertials.md`'s "Closed-Form Formulas" section, so this wires existing reference-doc content into the validator rather than deriving anything new. Warns (not errors) if any diagonal term is off by more than 10× in either direction, matching `inertia_triangle_inequality`'s existing warning-severity precedent — real hollow/irregular parts legitimately differ from a solid-primitive estimate by several times.

Mesh-backed links are untouched: no independent size is available without loading the mesh file, so that half still relies on the manual gate plus a helper script, exactly as `inertials.md` already describes.

New finding code: `magnitude_implausible_for_primitive`.

## Testing

Added 3 tests to `tests/python/skills/urdf/test_source.py`:
- warns on the exact "0.5 kg / 10 cm box / ixx=2.0" example from `inertials.md`
- accepts inertia that actually matches the declared box geometry
- confirms the check is silently skipped for mesh geometry (no false positives where no independent size exists)

Full suite: `python -m unittest tests.python.skills.urdf.test_source` — **28/28 pass**, including the 3 new tests and all pre-existing ones (no regressions).

Also manually re-verified against a real mesh-backed multi-link robot description to confirm the check stays silent there as designed (no false positives on realistic mesh-only links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)