### PR TITLE
fix(dxf): read the arc angle keys the parsers actually emit

### DIFF
--- a/packages/cadjs/src/lib/dxf/buildDrawingLines.js
+++ b/packages/cadjs/src/lib/dxf/buildDrawingLines.js
@@ -38,14 +38,28 @@ function sampleArc(target, arc, elevation, requested) {
   if (!Number.isFinite(radius) || radius <= 0) {
     return;
   }
-  const start = Number(arc.startAngle ?? arc.start_angle ?? 0);
-  const end = Number(arc.endAngle ?? arc.end_angle ?? 0);
-  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+  // parseDxf and drawing_render.py both emit startAngleDeg/sweepAngleDeg.
+  // Reading only startAngle/endAngle left start and end at 0 for every real
+  // arc, so sweep came out 0, the wrap below turned it into a full turn, and
+  // each arc was drawn as a complete circle.
+  const start = Number(arc.startAngleDeg ?? arc.startAngle ?? arc.start_angle ?? 0);
+  if (!Number.isFinite(start)) {
     return;
   }
   // Angles arrive in degrees, counter-clockwise, as DXF stores them.
   const startRadians = (start * Math.PI) / 180;
-  let sweep = ((end - start) * Math.PI) / 180;
+  let sweep;
+  const sweepDeg = Number(arc.sweepAngleDeg ?? arc.sweep_angle_deg);
+  if (Number.isFinite(sweepDeg) && sweepDeg !== 0) {
+    // Both producers guarantee a non-zero sweep in (0, 360].
+    sweep = (sweepDeg * Math.PI) / 180;
+  } else {
+    const end = Number(arc.endAngle ?? arc.end_angle ?? 0);
+    if (!Number.isFinite(end)) {
+      return;
+    }
+    sweep = ((end - start) * Math.PI) / 180;
+  }
   if (sweep <= 0) {
     sweep += Math.PI * 2;
   }

--- a/packages/cadjs/src/lib/dxf/buildDrawingLines.test.js
+++ b/packages/cadjs/src/lib/dxf/buildDrawingLines.test.js
@@ -111,3 +111,49 @@ test("bounds cover the drawing, for fitting a camera with no mesh to measure", (
   assert.equal(bounds.max[2], 425);
   assert.equal(drawingLineBounds({ layers: [] }), null);
 });
+
+function arcXRange(arc) {
+  const groups = buildDxfDrawingLineGroups({ geometry: { arcs: [arc], lines: [], circles: [] } });
+  const positions = groups.layers[0].positions;
+  const xs = [];
+  for (let index = 0; index < positions.length; index += 3) {
+    xs.push(positions[index]);
+  }
+  return [Math.min(...xs), Math.max(...xs)];
+}
+
+// parseDxf and drawing_render.py emit startAngleDeg/sweepAngleDeg. Reading
+// only startAngle/endAngle left both at 0, so every arc swept a full turn.
+test("an arc in the parser's angle keys keeps its sweep", () => {
+  const [minX, maxX] = arcXRange({
+    layer: "DIMS", center: [0, 0], radius: 10, startAngleDeg: 0, sweepAngleDeg: 90,
+  });
+
+  assert.ok(minX >= -0.001, `quarter arc should stay in x >= 0, got ${minX}`);
+  assert.ok(Math.abs(maxX - 10) < 0.001);
+});
+
+test("a full circle in the parser's angle keys still closes", () => {
+  const [minX, maxX] = arcXRange({
+    layer: "DIMS", center: [0, 0], radius: 10, startAngleDeg: 0, sweepAngleDeg: 360,
+  });
+
+  assert.ok(Math.abs(minX + 10) < 0.001);
+  assert.ok(Math.abs(maxX - 10) < 0.001);
+});
+
+test("the legacy start/end angle shape is still honoured", () => {
+  const [minX, maxX] = arcXRange({
+    layer: "DIMS", center: [0, 0], radius: 10, startAngle: 0, endAngle: 90,
+  });
+
+  assert.ok(minX >= -0.001);
+  assert.ok(Math.abs(maxX - 10) < 0.001);
+});
+
+test("an arc with no angles at all still yields a closed circle", () => {
+  const [minX, maxX] = arcXRange({ layer: "DIMS", center: [0, 0], radius: 10 });
+
+  assert.ok(Math.abs(minX + 10) < 0.001);
+  assert.ok(Math.abs(maxX - 10) < 0.001);
+});


### PR DESCRIPTION
Re-files #326 against `develop`, per @earthtojake — that one targeted `main` and edited the generated copy under `skills/cad-viewer/`, which the next release would have regenerated away.

This one patches the source at `packages/cadjs/src/lib/dxf/buildDrawingLines.js` and adds the cases to the existing `buildDrawingLines.test.js`.

## The bug

Every DXF `ARC` renders as a **complete circle** in the drawing view.

`sampleArc` reads `arc.startAngle` / `arc.endAngle`. Neither producer emits those keys — `parseDxf.js` and `drawing_render.py` both emit `startAngleDeg` and `sweepAngleDeg`. So `start` and `end` both fall back to `0`, `sweep` comes out `0`, and the wrap immediately below turns that into a full turn:

```js
let sweep = ((end - start) * Math.PI) / 180;   // 0
if (sweep <= 0) {
  sweep += Math.PI * 2;                        // 360°
}
```

A 90° arc at the origin, radius 10 — the payload `parseDxf` produces for `code 50 = 0`, `code 51 = 90`:

```
before   48 segments, last point back on the first, x spans -10.00 .. 10.00
after    12 segments, x spans   0.00 .. 10.00
```

`drawingLineBounds` measures those sampled points, so the fitted camera saw the full circle's extent too.

## The fix

Prefer `startAngleDeg`, and derive the sweep from `sweepAngleDeg`, which both producers guarantee non-zero in `(0, 360]`.

The end-angle path stays as the fallback, so `sampleCircle`'s `{ startAngle: 0, endAngle: 360 }` call and any legacy payload keep working unchanged — including the `sweep <= 0` wrap that makes a bare arc with no angles still close into a circle.

## Tests

Four cases appended to `buildDrawingLines.test.js`. They assert the sampled geometry rather than the key names, which is what actually drifted:

| test | asserts |
|---|---|
| an arc in the parser's angle keys keeps its sweep | x stays ≥ 0 |
| a full circle in the parser's angle keys still closes | x spans −10..10 |
| the legacy start/end angle shape is still honoured | x stays ≥ 0 |
| an arc with no angles at all still yields a closed circle | x spans −10..10 |

```
node scripts/run-tests.mjs src/lib/dxf/buildDrawingLines.test.js
ℹ tests 12   ℹ pass 12   ℹ fail 0
```

That is the existing 8 plus these 4. Only the first fails without the source change; the three control cases pass either way, which is what makes the fallback safe.

The MTEXT fix in #327 is being re-filed against `develop` the same way.