### PR TITLE
viewer: stream asset and download responses in 64 KiB chunks

### DIFF
--- a/viewer/server_py/server.py
+++ b/viewer/server_py/server.py
@@ -26,6 +26,7 @@ import argparse
 import os
 import posixpath
 import re
+import shutil
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlsplit, parse_qs, unquote
@@ -102,18 +103,6 @@ class Handler(BaseHTTPRequestHandler):
         if self.command != "HEAD":
             self.wfile.write(body)
 
-    def _send_bytes(self, status: int, data: bytes, content_type: str, *, disposition: str | None = None):
-        self.send_response(status)
-        if content_type:
-            self.send_header("content-type", content_type)
-        if disposition:
-            self.send_header("content-disposition", disposition)
-        self.send_header("cache-control", "no-store")
-        self.send_header("content-length", str(len(data)))
-        self.end_headers()
-        if self.command != "HEAD":
-            self.wfile.write(data)
-
     def _query(self):
         parts = urlsplit(self.path)
         q = parse_qs(parts.query)
@@ -170,22 +159,41 @@ class Handler(BaseHTTPRequestHandler):
         self.do_GET()
 
     # --- route bodies ---
+    def _stream_file(
+        self,
+        file_path: str,
+        content_type: str | None,
+        *,
+        status: int = 200,
+        disposition: str | None = None,
+    ) -> bool:
+        """Stream a file with no-store + content-length in 64 KiB chunks."""
+        if not os.path.isfile(file_path):
+            return False
+        try:
+            size = os.path.getsize(file_path)
+        except OSError:
+            return False
+        self.send_response(status)
+        if content_type:
+            self.send_header("content-type", content_type)
+        if disposition:
+            self.send_header("content-disposition", disposition)
+        self.send_header("cache-control", "no-store")
+        self.send_header("content-length", str(size))
+        self.end_headers()
+        if self.command != "HEAD":
+            try:
+                with open(file_path, "rb") as handle:
+                    shutil.copyfileobj(handle, self.wfile, length=64 * 1024)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+        return True
+
     def _serve_static_file(self, file_path: str, content_type: str | None) -> bool:
         """Stream a file with no-store + content-length, NO etag/last-modified/range.
         Returns False (no response written) if the path is missing/not a regular file."""
-        if not os.path.isfile(file_path):
-            return False
-        with open(file_path, "rb") as handle:
-            data = handle.read()
-        self.send_response(200)
-        if content_type:
-            self.send_header("content-type", content_type)
-        self.send_header("cache-control", "no-store")
-        self.send_header("content-length", str(len(data)))
-        self.end_headers()
-        if self.command != "HEAD":
-            self.wfile.write(data)
-        return True
+        return self._stream_file(file_path, content_type)
 
     def _request_referer_file_ref(self):
         value = self.headers.get("referer") or self.headers.get("referrer") or ""
@@ -298,13 +306,9 @@ class Handler(BaseHTTPRequestHandler):
         if not candidate or not os.path.isfile(candidate):
             self._send_json(404, {"error": "Not found"})
             return
-        with open(candidate, "rb") as handle:
-            data = handle.read()
         content_type = _Ctx.backend.content_type_for_path(candidate) or "application/octet-stream"
-        disposition = None
-        if download:
-            disposition = enc.attachment_content_disposition(os.path.basename(candidate))
-        self._send_bytes(200, data, content_type, disposition=disposition)
+        disposition = enc.attachment_content_disposition(os.path.basename(candidate)) if download else None
+        self._stream_file(candidate, content_type, disposition=disposition)
 
     def _artifact_build(self, q):
         root_dir = q.get("dir", "")

--- a/viewer/server_py/tests/test_stream_file.py
+++ b/viewer/server_py/tests/test_stream_file.py
@@ -1,0 +1,66 @@
+"""Large asset/download responses stream in chunks instead of buffering whole files."""
+
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from server_py import server as server_mod  # noqa: E402
+
+
+class StreamFileTests(unittest.TestCase):
+    def _handler(self):
+        handler = mock.MagicMock(spec=server_mod.Handler)
+        handler.command = "GET"
+        written = bytearray()
+        handler.wfile = mock.MagicMock()
+        handler.wfile.write.side_effect = lambda data: written.extend(data)
+        return handler, written
+
+    def test_stream_file_serves_chunks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_file = pathlib.Path(tmp) / "large.bin"
+            payload = b"X" * (128 * 1024)  # 128 KiB, spans several 64 KiB chunks
+            test_file.write_bytes(payload)
+            handler, written = self._handler()
+
+            ok = server_mod.Handler._stream_file(handler, str(test_file), "application/octet-stream")
+
+            self.assertTrue(ok)
+            handler.send_response.assert_called_once_with(200)
+            handler.send_header.assert_any_call("content-length", str(len(payload)))
+            handler.send_header.assert_any_call("content-type", "application/octet-stream")
+            self.assertEqual(bytes(written), payload)
+
+    def test_stream_file_carries_a_download_disposition(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            test_file = pathlib.Path(tmp) / "part.step"
+            test_file.write_bytes(b"solid")
+            handler, _ = self._handler()
+
+            ok = server_mod.Handler._stream_file(
+                handler, str(test_file), "application/octet-stream", disposition="attachment; filename=x"
+            )
+
+            self.assertTrue(ok)
+            handler.send_header.assert_any_call("content-disposition", "attachment; filename=x")
+
+    def test_a_broken_client_connection_does_not_raise(self):
+        # A browser cancelling a multi-GB download must not spam tracebacks from the
+        # handler thread; the socket is going away either way.
+        with tempfile.TemporaryDirectory() as tmp:
+            test_file = pathlib.Path(tmp) / "large.bin"
+            test_file.write_bytes(b"Z" * (256 * 1024))
+            handler, _ = self._handler()
+            handler.wfile.write.side_effect = BrokenPipeError("client gone")
+
+            ok = server_mod.Handler._stream_file(handler, str(test_file), None)
+
+            self.assertTrue(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Split from #305 per review.

Asset and download responses (`GET /__cad/asset`, `/__cad/download`, and static dist files) read the whole file into memory before writing - a multi-GB GLB pinned that much RAM per request, under an unbounded `ThreadingHTTPServer`.

Responses now stream in 64 KiB chunks with an explicit `content-length` header, and a client that hangs up mid-download is absorbed (BrokenPipeError/ConnectionResetError) instead of raising from the handler thread. Nothing else about the response changes: still no-store, no etag/range, HEAD writes headers only.

The timeout work stays on #305 for the idle-watchdog rework discussed in review.

## Verification
- New `test_stream_file.py`: chunked payload integrity, disposition header, broken-pipe absorption
- Full `viewer/server_py` suite: 179 tests OK
