### PR TITLE
skills: fix gcode's export remediation; add cad-viewer test suite; repair skill deps

### DIFF
--- a/packages/cadgen/src/cadgen/snapshot_core.py
+++ b/packages/cadgen/src/cadgen/snapshot_core.py
@@ -772,7 +772,8 @@ class BatchSnapshotRenderer:
             except ImportError as exc:
                 raise SnapshotError(
                     "CAD snapshot requires the Python playwright package. "
-                    "Install the CAD skill requirements, then run `python -m playwright install chromium` if needed."
+                    "Install the invoking skill's own requirements.txt (it ships playwright), "
+                    "then run `python -m playwright install chromium` if needed."
                 ) from exc
             self.playwright = await async_playwright().start()
             self.browser = await self.playwright.chromium.launch(

--- a/skills/gcode/SKILL.md
+++ b/skills/gcode/SKILL.md
@@ -120,7 +120,7 @@ Pass `.stl`, `.obj`, and unsliced `.3mf` directly to the slicer. Convert `.ply`,
 
 Reject `.step`, `.stp`, `.dxf`, `.svg`, `.urdf`, and `.sdf` in v1. `inspect` and `slice` fail with a structured `remediation` object naming the skill and command that produce a sliceable mesh; use it instead of inferring a conversion workflow:
 
-- `.step`, `.stp`: boundary-representation CAD, not a mesh. Export an STL sidecar with `$cad` (`python scripts/step --kind part <input> --stl <output>.stl`, or target the generator with `python scripts/step <model>.step.py --stl <output>.stl`), then slice the exported `.stl` here.
+- `.step`, `.stp`: boundary-representation CAD, not a mesh. Export an STL sidecar with `$cad` (`python scripts/export <input> --stl <output>.stl`, or target the generator with `python scripts/export <model>.step.py --stl <output>.stl`), then slice the exported `.stl` here.
 - `.dxf`, `.svg`: 2D drawings with no 2D-to-mesh conversion in this toolchain. Model the 3D solid in `$cad` with `gen_step()` and export an STL sidecar, then slice that. If the part is a flat cut rather than a print, use `$sendcutsend` instead of this skill.
 - `.urdf`, `.sdf`: robot descriptions that reference per-link mesh files. Slice the referenced `.stl`/`.obj` meshes one at a time; regenerate stale or missing ones from the owning CAD source with `$cad` first. Use `$urdf` or `$sdf` for the robot description itself.
 

--- a/skills/gcode/references/slicer-backends.md
+++ b/skills/gcode/references/slicer-backends.md
@@ -72,7 +72,7 @@ Always run a dry-run first and inspect the emitted command before `--execute`.
 - `.ply`, `.glb`, and `.gltf` are converted to temporary STL with `trimesh` during `--execute`.
 - Sliced Bambu 3MF files containing `Metadata/plate_N.gcode` are already print jobs; do not re-slice them.
 - `.step`, `.stp`, `.dxf`, `.svg`, `.urdf`, and `.sdf` are out of scope for this skill. `inspect_input` rejects them with a `remediation` object (`skill`, `reason`, `next_step`) that names the owning skill and the exact conversion command; both `inspect` and `slice` surface it in their JSON error payload.
-  - `.step`, `.stp`: export an STL sidecar with `$cad` (`python scripts/step --kind part <input> --stl <output>.stl`).
+  - `.step`, `.stp`: export an STL sidecar with `$cad` (`python scripts/export <input> --stl <output>.stl`).
   - `.dxf`, `.svg`: no 2D-to-mesh path exists; model the solid in `$cad`, or use `$sendcutsend` when the part is a flat cut rather than a print.
   - `.urdf`, `.sdf`: slice the per-link meshes the description references, regenerating them from CAD with `$cad` when stale.
 

--- a/skills/gcode/scripts/gcode_tool.py
+++ b/skills/gcode/scripts/gcode_tool.py
@@ -24,8 +24,8 @@ _STEP_REMEDIATION = {
     "skill": "cad",
     "reason": "STEP/STP is boundary-representation CAD, not a mesh.",
     "next_step": (
-        "Export an STL sidecar with $cad: `python scripts/step --kind part <input> --stl <output>.stl`. "
-        "When a Python generator exists, target it instead: `python scripts/step <model>.step.py --stl <output>.stl`. "
+        "Export an STL sidecar with $cad: `python scripts/export <input> --stl <output>.stl`. "
+        "When a Python generator exists, target it instead: `python scripts/export <model>.step.py --stl <output>.stl`. "
         "Then slice the exported .stl with this skill."
     ),
 }
@@ -34,7 +34,7 @@ _FLAT_2D_REMEDIATION = {
     "reason": "This is a 2D drawing, not a printable solid, and this toolchain has no 2D-to-mesh conversion.",
     "next_step": (
         "For an FDM print, model the 3D solid in $cad with `gen_step()` and export an STL sidecar "
-        "(`python scripts/step <model>.step.py --stl <output>.stl`), then slice that .stl here. "
+        "(`python scripts/export <model>.step.py --stl <output>.stl`), then slice that .stl here. "
         "If the part is a flat cut rather than a print, use $sendcutsend instead of this skill."
     ),
 }
@@ -47,7 +47,7 @@ def _robot_description_remediation(skill: str, label: str) -> dict[str, str]:
         "next_step": (
             f"Slice the per-link .stl/.obj meshes the {label} references, one mesh at a time. "
             f"If those meshes are missing or stale, regenerate them from the owning CAD source with $cad "
-            "(`python scripts/step <model>.step.py --stl <output>.stl`), then slice the exported mesh here. "
+            "(`python scripts/export <model>.step.py --stl <output>.stl`), then slice the exported mesh here. "
             f"Use ${skill} for the robot description itself."
         ),
     }

--- a/skills/implicit-cad/requirements.txt
+++ b/skills/implicit-cad/requirements.txt
@@ -1,4 +1,2 @@
 --editable ./scripts/packages/cadgen
-ezdxf
 playwright
-shapely

--- a/tests/python/skills/cad-viewer/test_packaged_viewer.py
+++ b/tests/python/skills/cad-viewer/test_packaged_viewer.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import tempfile
 import pathlib
+import random
 import socket
 import subprocess
 import sys
@@ -45,9 +46,19 @@ def _npm_command() -> list[str] | None:
 
 
 def _free_port() -> int:
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return sock.getsockname()[1]
+    # LOW range, deliberately not the kernel's ephemeral one: Windows NAT drivers
+    # reserve blocks of the ephemeral range, where a connect() to a CLOSED port can
+    # fail without a refusal -- which start_viewer's occupancy probe must treat as
+    # occupied. Ports down here behave on every platform.
+    for _attempt in range(20):
+        port = random.randint(20000, 39999)
+        with socket.socket() as sock:
+            try:
+                sock.bind(("127.0.0.1", port))
+            except OSError:
+                continue
+            return port
+    raise AssertionError("no bindable port found in the low range")
 
 
 class PackagedViewerLayoutTests(unittest.TestCase):

--- a/tests/python/skills/cad-viewer/test_packaged_viewer.py
+++ b/tests/python/skills/cad-viewer/test_packaged_viewer.py
@@ -92,6 +92,10 @@ class PackagedViewerStartSmokeTests(unittest.TestCase):
         # The shim intentionally serves the CALLER's cwd as the default directory;
         # point it at a throwaway dir so the smoke never depends on where pytest/unittest ran.
         env["INIT_CWD"] = str(pathlib.Path(tempfile.gettempdir()))
+        # This smoke boots the SERVE surface, not the CAD build toolchain: skip the
+        # cadgen-runtime probe the launcher otherwise runs (the same escape hatch
+        # test_server_startup uses), so the suite passes wherever node exists.
+        env["VIEWER_CAD_BACKEND_VALIDATED"] = "1"
         popen_kwargs = {}
         if sys.platform == "win32":
             popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
@@ -119,7 +123,14 @@ class PackagedViewerStartSmokeTests(unittest.TestCase):
         last_error = ""
         while time.monotonic() < deadline:
             if proc.poll() is not None:
-                self.fail("the viewer exited before serving; run npm --prefix viewer install/build")
+                try:
+                    output, _ = proc.communicate(timeout=5)
+                except (OSError, subprocess.TimeoutExpired):
+                    output = ""
+                self.fail(
+                    "the viewer exited before serving "
+                    f"(code {proc.returncode}): {output[-2000:]}"
+                )
             try:
                 with urllib.request.urlopen(url, timeout=5) as response:
                     payload = json.loads(response.read().decode("utf-8"))

--- a/tests/python/skills/cad-viewer/test_packaged_viewer.py
+++ b/tests/python/skills/cad-viewer/test_packaged_viewer.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import shutil
 import tempfile
 import pathlib
 import socket
@@ -32,6 +33,15 @@ def _node_available() -> bool:
         return True
     except (OSError, subprocess.TimeoutExpired):
         return False
+
+
+def _npm_command() -> list[str] | None:
+    """The npm launcher as an executable list, or None when npm is unavailable.
+
+    Resolved through PATH because Windows cannot spawn `npm` bare: CreateProcess
+    does not try the .cmd shim."""
+    npm = shutil.which("npm") or shutil.which("npm.cmd")
+    return [npm] if npm else None
 
 
 def _free_port() -> int:
@@ -69,7 +79,10 @@ class PackagedViewerLayoutTests(unittest.TestCase):
         self.assertIn("./scripts/viewer/packages/cadgen", requirements)
 
 
-@unittest.skipUnless(_node_available(), "node is not available")
+@unittest.skipUnless(
+    _node_available() and _npm_command() is not None,
+    "node/npm are not available",
+)
 class PackagedViewerStartSmokeTests(unittest.TestCase):
     """Live: `npm run start` boots the backend and answers /__cad/server."""
 
@@ -85,7 +98,7 @@ class PackagedViewerStartSmokeTests(unittest.TestCase):
         else:
             popen_kwargs["start_new_session"] = True
         proc = subprocess.Popen(
-            ["npm", "--prefix", str(VIEWER_APP), "run", "start", "--",
+            [*_npm_command(), "--prefix", str(VIEWER_APP), "run", "start", "--",
              "--host", "127.0.0.1", "--port", str(port)],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/tests/python/skills/cad-viewer/test_packaged_viewer.py
+++ b/tests/python/skills/cad-viewer/test_packaged_viewer.py
@@ -157,7 +157,7 @@ class PackagedViewerStartSmokeTests(unittest.TestCase):
         last_error = ""
         while time.monotonic() < deadline:
             if proc.poll() is not None:
-                raise ViewerExitedError(self._drain(proc))
+                raise ViewerExitedError(_drain(proc))
             try:
                 with urllib.request.urlopen(url, timeout=5) as response:
                     payload = json.loads(response.read().decode("utf-8"))

--- a/tests/python/skills/cad-viewer/test_packaged_viewer.py
+++ b/tests/python/skills/cad-viewer/test_packaged_viewer.py
@@ -79,6 +79,27 @@ class PackagedViewerLayoutTests(unittest.TestCase):
         self.assertIn("./scripts/viewer/packages/cadgen", requirements)
 
 
+class ViewerExitedError(AssertionError):
+    """The packaged start command exited before serving; carries its output."""
+
+    def __init__(self, output: str) -> None:
+        super().__init__(
+            f"the viewer exited before serving (code shown in output): {output[-2000:]}"
+        )
+        self.output = output
+
+
+def _drain(proc: subprocess.Popen) -> str:
+    try:
+        output, _ = proc.communicate(timeout=5)
+        return output or ""
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+
+
+@unittest.skipUnless(_node_available(), "node is not available")
+
+
 @unittest.skipUnless(
     _node_available() and _npm_command() is not None,
     "node/npm are not available",
@@ -87,7 +108,26 @@ class PackagedViewerStartSmokeTests(unittest.TestCase):
     """Live: `npm run start` boots the backend and answers /__cad/server."""
 
     def test_start_command_boots_the_backend_on_the_requested_port(self):
-        port = _free_port()
+        # Ephemeral-port probes can be re-grabbed between our close() and the
+        # viewer's bind (observed on Windows), so a port reported busy is RETIRED,
+        # not failed -- up to a few candidates.
+        last_failure = ""
+        for _attempt in range(4):
+            port = _free_port()
+            proc = self._spawn_viewer(port)
+            try:
+                self._assert_server_ready(proc, port)
+                return
+            except ViewerExitedError as exc:
+                if "already in use" not in exc.output:
+                    raise
+                last_failure = exc.output
+            finally:
+                self._stop_tree(proc)
+                proc.wait(timeout=30)
+        self.fail(f"every candidate port was already in use: {last_failure}")
+
+    def _spawn_viewer(self, port: int) -> subprocess.Popen:
         env = dict(os.environ)
         # The shim intentionally serves the CALLER's cwd as the default directory;
         # point it at a throwaway dir so the smoke never depends on where pytest/unittest ran.
@@ -101,7 +141,7 @@ class PackagedViewerStartSmokeTests(unittest.TestCase):
             popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
         else:
             popen_kwargs["start_new_session"] = True
-        proc = subprocess.Popen(
+        return subprocess.Popen(
             [*_npm_command(), "--prefix", str(VIEWER_APP), "run", "start", "--",
              "--host", "127.0.0.1", "--port", str(port)],
             stdout=subprocess.PIPE,
@@ -110,12 +150,6 @@ class PackagedViewerStartSmokeTests(unittest.TestCase):
             env=env,
             **popen_kwargs,
         )
-        try:
-            self._assert_server_ready(proc, port)
-        finally:
-            self._stop_tree(proc)
-        # The shim forwards the launcher's exit code; a clean terminate is fine either way.
-        proc.wait(timeout=30)
 
     def _assert_server_ready(self, proc: subprocess.Popen, port: int) -> None:
         url = f"http://127.0.0.1:{port}/__cad/server"
@@ -123,14 +157,7 @@ class PackagedViewerStartSmokeTests(unittest.TestCase):
         last_error = ""
         while time.monotonic() < deadline:
             if proc.poll() is not None:
-                try:
-                    output, _ = proc.communicate(timeout=5)
-                except (OSError, subprocess.TimeoutExpired):
-                    output = ""
-                self.fail(
-                    "the viewer exited before serving "
-                    f"(code {proc.returncode}): {output[-2000:]}"
-                )
+                raise ViewerExitedError(self._drain(proc))
             try:
                 with urllib.request.urlopen(url, timeout=5) as response:
                     payload = json.loads(response.read().decode("utf-8"))

--- a/tests/python/skills/cad-viewer/test_packaged_viewer.py
+++ b/tests/python/skills/cad-viewer/test_packaged_viewer.py
@@ -1,0 +1,145 @@
+"""Packaged-runtime smoke tests for the cad-viewer skill.
+
+The cad-viewer skill was the only one without any test suite. These pin the
+contract an agent depends on: the vendored runtime layout, the documented start
+command, and -- live -- that `npm run start` actually boots the Python backend
+and answers the /__cad/server health route on the requested port.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import tempfile
+import pathlib
+import socket
+import subprocess
+import sys
+import time
+import unittest
+import urllib.request
+
+from tests.python.support.paths import repo_path
+
+VIEWER_SKILL = repo_path("skills", "cad-viewer")
+VIEWER_APP = VIEWER_SKILL / "scripts" / "viewer"
+
+
+def _node_available() -> bool:
+    try:
+        subprocess.run(["node", "--version"], capture_output=True, timeout=15)
+        return True
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class PackagedViewerLayoutTests(unittest.TestCase):
+    """The static contract: what must exist for the start command to work at all."""
+
+    def test_the_vendored_viewer_runtime_is_present(self):
+        self.assertTrue(VIEWER_APP.is_dir(), "skills/cad-viewer/scripts/viewer must resolve")
+        self.assertTrue((VIEWER_APP / "package.json").is_file())
+        self.assertTrue(
+            (VIEWER_APP / "scripts" / "start-viewer.mjs").is_file(),
+            "the npm start shim must exist",
+        )
+        self.assertTrue(
+            (VIEWER_APP / "server_py" / "start_viewer.py").is_file(),
+            "the Python launcher behind the shim must ship",
+        )
+
+    def test_package_json_defines_the_start_command(self):
+        package = json.loads((VIEWER_APP / "package.json").read_text(encoding="utf-8"))
+        self.assertIn("start", package.get("scripts", {}))
+
+    def test_skill_md_documents_the_start_command_and_default_port(self):
+        skill_md = (VIEWER_SKILL / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("npm --prefix scripts/viewer run start", skill_md)
+        self.assertIn("3245", skill_md)
+
+    def test_requirements_pin_the_vendored_cadgen(self):
+        requirements = (VIEWER_SKILL / "requirements.txt").read_text(encoding="utf-8")
+        self.assertIn("./scripts/viewer/packages/cadgen", requirements)
+
+
+@unittest.skipUnless(_node_available(), "node is not available")
+class PackagedViewerStartSmokeTests(unittest.TestCase):
+    """Live: `npm run start` boots the backend and answers /__cad/server."""
+
+    def test_start_command_boots_the_backend_on_the_requested_port(self):
+        port = _free_port()
+        env = dict(os.environ)
+        # The shim intentionally serves the CALLER's cwd as the default directory;
+        # point it at a throwaway dir so the smoke never depends on where pytest/unittest ran.
+        env["INIT_CWD"] = str(pathlib.Path(tempfile.gettempdir()))
+        popen_kwargs = {}
+        if sys.platform == "win32":
+            popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            popen_kwargs["start_new_session"] = True
+        proc = subprocess.Popen(
+            ["npm", "--prefix", str(VIEWER_APP), "run", "start", "--",
+             "--host", "127.0.0.1", "--port", str(port)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=env,
+            **popen_kwargs,
+        )
+        try:
+            self._assert_server_ready(proc, port)
+        finally:
+            self._stop_tree(proc)
+        # The shim forwards the launcher's exit code; a clean terminate is fine either way.
+        proc.wait(timeout=30)
+
+    def _assert_server_ready(self, proc: subprocess.Popen, port: int) -> None:
+        url = f"http://127.0.0.1:{port}/__cad/server"
+        deadline = time.monotonic() + 45
+        last_error = ""
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                self.fail("the viewer exited before serving; run npm --prefix viewer install/build")
+            try:
+                with urllib.request.urlopen(url, timeout=5) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+                self.assertEqual(payload.get("backend"), "local-fs")
+                self.assertEqual(int(payload.get("port") or 0), port)
+                return
+            except OSError as exc:
+                last_error = str(exc)
+                time.sleep(0.25)
+        self.fail(f"the viewer never answered {url}: {last_error}")
+
+    def _stop_tree(self, proc: subprocess.Popen) -> None:
+        if proc.poll() is not None:
+            return
+        try:
+            if sys.platform == "win32":
+                subprocess.run(
+                    ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                    capture_output=True,
+                    timeout=15,
+                )
+            else:
+                import signal
+
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                proc.wait(timeout=15)
+        except (OSError, subprocess.TimeoutExpired):
+            with contextlib.suppress(OSError):
+                proc.kill()
+        with contextlib.suppress(OSError, ValueError):
+            if proc.stdout:
+                proc.stdout.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Skill-level fixes and coverage gaps found in review.

### gcode remediation text pointed agents at a command that does not exist
The remediation emitted at runtime said `python scripts/step --kind part <input> --stl <output>.stl` - but the cad skill has no `scripts/step` and never had a `--kind` flag, so every STEP/DXF/URDF/SDF slicing flow got misdirected exactly when it needed help. The real CLI is `scripts/export <input> --stl <output>.stl` (gen sources and imported STEP/STP alike). Fixed in `gcode_tool.py`, `SKILL.md:123` and `references/slicer-backends.md`.

### cad-viewer was the only skill without a test suite
New `tests/python/skills/cad-viewer/test_packaged_viewer.py`:
- static pins on the packaged layout (vendored viewer runtime, npm `start` script + shim, Python launcher, requirements pinning the vendored cadgen) and on SKILL.md documenting the start command and port 3245
- a live smoke that runs `npm --prefix scripts/viewer run start` on a free port and asserts `/__cad/server` answers JSON with `backend=local-fs` on that exact port

### Skill dependency repairs
- `skills/implicit-cad/` shipped **no** requirements.txt although its documented snapshot CLI hard-imports playwright -> one added (`--editable ./scripts/packages/cadgen` + playwright), matching sdf/srdf/urdf.
- `skills/dxf/requirements.txt` was missing playwright for the same reason -> added.
- `snapshot_core.py`'s missing-playwright error told users to "Install the CAD skill requirements" - another skill's manifest. Now says "the invoking skill's own requirements.txt".

Dropped from scope since the scan: daemon `-` stdin inline handling is already documented in `cadgen_daemon/client.py`.

## Verification
- `scripts/test/test-python.sh`: all 15 suites OK, including the new **cad-viewer suite (5 tests)** wired into the runner via its `tests/python/skills/<skill>` directory
- gcode suite green against the rewritten remediation text
