### PR TITLE
viewer: probe port availability by binding, not connecting

### DIFF
--- a/viewer/server_py/start_viewer.py
+++ b/viewer/server_py/start_viewer.py
@@ -21,6 +21,7 @@ Run: python -m server_py.start_viewer [--port N] [--json]
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import socket
@@ -37,7 +38,6 @@ else:
     from .paths import url_path_from_filesystem_path
     from .server_info import DEFAULT_VIEWER_PORT, DEFAULT_VIEWER_HOST
 
-_PROBE_TIMEOUT_S = 0.35
 _VIEWER_APP_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
@@ -53,16 +53,27 @@ def viewer_url(host: str, port: int, directory: str = "") -> str:
 
 
 def port_is_free(host: str, port: int) -> bool:
-    """True only when nothing is listening on host:port (connection refused). A
-    live listener — or an ambiguous/unreachable socket — counts as occupied, so
-    we never race a bind against another process."""
+    """True when this process can bind host:port -- the same operation the server
+    is about to perform, so the probe cannot disagree with reality.
+
+    This used to probe by CONNECTING, with only ConnectionRefusedError counting
+    as free. On Windows a connect to a closed port routinely fails some other
+    way (Hyper-V/WSL port exclusions, loopback filtering, refusals arriving as
+    timeouts), so every port read as occupied and the launcher refused to start
+    with a false "already in use" -- found by #335's Windows smoke, where four
+    random ports Python had just bound all "failed" the connect probe.
+
+    A definite EADDRINUSE (and EACCES, Windows's answer for its excluded port
+    ranges) keeps the friendly rerun-with---port message. Any other error counts
+    as FREE: this probe exists only for that message, and a probe that cannot
+    tell must never block a launch -- the server's own bind stays authoritative
+    and reports anything genuinely wrong."""
     try:
-        with socket.create_connection((host, port), timeout=_PROBE_TIMEOUT_S):
-            return False
-    except ConnectionRefusedError:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind((host, port))
         return True
-    except OSError:
-        return False
+    except OSError as exc:
+        return exc.errno not in (errno.EADDRINUSE, errno.EACCES)
 
 
 def spawn_backend(host: str, port: int):

--- a/viewer/server_py/tests/test_start_viewer.py
+++ b/viewer/server_py/tests/test_start_viewer.py
@@ -9,10 +9,12 @@ launcher only reports a URL for the cwd it happens to run in.
 """
 
 import contextlib
+import errno
 import io
 import json
 import os
 import pathlib
+import socket
 import sys
 import tempfile
 import unittest
@@ -21,6 +23,49 @@ from unittest import mock
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 
 from server_py import start_viewer as sav  # noqa: E402
+
+
+class PortProbeTests(unittest.TestCase):
+    """port_is_free answers by BINDING, because binding is what the server will do.
+
+    The connect-based probe this replaced treated every non-refusal as occupied,
+    and on Windows a connect to a closed port routinely fails without a refusal
+    (Hyper-V/WSL port exclusions, loopback filtering) -- so the launcher reported
+    "already in use" for every port and refused to start. Found by the packaged
+    viewer smoke on Windows CI, where four random ports Python had just bound all
+    "failed" the connect probe (#335).
+    """
+
+    def test_a_bindable_port_is_free(self):
+        with socket.socket() as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
+        # Closed again: bindable, so free. The old probe would also have said
+        # free here on POSIX; this pins the new mechanism agrees.
+        self.assertTrue(sav.port_is_free("127.0.0.1", port))
+
+    def test_a_listening_port_is_occupied(self):
+        with socket.socket() as listener:
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            port = listener.getsockname()[1]
+            self.assertFalse(sav.port_is_free("127.0.0.1", port))
+
+    def test_an_ambiguous_probe_error_never_blocks_a_launch(self):
+        # The probe exists only for a friendly message. When it cannot tell (a
+        # timeout, a filtered socket, any OSError that is not a definite
+        # in-use/excluded answer), the launch must proceed and the server's own
+        # bind stays authoritative. This is the exact Windows failure shape.
+        for exc in (TimeoutError("timed out"), OSError(errno.ECONNRESET, "reset")):
+            with mock.patch.object(sav.socket, "socket") as socket_factory:
+                socket_factory.return_value.__enter__.return_value.bind.side_effect = exc
+                self.assertTrue(sav.port_is_free("127.0.0.1", 3245), exc)
+
+    def test_definite_in_use_and_excluded_answers_still_block(self):
+        for code in (errno.EADDRINUSE, errno.EACCES):
+            with mock.patch.object(sav.socket, "socket") as socket_factory:
+                socket_factory.return_value.__enter__.return_value.bind.side_effect = OSError(code, "nope")
+                self.assertFalse(sav.port_is_free("127.0.0.1", 3245), errno.errorcode[code])
 
 
 class _FakeChild:


### PR DESCRIPTION
## Problem

The launcher's `port_is_free` probed by CONNECTING to the port, and counted only `ConnectionRefusedError` as free. On Windows a connect to a closed port routinely fails some other way: Hyper-V/WSL port exclusions, loopback filtering, refusals arriving as timeouts. Every one of those fell into `except OSError: return False`, so every port read as occupied and the launcher refused to start with a false "already in use" error.

#335's Windows smoke test found this: four random ports that Python itself had just bound and released all failed the connect probe, including ports inside the range its `_free_port` helper pre-verified as bindable. The test-side workarounds in that PR ruled out every innocent explanation and left the launcher's probe as the cause.

## Fix

Probe by **binding**, the same operation the server is about to perform, so the probe cannot disagree with reality:

- `EADDRINUSE` (and `EACCES`, Windows's answer for its excluded port ranges) keeps the friendly "rerun with `--port <n>`" message.
- Any other error counts as **free**. The probe exists only for that message; a probe that cannot tell must never block a launch. The server's own bind stays authoritative and reports anything genuinely wrong.

`skills/cad-viewer/scripts/viewer` is a symlink to this file, so the skill copy is covered by the same edit.

## Tests

Four new probe-semantics tests in `viewer/server_py/tests/test_start_viewer.py`:
- a listening port reads as occupied
- a bindable port reads as free
- ambiguous `OSError`s (timeout, reset) read as free — the exact Windows failure shape
- `EADDRINUSE`/`EACCES` still block

Verified locally: 15/15 launcher tests pass, the live launch smoke (`scripts/test/test-viewer-launch.sh`) passes, and a genuinely occupied port still exits 1 with the friendly message.

Unblocks #335 (its Windows run fails only on this probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)