### PR TITLE
release: enforce build-test rehearsal pairing; drop dead version/docs targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Validate build-test rehearsal pairing
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          BUMP: ${{ inputs.bump }}
+          SET_VERSION: ${{ inputs.set_version }}
+        run: |
+          # AGENTS.md and CONTRIBUTING.md: target_branch=build-test exists to rehearse
+          # the CI/CD pipeline, so it must publish base_branch AS IT STANDS -- bump=none.
+          # Anything else burns a version number and opens a release PR for a rehearsal.
+          if [ "$TARGET_BRANCH" = "build-test" ] && [ "$BUMP" != "none" ]; then
+            echo "::error title=Invalid release dispatch::target_branch=build-test is a CI/CD rehearsal and must be paired with bump=none (got bump=$BUMP). Re-dispatch with bump=none."
+            exit 1
+          fi
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/scripts/release/sync-version.mjs
+++ b/scripts/release/sync-version.mjs
@@ -63,12 +63,6 @@ export const jsonTargets = [
     fields: [["version"], ["packages", "", "version"]],
     required: false,
   },
-  { path: "skills/cad/scripts/packages/implicitjs/package.json", fields: [["version"]], required: false },
-  {
-    path: "skills/cad/scripts/packages/implicitjs/package-lock.json",
-    fields: [["version"], ["packages", "", "version"]],
-    required: false,
-  },
 ];
 
 const tomlTargets = [

--- a/scripts/test/test-docs.sh
+++ b/scripts/test/test-docs.sh
@@ -7,9 +7,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/common.sh"
 cd "$REPO_ROOT"
 
 section "Documentation checks"
-if git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git lfs version >/dev/null 2>&1; then
-  if git lfs ls-files --name-only | grep -q '^docs/public/hero/'; then
-    git lfs pull --include="docs/public/hero/**" --exclude=""
-  fi
-fi
+# Hero GLBs are deliberately NOT LFS (.gitattributes marks docs/public/hero/** with
+# !filter), so there is nothing to `git lfs pull` for them -- the old conditional here
+# never matched anything.
 npm --prefix docs run check


### PR DESCRIPTION
## Summary

Three small release-tooling fixes.

### Release workflow accepts invalid build-test dispatches
`AGENTS.md`/`CONTRIBUTING.md` say `target_branch=build-test` is strictly a CI/CD rehearsal that must be paired with `bump=none`, but nothing enforced it: dispatching with the default `bump=patch` burned a version number and opened a release PR into `develop`. The `release-pr` job now validates the pairing in its first step - before anything mutates - and fails with an actionable `::error::`.

### Dead version-sync targets
`sync-version.mjs` carried `required:false` entries under `skills/cad/scripts/packages/implicitjs/` - a mirror that exists nowhere (the cad skill ships only `cadgen` and `cadjs`). Removed. The `implicit-cad` pair stays: that path resolves through the vendored-runtime layout.

### Dead hero-GLB LFS branch in test-docs.sh
`.gitattributes` marks `docs/public/hero/**` deliberately **non-LFS**, so the script's `git lfs ls-files | grep docs/public/hero` gate never matched and the pull never ran. Removed with a comment so it stays gone.

## Verification
- `sync-version.mjs --check`: metadata synced from VERSION
- `scripts/bundle/bundle.sh --check`: all outputs up to date
- `scripts/test/test-global.sh`: 86 tests OK
- release.yml parses; guard step confirmed first after checkout
- test-docs.sh reaches its `npm run check` tail (local eslint gap only; CI covers)
