### PR TITLE
moveit2_server: bound the warm MoveItPy instance cache

### DIFF
--- a/tests/python/viewer/moveit2_server/test_moveit_py_adapter.py
+++ b/tests/python/viewer/moveit2_server/test_moveit_py_adapter.py
@@ -169,3 +169,72 @@ class MoveItPyAdapterHelperTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class MoveItPyCacheTests(unittest.TestCase):
+    """The warm-instance cache is bounded LRU: heavyweight ROS nodes cannot be allowed
+    to accumulate one per model for the life of the server."""
+
+    def _adapter(self, limit: int) -> MoveItPyAdapter:
+        adapter = MoveItPyAdapter()
+        adapter.CACHE_LIMIT = limit
+        return adapter
+
+    class _FakeMoveIt:
+        instances: list["MoveItPyCacheTests._FakeMoveIt"] = []
+
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.shutdown_calls = 0
+
+        def shutdown(self) -> None:
+            self.shutdown_calls += 1
+
+    def tearDown(self) -> None:
+        MoveItPyCacheTests._FakeMoveIt.instances.clear()
+
+    def test_cache_sheds_the_least_recently_used_instance_beyond_the_limit(self) -> None:
+        adapter = self._adapter(2)
+        first = self._FakeMoveIt("a")
+        second = self._FakeMoveIt("b")
+        third = self._FakeMoveIt("c")
+
+        adapter._store_moveit("a", first)
+        adapter._store_moveit("b", second)
+        adapter._store_moveit("c", third)
+
+        self.assertIsNone(adapter._cached_moveit("a"), "oldest instance must be evicted")
+        self.assertEqual(first.shutdown_calls, 1, "an evicted ROS node must be shut down")
+        self.assertIs(adapter._cached_moveit("b"), second)
+        self.assertIs(adapter._cached_moveit("c"), third)
+
+    def test_a_cache_hit_refreshes_recency(self) -> None:
+        adapter = self._adapter(2)
+        first = self._FakeMoveIt("a")
+        second = self._FakeMoveIt("b")
+
+        adapter._store_moveit("a", first)
+        adapter._store_moveit("b", second)
+        # Touching "a" makes "b" the least recently used.
+        self.assertIs(adapter._cached_moveit("a"), first)
+        third = self._FakeMoveIt("c")
+        adapter._store_moveit("c", third)
+
+        self.assertIs(adapter._cached_moveit("a"), first)
+        self.assertIsNone(adapter._cached_moveit("b"))
+        self.assertEqual(second.shutdown_calls, 1)
+
+    def test_an_eviction_shutdown_failure_is_swallowed(self) -> None:
+        adapter = self._adapter(1)
+        broken = self._FakeMoveIt("broken")
+
+        def explode() -> None:
+            raise RuntimeError("node already gone")
+
+        broken.shutdown = explode  # type: ignore[method-assign]
+        adapter._store_moveit("broken", broken)
+        survivor = self._FakeMoveIt("survivor")
+        adapter._store_moveit("survivor", survivor)
+
+        self.assertIsNone(adapter._cached_moveit("broken"), "eviction must proceed past the failure")
+        self.assertIs(adapter._cached_moveit("survivor"), survivor)

--- a/viewer/moveit2_server/moveit2_server/moveit_py.py
+++ b/viewer/moveit2_server/moveit2_server/moveit_py.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import math
+import os
+from collections import OrderedDict
 from pathlib import Path
 import subprocess
 import sys
@@ -289,8 +292,14 @@ class _JointStateSeeder:
 class MoveItPyAdapter:
     """MoveIt 2 adapter used by the local ROS 2 MoveIt2 server."""
 
+    # Warm MoveItPy instances are heavyweight (a ROS node plus planning context per
+    # model), so the cache is bounded: at most this many distinct models stay warm,
+    # least-recently-used first out. Each model still pays its own first-touch cost;
+    # the bound just stops an unbounded crawl across many robots.
+    CACHE_LIMIT = max(1, int(os.environ.get("MOVEIT_PY_ADAPTER_CACHE", "5")))
+
     def __init__(self) -> None:
-        self._moveit_by_key: dict[str, Any] = {}
+        self._moveit_by_key: OrderedDict[str, Any] = OrderedDict()
 
     def _config_dict(self, request: Any) -> dict[str, Any]:
         urdf_path = Path(str(request.context.get("urdfPath") or ""))
@@ -341,8 +350,9 @@ class MoveItPyAdapter:
             ) from exc
 
         cache_key = str(request.context.get("modelAssetHash") or request.context.get("urdfPath") or "")
-        if cache_key in self._moveit_by_key:
-            return self._moveit_by_key[cache_key]
+        cached = self._cached_moveit(cache_key)
+        if cached is not None:
+            return cached
 
         if not rclpy.ok():
             rclpy.init(args=None)
@@ -362,8 +372,28 @@ class MoveItPyAdapter:
                 moveit = MoveItPy(node_name=f"moveit2_server_{node_hash}")
         finally:
             joint_state_seeder.stop()
-        self._moveit_by_key[cache_key] = moveit
+        self._store_moveit(cache_key, moveit)
         return moveit
+
+    def _cached_moveit(self, cache_key: str) -> Any | None:
+        """The warm instance for ``cache_key``, refreshing its recency, or None."""
+        moveit = self._moveit_by_key.get(cache_key)
+        if moveit is not None:
+            self._moveit_by_key.move_to_end(cache_key)
+        return moveit
+
+    def _store_moveit(self, cache_key: str, moveit: Any) -> None:
+        """Insert a built instance and shed the least-recently-used ones beyond the
+        bound. Eviction shuts each instance down best-effort -- it is a ROS node with
+        native state, so letting it be garbage-collected silently would leak the node."""
+        self._moveit_by_key[cache_key] = moveit
+        self._moveit_by_key.move_to_end(cache_key)
+        while len(self._moveit_by_key) > self.CACHE_LIMIT:
+            _, evicted = self._moveit_by_key.popitem(last=False)
+            shutdown = getattr(evicted, "shutdown", None)
+            if callable(shutdown):
+                with contextlib.suppress(Exception):
+                    shutdown()
 
     def _planning_component(self, request: Any, planning_group: str) -> Any:
         return self._moveit(request).get_planning_component(planning_group)


### PR DESCRIPTION
## Summary

`MoveItPyAdapter` kept one warm `MoveItPy` instance per model **forever** - keyed by model asset hash, never evicted. Each instance is a ROS node plus a planning context, so serving many distinct robots crawled memory for the life of the server.

The cache is now bounded LRU:

- default limit **5** warm instances, tunable via `MOVEIT_PY_ADAPTER_CACHE` (floored at 1)
- a cache hit refreshes recency; the least-recently-used instance is shed when the bound is exceeded
- eviction calls the instance's `shutdown()` best-effort rather than letting the native ROS node be silently collected; a shutdown failure is swallowed so eviction always proceeds
- each model still pays its own first-touch cost - only the cross-model crawl is bounded

## Verification

- New `MoveItPyCacheTests`: LRU shedding order, recency refresh on hit, shutdown-failure tolerance (all without rclpy, matching the suite's existing style)
- Full MoveIt2 server suite: 20 tests OK; `scripts/test/test-python.sh` all suites green
