### PR TITLE
Improve CAD Viewer runtime diagnostics and DXF framing

### DIFF
--- a/packages/cadjs/src/lib/dxf/buildDrawingLines.js
+++ b/packages/cadjs/src/lib/dxf/buildDrawingLines.js
@@ -134,6 +134,19 @@ export function drawingHasRenderableGeometry(dxfData) {
   return buildDxfDrawingLineGroups(dxfData).layers.length > 0;
 }
 
+/** Return only the line groups that are currently visible in the drawing viewport. */
+export function visibleDrawingLineGroups(groups, hiddenLayerNames = []) {
+  const hidden = new Set(
+    Array.isArray(hiddenLayerNames)
+      ? hiddenLayerNames.map((name) => normalizeLayerName(name))
+      : []
+  );
+  return {
+    layers: (Array.isArray(groups?.layers) ? groups.layers : [])
+      .filter((layer) => !hidden.has(normalizeLayerName(layer?.name)))
+  };
+}
+
 /** The drawing's extent in the sheet plane, for fitting a camera to a document that has no mesh. */
 export function drawingLineBounds(groups) {
   const min = [Infinity, Infinity, Infinity];

--- a/packages/cadjs/src/lib/dxf/buildDrawingLines.test.js
+++ b/packages/cadjs/src/lib/dxf/buildDrawingLines.test.js
@@ -4,7 +4,8 @@ import { test } from "node:test";
 import {
   buildDxfDrawingLineGroups,
   drawingHasRenderableGeometry,
-  drawingLineBounds
+  drawingLineBounds,
+  visibleDrawingLineGroups
 } from "./buildDrawingLines.js";
 
 const DRAWING = {
@@ -110,6 +111,21 @@ test("bounds cover the drawing, for fitting a camera with no mesh to measure", (
   assert.equal(bounds.min[2], -25);
   assert.equal(bounds.max[2], 425);
   assert.equal(drawingLineBounds({ layers: [] }), null);
+});
+
+test("visible drawing bounds exclude hidden and distant layers", () => {
+  const groups = buildDxfDrawingLineGroups({
+    geometry: {
+      lines: [
+        { layer: "VISIBLE", start: [0, 0], end: [10, 0] },
+        { layer: "HIDDEN_FAR", start: [10000, 10000], end: [20000, 20000] }
+      ]
+    }
+  });
+  const visible = visibleDrawingLineGroups(groups, ["HIDDEN_FAR"]);
+  assert.deepEqual(visible.layers.map((layer) => layer.name), ["VISIBLE"]);
+  assert.equal(drawingLineBounds(visible).max[0], 10);
+  assert.equal(visibleDrawingLineGroups(groups, ["VISIBLE", "HIDDEN_FAR"]).layers.length, 0);
 });
 
 function arcXRange(arc) {

--- a/viewer/scripts/cad-python.mjs
+++ b/viewer/scripts/cad-python.mjs
@@ -13,6 +13,16 @@ function firstExistingFile(paths) {
   return paths.find((candidate) => fs.existsSync(candidate)) || "";
 }
 
+function virtualEnvironmentPython(root) {
+  if (!root) {
+    return [];
+  }
+  return [
+    path.join(root, ".venv", "Scripts", "python.exe"),
+    path.join(root, ".venv", "bin", "python"),
+  ];
+}
+
 function firstExistingDirectory(paths) {
   return paths.find((candidate) => {
     try {
@@ -59,10 +69,13 @@ export function cadPythonExecutable(repoRoot) {
     return configured;
   }
   const resolvedRepoRoot = path.resolve(repoRoot || "");
+  const launchRoot = String(process.env.INIT_CWD || "").trim();
   return firstExistingFile([
-    path.join(resolvedRepoRoot, ".venv", "bin", "python"),
-    path.join(process.cwd(), ".venv", "bin", "python"),
-    path.join(PACKAGE_ROOT, ".venv", "bin", "python"),
+    ...virtualEnvironmentPython(launchRoot),
+    ...virtualEnvironmentPython(resolvedRepoRoot),
+    ...virtualEnvironmentPython(process.cwd()),
+    ...virtualEnvironmentPython(PACKAGE_ROOT),
+    findUpFile(path.join(".venv", "Scripts", "python.exe")),
     findUpFile(path.join(".venv", "bin", "python")),
   ]) || "python3";
 }

--- a/viewer/scripts/cad-python.test.mjs
+++ b/viewer/scripts/cad-python.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { cadPythonExecutable } from "./cad-python.mjs";
+
+test("launch-root Windows virtualenv wins over the packaged fallback", (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "cad-viewer-python-"));
+  const python = path.join(root, ".venv", "Scripts", "python.exe");
+  fs.mkdirSync(path.dirname(python), { recursive: true });
+  fs.writeFileSync(python, "");
+
+  const previousInitCwd = process.env.INIT_CWD;
+  const previousViewerPython = process.env.VIEWER_CAD_PYTHON;
+  const previousCadPython = process.env.CAD_PYTHON;
+  context.after(() => {
+    if (previousInitCwd === undefined) delete process.env.INIT_CWD;
+    else process.env.INIT_CWD = previousInitCwd;
+    if (previousViewerPython === undefined) delete process.env.VIEWER_CAD_PYTHON;
+    else process.env.VIEWER_CAD_PYTHON = previousViewerPython;
+    if (previousCadPython === undefined) delete process.env.CAD_PYTHON;
+    else process.env.CAD_PYTHON = previousCadPython;
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  process.env.INIT_CWD = root;
+  delete process.env.VIEWER_CAD_PYTHON;
+  delete process.env.CAD_PYTHON;
+  assert.equal(cadPythonExecutable(path.join(root, "packaged-runtime")), python);
+});

--- a/viewer/scripts/start-viewer.mjs
+++ b/viewer/scripts/start-viewer.mjs
@@ -14,6 +14,10 @@ const viewerRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".
 const repoRoot = path.resolve(viewerRoot, "..");
 const python = cadPythonExecutable(repoRoot);
 const baseEnv = cadPythonEnv(repoRoot);
+// The Python backend launches Node builders later. Pin those children to the exact
+// runtime that successfully launched this viewer instead of resolving a potentially
+// different `node` from PATH.
+baseEnv.VIEWER_CAD_NODE ||= process.execPath;
 // server_py lives under viewer/ — prepend it so `python -m server_py.*` resolves.
 baseEnv.PYTHONPATH = [viewerRoot, baseEnv.PYTHONPATH].filter(Boolean).join(path.delimiter);
 

--- a/viewer/server_py/backend.py
+++ b/viewer/server_py/backend.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
+import sys
 from urllib.parse import urlsplit, parse_qs, unquote
 
 from . import artifact as artifact_mod
@@ -473,6 +475,17 @@ class LocalAssetBackend:
             # reports the peer's run so the client attaches to its progress.
             return {"ok": True, "contended": True, "error": "", "result": result}
         error = "" if result.get("ok") else str(result.get("error") or error_label)
+        if error:
+            node = next(
+                (
+                    str(os.environ.get(name) or "").strip()
+                    for name in ("CADGEN_NODE", "VIEWER_CAD_NODE", "CAD_NODE")
+                    if str(os.environ.get(name) or "").strip()
+                ),
+                "",
+            ) or shutil.which("node") or "unresolved"
+            mode = str(result.get("_viewerBackendMode") or "unknown")
+            error = f"{error}\nViewer runtime: Python={sys.executable}; Node={node}; backend={mode}"
         return {"ok": bool(result.get("ok")), "error": error, "result": result}
 
     def resolve_artifact(self, file_ref, force, resolved_root, catalog):

--- a/viewer/server_py/cadgen_bridge.py
+++ b/viewer/server_py/cadgen_bridge.py
@@ -133,10 +133,16 @@ def run_cadgen(module: str, args, repo_root: str, timeout: float | None = None) 
     try:
         from . import worker_client
 
-        return worker_client.run_cadgen(module, args, repo_root, timeout=timeout)
+        return {
+            **worker_client.run_cadgen(module, args, repo_root, timeout=timeout),
+            "_viewerBackendMode": "warm-worker",
+        }
     except worker_client._WorkerError:
         pass  # worker disabled or faulted -> cold subprocess below
-    return run_cadgen_cold(module, args, repo_root, timeout=timeout)
+    return {
+        **run_cadgen_cold(module, args, repo_root, timeout=timeout),
+        "_viewerBackendMode": "cold-subprocess",
+    }
 
 
 def run_cadgen_cold(module: str, args, repo_root: str, timeout: float | None = None) -> dict:

--- a/viewer/server_py/tests/test_artifact_runtime_diagnostics.py
+++ b/viewer/server_py/tests/test_artifact_runtime_diagnostics.py
@@ -1,0 +1,51 @@
+"""Artifact build failures preserve the runtime provenance needed to compare CLI and Viewer runs."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from server_py import backend, cadgen_bridge, worker_client  # noqa: E402
+
+
+class ArtifactRuntimeDiagnosticTests(unittest.TestCase):
+    def test_bridge_labels_warm_worker_results(self):
+        with mock.patch.object(worker_client, "run_cadgen", return_value={"ok": True}):
+            result = cadgen_bridge.run_cadgen("cadgen.dxf_artifact", [], os.getcwd())
+        self.assertEqual(result["_viewerBackendMode"], "warm-worker")
+
+    def test_bridge_labels_cold_fallback_results(self):
+        with mock.patch.object(worker_client, "run_cadgen", side_effect=worker_client._WorkerError("offline")), \
+                mock.patch.object(cadgen_bridge, "run_cadgen_cold", return_value={"ok": False, "error": "failed"}):
+            result = cadgen_bridge.run_cadgen("cadgen.dxf_artifact", [], os.getcwd())
+        self.assertEqual(result["_viewerBackendMode"], "cold-subprocess")
+
+    def test_failure_names_python_node_and_backend_mode(self):
+        result = {
+            "ok": False,
+            "error": "Node builder failed with exit code 1: dxf-artifact.mjs",
+            "_viewerBackendMode": "warm-worker",
+        }
+        with mock.patch.object(backend.cadgen_bridge, "run_cadgen", return_value=result), \
+                mock.patch.dict(os.environ, {"VIEWER_CAD_NODE": r"C:\\node\\node.exe"}, clear=False):
+            built = backend.LocalAssetBackend()._run_artifact_build(
+                "cadgen.dxf_artifact",
+                ["--source-path", "drawing.dxf.py"],
+                os.getcwd(),
+                force=False,
+                error_label="DXF render artifact build failed",
+            )
+
+        self.assertFalse(built["ok"])
+        self.assertIn(f"Python={sys.executable}", built["error"])
+        self.assertIn(r"Node=C:\\node\\node.exe", built["error"])
+        self.assertIn("backend=warm-worker", built["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/src/client/components/CadViewer.js
+++ b/viewer/src/client/components/CadViewer.js
@@ -13,7 +13,11 @@ import {
   transformDxfPreviewPositions
 } from "cadjs/lib/dxf/foldPreview";
 import { buildDxfPreviewMeshData, extractDxfScorePolylines } from "cadjs/lib/dxf/buildPreviewMesh";
-import { buildDxfDrawingLineGroups, drawingLineBounds } from "cadjs/lib/dxf/buildDrawingLines";
+import {
+  buildDxfDrawingLineGroups,
+  drawingLineBounds,
+  visibleDrawingLineGroups
+} from "cadjs/lib/dxf/buildDrawingLines";
 import { STEP_TREE_TOPOLOGY_NODE_PREFIX } from "cadjs/lib/step/stepTree";
 import { copyImageBlobToClipboard } from "@/ui/clipboard";
 import { triggerBlobDownload } from "@/ui/download";
@@ -1883,6 +1887,7 @@ const CadViewer = forwardRef(function CadViewer({
   const [transformedDisplayEdgeRuntime, setTransformedDisplayEdgeRuntime] = useState(null);
   const [defaultPerspectiveDetached, setDefaultPerspectiveDetached] = useState(false);
   const [error, setError] = useState("");
+  const [drawingVisibilityMessage, setDrawingVisibilityMessage] = useState("");
   const [viewerReadyTick, setViewerReadyTick] = useState(0);
   const [runtimeResetToken, setRuntimeResetToken] = useState(0);
   const [activeViewPlaneFace, setActiveViewPlaneFace] = useState("");
@@ -2878,10 +2883,10 @@ const CadViewer = forwardRef(function CadViewer({
     };
     if (!group || !drawingIsDocument || !drawingGeometry?.geometry) {
       dispose();
+      setDrawingVisibilityMessage("");
       return undefined;
     }
     dispose();
-    const hiddenLayers = new Set(Array.isArray(drawingHiddenLayers) ? drawingHiddenLayers : []);
     // ACI 7 is the DXF "default ink" colour: it means "whatever reads against the background",
     // which is why the package resolves it to a near-white grey suited to a dark sheet. Taking
     // that literally paints a drawing invisible on a light theme, so only a layer that names a
@@ -2892,16 +2897,22 @@ const CadViewer = forwardRef(function CadViewer({
       (Array.isArray(drawingGeometry.layers) ? drawingGeometry.layers : [])
         .map((layer) => [layer?.name, Number(layer?.colorAci) === 7 ? null : layer?.colorHex])
     );
-    const { layers } = buildDxfDrawingLineGroups(drawingGeometry);
+    const groups = buildDxfDrawingLineGroups(drawingGeometry);
+    const { layers } = visibleDrawingLineGroups(groups, drawingHiddenLayers);
     if (!layers.length) {
+      if (runtime) {
+        runtime.hasVisibleModel = false;
+      }
+      setDrawingVisibilityMessage(
+        groups.layers.length ? "All drawing layers are hidden." : "Drawing has no renderable geometry."
+      );
+      runtime?.requestRender?.();
       return undefined;
     }
+    setDrawingVisibilityMessage("");
     const container = new THREE.Group();
     container.userData.dxfDrawingLines = true;
     for (const layer of layers) {
-      if (hiddenLayers.has(layer.name)) {
-        continue;
-      }
       // Mesher space is y-up; the scene is CAD Z-up. Same (x, y, z) -> (x, z, -y) map the
       // curved fold preview uses, so a drawing and a flat pattern share one orientation,
       // one camera fit and one set of view controls.
@@ -5561,6 +5572,11 @@ const CadViewer = forwardRef(function CadViewer({
       {error ? (
         <p className="cad-glass-popover pointer-events-none absolute left-4 top-24 z-20 rounded-[10px] border border-[var(--ui-error-bg)] px-4 py-3 text-sm text-[var(--ui-error-text)] shadow-[var(--ui-shadow-soft)] sm:top-20">
           {error}
+        </p>
+      ) : null}
+      {drawingVisibilityMessage ? (
+        <p className="cad-glass-popover pointer-events-none absolute left-4 top-24 z-20 rounded-[10px] border border-sidebar-border px-4 py-3 text-sm text-sidebar-foreground shadow-[var(--ui-shadow-soft)] sm:top-20">
+          {drawingVisibilityMessage}
         </p>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- prefer the launching project's virtualenv and pin the Viewer Node runtime
- include Python, Node, and backend-mode context in artifact failures
- frame DXF drawings from visible layers and explain an all-hidden drawing

## Validation
- npm --prefix packages/cadjs test
- npm --prefix viewer test
- npm --prefix viewer run build
- focused Python runtime diagnostic and worker-timeout tests