### PR TITLE
Add concrete base CAD model for seismograph mount

### DIFF
--- a/models/concrete_base.scad
+++ b/models/concrete_base.scad
@@ -1,0 +1,36 @@
+// Concrete base for seismograph
+// 300 x 300 x 300 mm block with 4 corner through-holes
+
+// Parameters (edit as needed)
+base_x = 300; // mm
+base_y = 300; // mm
+base_z = 300; // mm
+
+hole_d = 8;       // hole diameter in mm (default 8 mm)
+hole_offset = 20; // distance from each outer edge to hole center (mm)
+hole_h = base_z + 10; // hole height to ensure full through-hole
+
+$fn = 64; // cylinder resolution
+
+module concrete_base() {
+    difference() {
+        // Centered cube
+        cube([base_x, base_y, base_z], center=true);
+
+        // Four corner holes (through along Z)
+        x_off = (base_x/2) - hole_offset;
+        y_off = (base_y/2) - hole_offset;
+
+        translate([ x_off,  y_off, 0])    cylinder(h=hole_h, r=hole_d/2, center=true);
+        translate([-x_off,  y_off, 0])    cylinder(h=hole_h, r=hole_d/2, center=true);
+        translate([ x_off, -y_off, 0])    cylinder(h=hole_h, r=hole_d/2, center=true);
+        translate([-x_off, -y_off,0])    cylinder(h=hole_h, r=hole_d/2, center=true);
+    }
+}
+
+// Render the base
+concrete_base();
+
+// Notes:
+// - Hole diameter and offset can be changed above.
+// - To export STL: in OpenSCAD: Design -> Compile, then File -> Export -> Export as STL.

--- a/models/concrete_base.stl
+++ b/models/concrete_base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d440ef7dbf3c30b95d48f255ce844f22ebbddb1823277d179239c66c203c27a
+size 185070


### PR DESCRIPTION
## Summary

Added a parametric OpenSCAD design and exported STL for a concrete mounting base for seismograph devices.

## Changes

- **models/concrete_base.scad**: OpenSCAD source model
  - 300×300×300 mm concrete block (cube)
  - 4 corner through-holes (8 mm diameter, positioned 20 mm from edges)
  - Fully parametric: hole diameter, offset, and block dimensions can be edited
  - $fn=64 for smooth cylinder render

- **models/concrete_base.stl**: Exported STL mesh ready for manufacturing or 3D visualization

## Design Details

The base is centered at origin with corner mounting holes suitable for bolting down a seismograph instrument. All dimensions are in millimeters. The holes pass completely through the block (height set to 310 mm to ensure through-drilling).

Parameters can be easily adjusted in the SCAD file if different hole sizes, positions, or block dimensions are needed.