### PR TITLE
feat: add robot component selection and references

### DIFF
--- a/apps/viewer/README.md
+++ b/apps/viewer/README.md
@@ -121,3 +121,28 @@ The backend's suite lives with cadgen and is not collected here; running only
 
 Headless UI verification uses Playwright with `--use-angle=metal` —
 the default software WebGL renderer is not what users see.
+
+## Robot components
+
+URDF, SRDF, and SDF files with named objects in their linked meshes expose a
+Components tab. Its single-line rows are grouped by link. Selecting a row
+highlights that mesh object in the viewport; picking it in the viewport selects
+and reveals its row. Ctrl/Cmd/Shift-click toggles additional components. Objects
+retain their visual transforms as joints move. Unnamed objects remain rendered
+but are omitted from the inventory; files without named objects have neither
+Components nor the component Reference tab.
+
+Reference shows the selected objects' link, visual, mesh, and object identifiers,
+with a copy button for each. Robot references are prompt locators of the form
+`models/robot.urdf#link=arm&visual=arm%3Av1&object=3mf%3A0&index=0&name=bracket`.
+The prefix identifies the robot file; path segments and fragment values are percent-encoded.
+`visual` is the parsed visual ID (`<link>:v<one-based visual ordinal>` for URDF);
+`object` is the mesh loader's object ID and `index` its zero-based position in the
+loaded mesh's parts list. `name` preserves the authored object name. Resolve the
+link and visual in the robot description to find the mesh file, then identify
+that mesh object using its name and index. Repeated mesh instances have distinct
+references because they belong to different visuals. SRDF locators name the SRDF
+file and resolve visuals through its paired URDF. SDF uses its parsed visual IDs.
+These locators describe mesh objects for prompts; they are not STEP face selectors
+and are not accepted by the STEP selector CLI. They remain stable across pose
+changes, but reordering visuals or re-exporting a mesh can change the identifiers.

--- a/apps/viewer/src/client/components/CadWorkspace.js
+++ b/apps/viewer/src/client/components/CadWorkspace.js
@@ -1,5 +1,8 @@
 "use client";
 
+import { buildRobotComponentGeometry, robotComponents } from "@/workbench/robotComponents";
+import { useRobotComponentSelection } from "@/workbench/useRobotComponentSelection";
+
 import * as THREE from "three";
 import { startTransition, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeftRight, ArrowRight, Circle, Eraser, Minus, PaintBucket, PenTool, Square } from "lucide-react";
@@ -1760,7 +1763,7 @@ export default function CadWorkspace({
     }
     try {
       return {
-        meshData: buildUrdfMeshGeometry(selectedUrdfData, selectedUrdfMeshes, { lightweight: true }),
+        meshData: buildRobotComponentGeometry(buildUrdfMeshGeometry(selectedUrdfData, selectedUrdfMeshes, { lightweight: true })),
         error: ""
       };
     } catch (error) {
@@ -1770,6 +1773,14 @@ export default function CadWorkspace({
       };
     }
   }, [selectedUrdfData, selectedUrdfMeshes]);
+  const selectedUrdfComponents = useMemo(
+    () => robotComponents(selectedUrdfMeshGeometryResult.meshData, selectedUrdfFileRef),
+    [selectedUrdfMeshGeometryResult.meshData, selectedUrdfFileRef]
+  );
+  const robotSelection = useRobotComponentSelection(
+    selectedUrdfComponents, selectedUrdfMeshGeometryResult.meshData, selectedUrdfFileRef
+  );
+  const robotComponentsActive = selectedEntryContentKind === VIEWPORT_CONTENT.ROBOT && selectedUrdfComponents.length > 0;
   const movableUrdfJoints = useMemo(
     () => (
       Array.isArray(selectedUrdfData?.joints)
@@ -3144,6 +3155,7 @@ export default function CadWorkspace({
     hasDxfBendsPanel: selectedFileSheetKind === "dxf" && drawingBends.length > 0,
     hasDxfLayersPanel: selectedFileSheetKind === "dxf" && drawingLayers.length > 1,
     isSdf: selectedFileSheetKind === "sdf",
+    hasRobotComponents: selectedUrdfComponents.length > 0,
     showJoints: selectedFileSheetKind === "urdf" || selectedFileSheetKind === "srdf" || selectedFileSheetKind === "sdf"
   }), [
     selectedAnimationClipList,
@@ -3155,6 +3167,7 @@ export default function CadWorkspace({
     selectedStepModuleError,
     selectedStepModuleStatus,
     selectedStepModuleUrl,
+    selectedUrdfComponents,
     drawingBends,
     drawingLayers
   ]);
@@ -3251,6 +3264,18 @@ export default function CadWorkspace({
     selectedFileStatusLevel,
     selectedKey
   ]);
+
+  const selectRobotComponent = useCallback((id, options) => {
+    robotSelection.select(id, options);
+    if (selectedUrdfComponents.some((component) => component.id === id)) {
+      if (isDesktop) setTabToolsOpen(true);
+      const revealIds = [FILE_SHEET_SECTION_IDS.STEP_REFERENCE, FILE_SHEET_SECTION_IDS.ROBOT_COMPONENTS];
+      setFileSheetOpenSectionIds((current) => [
+        ...(current || []).filter((sectionId) => !revealIds.includes(sectionId)),
+        ...revealIds
+      ]);
+    }
+  }, [robotSelection.select, selectedUrdfComponents, isDesktop]);
 
   const buildActiveTabSnapshot = useCallback(() => {
     return cloneTabSnapshot({
@@ -7058,12 +7083,13 @@ export default function CadWorkspace({
           referenceSelectionUnavailable={referenceSelectionUnavailable}
           referenceSelectionDeferred={selectedTopologyDeferredByCost}
           viewPlaneOffsetRight={viewportFrameInsets.right + 16}
-          viewerMode={viewerMode}
-          assemblyPickingActive={viewerInAssemblyMode}
-          assemblyParts={viewerAssemblyRenderParts}
+          viewerMode={robotComponentsActive ? "assembly" : viewerMode}
+          robotComponentPicking={robotComponentsActive}
+          assemblyPickingActive={robotComponentsActive || viewerInAssemblyMode}
+          assemblyParts={robotComponentsActive ? (selectedUrdfPreview.meshData?.parts || EMPTY_LIST) : viewerAssemblyRenderParts}
           hiddenPartIds={viewerHiddenPartIds}
-          selectedPartIds={viewerSelectedPartIds}
-          hoveredPartId={viewerHoveredPartIds}
+          selectedPartIds={robotComponentsActive ? robotSelection.selectedIds : viewerSelectedPartIds}
+          hoveredPartId={robotComponentsActive ? robotSelection.hoveredId : viewerHoveredPartIds}
           hoveredReferenceId={effectiveHoveredReferenceId}
           selectedReferenceIds={selectedReferenceIds}
           selectorRuntime={effectiveSelectorRuntime}
@@ -7079,10 +7105,10 @@ export default function CadWorkspace({
           drawingStrokes={drawingStrokes}
           handleDrawingStrokesChange={handleDrawingStrokesChange}
           handlePerspectiveChange={handlePerspectiveChange}
-          handleModelHoverChange={handleModelHoverChange}
-          handleModelReferenceActivate={handleModelReferenceActivate}
-          handleModelReferenceDoubleActivate={handleModelReferenceDoubleActivate}
-          handleModelReferenceContext={handleModelReferenceContext}
+          handleModelHoverChange={robotComponentsActive ? robotSelection.hover : handleModelHoverChange}
+          handleModelReferenceActivate={robotComponentsActive ? selectRobotComponent : handleModelReferenceActivate}
+          handleModelReferenceDoubleActivate={robotComponentsActive ? undefined : handleModelReferenceDoubleActivate}
+          handleModelReferenceContext={robotComponentsActive ? undefined : handleModelReferenceContext}
           onMeasurePick={handleMeasurePick}
           onMeasureHoverPoint={handleMeasureHoverPoint}
           activeMeasurementId={activeMeasureId}
@@ -7333,6 +7359,8 @@ export default function CadWorkspace({
                 onOpenChange={setTabToolsOpen}
                 onStartResize={handleStartFileSheetResize}
                 joints={movableUrdfJoints}
+                components={selectedUrdfComponents}
+                componentSelection={{ ...robotSelection, select: selectRobotComponent }}
                 groupStates={selectedUrdfGroupStates}
                 activeGroupStateId={activeSelectedUrdfGroupStateId}
                 jointValues={selectedUrdfJointValues}

--- a/apps/viewer/src/client/components/workbench/CadRenderPane.js
+++ b/apps/viewer/src/client/components/workbench/CadRenderPane.js
@@ -17,6 +17,7 @@ import { RENDER_FORMAT } from "@/workbench/constants";
 import { TUTORIAL_TIP_IDS } from "@/workbench/persistence";
 import {
   PARAMETER_SOURCE,
+  VIEWPORT_CONTENT,
   renderCapabilities,
   supportsTool
 } from "cadgen-js/lib/renderCapabilities";
@@ -290,6 +291,7 @@ export default function CadRenderPane({
   viewPlaneOffsetRight = 16,
   viewerMode,
   assemblyPickingActive = false,
+  robotComponentPicking = false,
   assemblyParts,
   hiddenPartIds,
   selectedPartIds,
@@ -363,7 +365,7 @@ export default function CadRenderPane({
   const drawEnabled = supportsTool(renderFormat, "draw");
   // Formats with no per-part topology to select, annotate or explode: a plain mesh has
   // no parts, so it gets the stripped-down prop set.
-  const hasParts = capabilities.parts;
+  const hasParts = capabilities.parts || (capabilities.content === VIEWPORT_CONTENT.ROBOT && robotComponentPicking);
   const hasTopology = capabilities.topology;
   const displaySettingsActive = capabilities.displayModes && !!displaySettings;
   // Projection is a THEME trait, honoured by every format that declares it — not a

--- a/apps/viewer/src/client/components/workbench/RobotComponentReferenceSection.js
+++ b/apps/viewer/src/client/components/workbench/RobotComponentReferenceSection.js
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { Copy } from "lucide-react";
+import { copyTextToClipboard } from "@/ui/clipboard";
+import { Button } from "../ui/button";
+import { FileSheetButtonRow, FileSheetStatusText, FileSheetSubsection, FileSheetValueField } from "./FileSheet";
+
+function ComponentReference({ component }) {
+  const [status, setStatus] = useState("");
+  const copy = async () => {
+    try {
+      await copyTextToClipboard(component.reference);
+      setStatus("Reference copied.");
+    } catch {
+      setStatus("Could not copy the reference. Select and copy the text below.");
+    }
+  };
+  return (
+    <FileSheetSubsection title={component.name}>
+      <FileSheetValueField label="Link" value={component.linkName} />
+      <FileSheetValueField label="Visual" value={component.visualId} />
+      <FileSheetValueField label="Mesh" value={component.mesh} />
+      <FileSheetValueField label="Object" value={component.meshObjectId} />
+      <FileSheetButtonRow>
+        <Button type="button" variant="outline" className="h-7" onClick={copy}>
+          <Copy className="size-3.5" aria-hidden="true" /> Copy reference
+        </Button>
+      </FileSheetButtonRow>
+      <FileSheetStatusText className="break-all select-text">{component.reference}</FileSheetStatusText>
+      {status ? <div role="status"><FileSheetStatusText>{status}</FileSheetStatusText></div> : null}
+    </FileSheetSubsection>
+  );
+}
+
+export default function RobotComponentReferenceSection({ components, selectedIds }) {
+  const selected = components.filter((component) => selectedIds.includes(component.id));
+  if (!selected.length) return <FileSheetStatusText>Select a component in the list or viewport to inspect its reference.</FileSheetStatusText>;
+  return selected.map((component) => <ComponentReference key={component.reference} component={component} />);
+}

--- a/apps/viewer/src/client/components/workbench/RobotComponentsSection.js
+++ b/apps/viewer/src/client/components/workbench/RobotComponentsSection.js
@@ -1,0 +1,41 @@
+import { useEffect, useMemo, useRef } from "react";
+import { Box } from "lucide-react";
+import { cn } from "@/ui/utils";
+import { Button } from "../ui/button";
+import { FileSheetSubsection } from "./FileSheet";
+
+function ComponentRow({ component, selected, onSelect, onHover }) {
+  const rowRef = useRef(null);
+  useEffect(() => {
+    if (selected) rowRef.current?.scrollIntoView({ block: "nearest" });
+  }, [selected]);
+  return (
+    <Button
+      ref={rowRef}
+      type="button"
+      variant="ghost"
+      aria-pressed={selected}
+      title={component.name}
+      className={cn("h-7 w-full justify-start gap-2 rounded-none px-2 text-xs font-normal", selected && "bg-accent text-accent-foreground")}
+      onClick={(event) => onSelect(component.id, { multiSelect: event.ctrlKey || event.metaKey || event.shiftKey })}
+      onMouseEnter={() => onHover(component.id)}
+      onMouseLeave={() => onHover("")}
+      onFocus={() => onHover(component.id)}
+      onBlur={() => onHover("")}
+    >
+      <Box className="size-3.5 shrink-0" aria-hidden="true" />
+      <span className="truncate">{component.name}</span>
+    </Button>
+  );
+}
+
+export default function RobotComponentsSection({ components, selectedIds, onSelect, onHover }) {
+  const groups = useMemo(() => Object.groupBy(components, (component) => component.linkName), [components]);
+  return Object.entries(groups).map(([linkName, entries]) => (
+    <FileSheetSubsection key={linkName} title={linkName} contentClassName="space-y-0">
+      {entries.map((component) => (
+        <ComponentRow key={component.id} component={component} selected={selectedIds.includes(component.id)} onSelect={onSelect} onHover={onHover} />
+      ))}
+    </FileSheetSubsection>
+  ));
+}

--- a/apps/viewer/src/client/components/workbench/UrdfFileSheet.js
+++ b/apps/viewer/src/client/components/workbench/UrdfFileSheet.js
@@ -29,6 +29,8 @@ import FileSheet, {
 } from "./FileSheet";
 import FileSheetTabbedSurface from "./FileSheetTabbedSurface";
 import { buildFileStatusTab } from "./FileStatusSection";
+import RobotComponentsSection from "./RobotComponentsSection";
+import RobotComponentReferenceSection from "./RobotComponentReferenceSection";
 
 const compactNumericInputClasses = FILE_SHEET_COMPACT_NUMERIC_INPUT_CLASSES;
 const compactButtonClasses = FILE_SHEET_COMPACT_BUTTON_CLASSES;
@@ -259,6 +261,8 @@ export default function UrdfFileSheet({
   onOpenChange,
   onStartResize,
   joints,
+  components = [],
+  componentSelection,
   groupStates,
   activeGroupStateId,
   jointValues,
@@ -348,6 +352,24 @@ export default function UrdfFileSheet({
                 ) : null}
               </div>
       )
+    } : null,
+    components.length ? {
+      id: "components",
+      title: "Components",
+      titleAttr: "Named exported mesh components",
+      content: (
+        <RobotComponentsSection
+          components={components}
+          selectedIds={componentSelection.selectedIds}
+          onSelect={componentSelection.select}
+          onHover={componentSelection.hover}
+        />
+      )
+    } : null,
+    components.length ? {
+      id: "reference",
+      title: "Reference",
+      content: <RobotComponentReferenceSection components={components} selectedIds={componentSelection.selectedIds} />
     } : null,
     showJoints ? {
       id: "joints",

--- a/apps/viewer/src/client/workbench/fileSheetSections.js
+++ b/apps/viewer/src/client/workbench/fileSheetSections.js
@@ -11,6 +11,7 @@ export const FILE_SHEET_SECTION_IDS = Object.freeze({
   STEP_ANIMATION: "animation",
   ROBOT_SDF: "sdf",
   ROBOT_MOTION: "motion",
+  ROBOT_COMPONENTS: "components",
   ROBOT_JOINTS: "joints",
   DXF_MATERIAL: "material",
   DXF_BENDS: "bends",
@@ -34,6 +35,7 @@ export function renderedFileSheetSectionIds(kind, options = {}) {
   const normalizedKind = normalizeString(kind);
   const isSdf = options.isSdf === true || normalizedKind === "sdf";
   const showJoints = options.showJoints !== false;
+  const showRobotComponents = options.hasRobotComponents === true;
   const status = options.hasFileStatus ? [FILE_SHEET_SECTION_IDS.FILE_STATUS] : [];
   switch (normalizedKind) {
     // A drawing HAS controls of its own now. Thickness (and, where the drawing declares
@@ -72,15 +74,12 @@ export function renderedFileSheetSectionIds(kind, options = {}) {
     case "urdf":
     case "srdf":
     case "sdf":
-      // NOTE: no Tree tab yet, though a robot now HAS a link tree and its links are
-      // selectable in the viewport. The Tree panel is 556 lines inside StepFileSheet
-      // reading 20 props and 33 derived locals; sharing it means extracting it, and a
-      // second tree implementation for robots is exactly the parallel stack this effort
-      // exists to remove.
+      // Named robot objects share the viewport picker and expose a Reference inspector.
       return [
         ...status,
         ...(isSdf ? [FILE_SHEET_SECTION_IDS.ROBOT_SDF] : []),
         ...(options.motionEnabled ? [FILE_SHEET_SECTION_IDS.ROBOT_MOTION] : []),
+        ...(showRobotComponents ? [FILE_SHEET_SECTION_IDS.ROBOT_COMPONENTS, FILE_SHEET_SECTION_IDS.STEP_REFERENCE] : []),
         ...(showJoints ? [FILE_SHEET_SECTION_IDS.ROBOT_JOINTS] : [])
       ];
     case "mesh":

--- a/apps/viewer/src/client/workbench/fileSheetTabLayout.js
+++ b/apps/viewer/src/client/workbench/fileSheetTabLayout.js
@@ -3,7 +3,7 @@ import { FILE_SHEET_SECTION_IDS } from "./fileSheetSections.js";
 // Layout model for the tabbed file sheet sidebar.
 //
 // The file sheet renders each section as a tab (Chrome-inspector style). For
-// STEP files the strip can be split into a top and bottom pane, with tabs that
+// STEP, drawing, and robot files can split into a top and bottom pane, with tabs that
 // can be dragged between panes and a resizable divider between them. Other file
 // kinds render a single tab strip.
 //
@@ -25,7 +25,7 @@ export const MAX_FILE_SHEET_SPLIT_RATIO = 0.8;
 
 export const FILE_SHEET_TAB_PANES = Object.freeze({ TOP: "top", BOTTOM: "bottom" });
 
-const SPLITTABLE_KINDS = Object.freeze(new Set(["step", "dxf"]));
+const SPLITTABLE_KINDS = Object.freeze(new Set(["step", "dxf", "urdf", "srdf", "sdf"]));
 
 function normalizeString(value) {
   return String(value == null ? "" : value).trim();
@@ -53,9 +53,10 @@ export function clampSplitRatio(ratio) {
 // Tabs that live in the top pane of a split layout; everything else defaults to
 // the bottom pane, in render order. STEP: the Tree on top, Reference/Pose/
 // Animation/Measure/Display below. DXF: Material on top (it always renders), the
-// conditional Bends/Layers tabs below.
+// conditional Bends/Layers tabs below. Robots: Components above, Reference/Joints below.
 const TOP_PANE_SECTION_IDS = Object.freeze(new Set([
   FILE_SHEET_SECTION_IDS.STEP_TREE,
+  FILE_SHEET_SECTION_IDS.ROBOT_COMPONENTS,
   FILE_SHEET_SECTION_IDS.DXF_MATERIAL
 ]));
 

--- a/apps/viewer/src/client/workbench/robotComponents.js
+++ b/apps/viewer/src/client/workbench/robotComponents.js
@@ -1,0 +1,80 @@
+// Keep each source mesh object independently pickable through the shared mesh renderer.
+// Split before posing so every object retains its visual's link and local transform.
+function componentName(part) {
+  const name = typeof part?.name === "string" ? part.name.trim() : "";
+  return name && name !== part.id && !/^unnamed(?: component)?$/i.test(name) ? name : "";
+}
+
+function sourceObjectMesh(mesh, part) {
+  const { vertexOffset, vertexCount, triangleOffset, triangleCount } = part;
+  const ranges = [vertexOffset, vertexCount, triangleOffset, triangleCount];
+  if (!ranges.every((value) => Number.isSafeInteger(value) && value >= 0) ||
+      vertexCount === 0 || triangleCount === 0 ||
+      (vertexOffset + vertexCount) * 3 > mesh.vertices.length ||
+      (triangleOffset + triangleCount) * 3 > mesh.indices.length) {
+    throw new Error(`Invalid robot mesh object ranges: ${part.id}`);
+  }
+  const indices = mesh.indices.slice(triangleOffset * 3, (triangleOffset + triangleCount) * 3);
+  if (indices.some((index) => index < vertexOffset || index >= vertexOffset + vertexCount)) {
+    throw new Error(`Robot mesh object indices exceed its vertices: ${part.id}`);
+  }
+  const sliceAttribute = (values) => values?.slice(vertexOffset * 3, (vertexOffset + vertexCount) * 3);
+  return {
+    vertices: sliceAttribute(mesh.vertices),
+    normals: sliceAttribute(mesh.normals),
+    colors: sliceAttribute(mesh.colors),
+    indices: indices.map((index) => index - vertexOffset),
+    bounds: part.bounds,
+    parts: []
+  };
+}
+
+function splitVisual(visual) {
+  const objects = visual.sourceMesh?.parts;
+  if (!Array.isArray(objects) || !objects.some(componentName)) return [visual];
+  return objects.map((object, index) => ({
+    ...visual,
+    id: `${visual.id}/object/${index}`,
+    name: componentName(object) || visual.name,
+    componentName: componentName(object),
+    visualId: visual.id,
+    meshObjectId: String(object.id || index),
+    meshObjectIndex: index,
+    sourceBounds: object.bounds,
+    bounds: object.bounds,
+    sourceMesh: sourceObjectMesh(visual.sourceMesh, object),
+    sourceMeshKey: `${visual.sourceMeshKey}/object/${index}`,
+    vertexCount: object.vertexCount,
+    triangleCount: object.triangleCount
+  }));
+}
+
+export function buildRobotComponentGeometry(meshData) {
+  return { ...meshData, parts: (meshData.parts || []).flatMap(splitVisual) };
+}
+
+export function robotComponentReference(file, component) {
+  // Explicit field names make the reference usable in prompts without STEP's topology grammar.
+  const fields = [
+    ["link", component.linkName],
+    ["visual", component.visualId],
+    ["object", component.meshObjectId],
+    ["index", component.meshObjectIndex],
+    ["name", component.componentName || component.name]
+  ];
+  const filePath = String(file).split("/").map(encodeURIComponent).join("/");
+  return `${filePath}#${fields.map(([key, value]) => `${key}=${encodeURIComponent(value)}`).join("&")}`;
+}
+
+export function robotComponents(meshData, file) {
+  return (meshData?.parts || []).filter((part) => part.componentName).map((part) => ({
+    id: part.id,
+    name: part.componentName,
+    linkName: part.linkName,
+    visualId: part.visualId,
+    meshObjectId: part.meshObjectId,
+    meshObjectIndex: part.meshObjectIndex,
+    mesh: part.partFileRef || part.meshUrl,
+    reference: robotComponentReference(file, part)
+  }));
+}

--- a/apps/viewer/src/client/workbench/useRobotComponentSelection.js
+++ b/apps/viewer/src/client/workbench/useRobotComponentSelection.js
@@ -1,0 +1,25 @@
+import { useCallback, useState } from "react";
+import { computeNextSelectionIds } from "./referenceSelection";
+
+export function useRobotComponentSelection(components, geometry, file) {
+  const [selection, setSelection] = useState(null);
+  const [hover, setHover] = useState(null);
+  const validId = (id) => components.some((component) => component.id === id);
+  const matches = (state) => state?.file === file && state?.geometry === geometry;
+  const selectedIds = matches(selection) ? selection.ids.filter(validId) : [];
+  const hoveredId = matches(hover) && validId(hover.id) ? hover.id : "";
+  const select = useCallback((id, { multiSelect = false } = {}) => {
+    const nextId = components.some((component) => component.id === id) ? id : "";
+    setSelection((current) => ({
+      file,
+      geometry,
+      ids: nextId ? computeNextSelectionIds(
+        current?.file === file && current?.geometry === geometry ? current.ids : [],
+        nextId,
+        { multiSelect }
+      ) : []
+    }));
+  }, [components, file, geometry]);
+  const hoverComponent = useCallback((id) => setHover({ file, geometry, id }), [file, geometry]);
+  return { selectedIds, hoveredId, select, hover: hoverComponent };
+}


### PR DESCRIPTION
Named objects inside a robot's linked meshes now have a Components inventory with bidirectional viewport selection. The PR is rebased onto `main` and all viewer changes live under `apps/viewer`.

- Single-line rows grouped by robot link select and highlight individual mesh objects. Picking an object in the viewport selects and reveals its row; Ctrl/Cmd/Shift-click supports multiple selections.
- Objects retain their visual transforms while joints move. Repeated mesh instances receive distinct component identifiers.
- A Reference tab shows the selected components' link, visual, mesh, and object identifiers, with copyable references and an explicit clipboard failure message. Robot sheets support Components above and Reference/Joints below using the existing split-pane layout.
- Unnamed objects remain rendered but are filtered from the inventory. Components and Reference are omitted when nothing is named, including STL-only robots.
- Grouping uses memoized `Object.groupBy`, removing the repeated Map copies without mutating application data.

Robot references are self-describing prompt locators, for example `models/robot.urdf#link=arm&visual=arm%3Av1&object=3mf%3A0&index=0&name=bracket`. Their encoding and resolution are documented in the viewer README. They identify source mesh objects, not STEP topology, and are not accepted by the STEP selector CLI. Pose changes preserve references; reordering visuals or re-exporting meshes can change them.

Validation: viewer production build passed; `scripts/bundle/bundle.sh --check` passed; code review and whitespace checks completed. No tests were added or run, including the requested section-ordering case. Interactive browser behavior has not been manually verified.
