### PR TITLE
release-prepare: update only an open release PR; runbook records the squash

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -160,7 +160,11 @@ jobs:
           git commit -m "Release $VERSION"
           git push --force-with-lease origin "$branch"
 
-          if pr_json="$(gh pr view "$branch" --repo "$GITHUB_REPOSITORY" --json number,url 2>/dev/null)"; then
+          # Only an OPEN pull request from this branch is ours to update: a closed or
+          # merged one with the same head name (a previous release, or a development
+          # branch that happened to be called release/X.Y.Z) cannot be re-based.
+          pr_json="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$branch" --base "$TARGET" --state open --json number,url --jq '.[0] // empty')"
+          if [ -n "$pr_json" ]; then
             pr_number="$(printf '%s\n' "$pr_json" | jq -r '.number')"
             pr_url="$(printf '%s\n' "$pr_json" | jq -r '.url')"
             gh pr edit "$pr_number" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -471,9 +471,9 @@ done on 2026-09-04; `develop`'s protection is still in place until step 5.
 2. Retire the `main publish only` ruleset (it blocked updates, deletions and
    non-fast-forward pushes and required linear history, which would refuse
    every PR merge). Done: ruleset 17058028 deleted.
-3. Land the history: merge PR #273 once its required checks are green
-   (`gh pr merge 273 --merge`). Keep the merge commit; do not squash — the
-   source history is the point.
+3. Land the history: merge PR #273 once its required checks are green. Done
+   2026-09-04 as a squash (`gh pr merge 273 --squash`, `main` = 3eb1f9b8); the
+   granular source history is kept at `history/0.5.0-source`.
 4. Protect `main` the way `develop` was protected (done; the classic
    branch-protection API):
    ```bash


### PR DESCRIPTION
Prepare Release's first 0.5.0 dispatch found the merged #273 under the same head branch name and failed re-basing it (`Cannot change the base branch of a closed pull request`). The lookup now considers only OPEN pull requests from the release branch against the target. CONTRIBUTING's cutover runbook records that #273 landed as a squash and that the granular history lives at `history/0.5.0-source`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)