### PR TITLE
docs deploy: alias meshoptimizer/decoder; tag does not wait on docs

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -208,9 +208,10 @@ jobs:
 
   tag-release:
     name: Tag and GitHub Release
+    # The tag records what was published; a docs deploy failing must not leave a
+    # PyPI release untagged (Deploy Docs can be re-run on its own).
     needs:
       - publish
-      - deploy-docs
     if: ${{ needs.publish.outputs.should_publish == 'true' && needs.publish.outputs.is_main == 'true' }}
     runs-on: ubuntu-latest
 

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -22,6 +22,10 @@ const threeExample = (subpath: string) =>
 // locally by moving packages/cadgen-js/node_modules aside before building.
 const cadJsBareImports = {
   meshoptimizer: docsMeshoptimizer,
+  // The GLB reader loads the decoder on demand through the package's `./decoder`
+  // export; Turbopack's alias table bypasses the exports map, so point straight at
+  // the file that export names.
+  "meshoptimizer/decoder": `${docsMeshoptimizer}/meshopt_decoder.mjs`,
   "three/examples/jsm/loaders/GLTFLoader.js": threeExample(
     "loaders/GLTFLoader.js",
   ),


### PR DESCRIPTION
The 0.5.0 publish reached PyPI, then the Vercel docs build failed on the new `meshoptimizer/decoder` subpath import (no alias) and the tag job, which needed the docs deploy, was skipped. Alias added (reproduced and verified locally without packages/cadgen-js/node_modules); the tag job now needs only the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)