### PR TITLE
feat(plugin): add QwenPaw plugin with CAD, robotics and fabrication s…

### DIFF
--- a/.qwenpaw-plugin/README.md
+++ b/.qwenpaw-plugin/README.md
@@ -1,0 +1,111 @@
+# text-to-cad for QwenPaw
+
+A [QwenPaw](https://qwenpaw.agentscope.io) plugin that installs the
+[text-to-cad](https://github.com/earthtojake/text-to-cad) skill library — CAD,
+robotics, fabrication, and local review workflows — into every QwenPaw
+workspace.
+
+## What it provides
+
+| Skill      | What it does                                                                                    |
+| ---------- | ----------------------------------------------------------------------------------------------- |
+| `cad`      | Creates, edits, and validates parametric CAD models; STEP default, STL/3MF/GLB exports.         |
+| `cad-viewer` | Opens a local browser preview (CAD Viewer) for CAD, robot-description, and DXF files.         |
+| `step-parts` | Finds off-the-shelf STEP parts (screws, bearings, motors, connectors) on step.parts.          |
+| `dxf`      | Generates and validates 2D DXF drawings from Python sources or CAD geometry.                    |
+| `urdf`     | Authors and validates URDF robot descriptions.                                                  |
+| `srdf`     | Adds MoveIt2 planning groups, end effectors, poses, and collision rules to a URDF.              |
+| `sdf`      | Authors SDFormat models and worlds for simulators.                                              |
+| `dfam-check` | Measures mesh printability per process (FDM, SLS, SLA/DLP, metal PBF, MJF).                   |
+| `gcode`    | Slices mesh files into validated, printer-profiled FDM G-code with real slicer CLIs.            |
+| `bambu-labs` | Dry-runs, uploads, and cautiously starts local Bambu Lab print jobs from validated G-code.    |
+| `sendcutsend` | Checks DXF and STEP files before uploading a SendCutSend order.                              |
+
+Skills are enabled by default on all channels in every workspace. The plugin
+itself ships no tools: each skill's `requirements.txt` names the `cadgen`
+distribution it runs on, and the skill instructs the agent to install it on
+first use (`python -m pip install -r requirements.txt`).
+
+## Install
+
+Plugin operations require QwenPaw to be offline.
+
+From a clone of this repository:
+
+```bash
+qwenpaw plugin install /path/to/text-to-cad/.qwenpaw-plugin
+```
+
+Or from a ZIP of the plugin directory:
+
+```bash
+cd /path/to/text-to-cad
+zip -r text-to-cad-qwenpaw.zip .qwenpaw-plugin
+qwenpaw plugin install text-to-cad-qwenpaw.zip
+```
+
+Then start QwenPaw (`qwenpaw app`). On startup the plugin copies every skill
+into each workspace's `skills/` directory, so the CAD skills appear under
+**Workspace → Skills** alongside QwenPaw's built-ins.
+
+## Verify
+
+```bash
+qwenpaw plugin list
+```
+
+shows `text-to-cad` as installed; the workspace skill page lists the eleven
+skills above as enabled.
+
+## Requirements
+
+- QwenPaw 2.1.1 or newer (`qwenpaw_version.min` in `plugin.json`; the loader
+  checks `>=min` and disables the plugin otherwise).
+- Per skill, at runtime: Python ≥ 3.11 and the `cadgen` distribution from
+  PyPI (the agent installs it from the skill's `requirements.txt`). `cad`
+  rendering additionally needs a Chromium browser
+  (`python -m playwright install chromium`).
+
+## Preflight: /cad-setup
+
+Run `/cad-setup` in any workspace chat to check the runtime before first use:
+
+- whether the `cadgen` distribution is installed (and its version);
+- each cadgen-pinned skill's `requirements.txt` pin, verified with
+  `cadgen doctor` (exit 3 = mismatch, and the command prints the fix);
+- viewer instances and the warm daemon, so background processes are visible.
+
+A one-line pointer to `/cad-setup` is injected into the system prompt, so the
+agent knows the check exists without reading a skill.
+
+## Fabrication opt-in
+
+`bambu-labs` and `sendcutsend` reach real machines (starting LAN prints,
+uploading parts for manufacture), so the plugin provisions them **disabled**
+the first time it fills a workspace; enable them per workspace in
+**Workspace → Skills** when you want them. The once-only gate is marked by a
+`.text-to-cad-provisioned` file in each workspace: after the first provision,
+your own enable/disable choices always win.
+
+## Files
+
+```
+.qwenpaw-plugin/
+├── plugin.json   # Manifest: id "cad", type "general"
+├── plugin.py     # Entry point: skill provider, /cad-setup, fabrication gate
+├── README.md     # This file
+└── skills/       # GENERATED copy of the canonical skills/ — do not edit
+```
+
+The QwenPaw loader installs a plugin by copying this directory, so the skill
+tree travels inside it. `skills/` here is generated from the repository's
+canonical `skills/` (what every other installer ships):
+
+```bash
+rsync -a --delete --exclude '__pycache__' --exclude '.DS_Store' \
+  skills/ .qwenpaw-plugin/skills/
+```
+
+`tests/python/global/test_qwenpaw_plugin.py` fails when the copy drifts from
+the canonical tree. The release PR stamps the version into `plugin.json`
+alongside the other plugin manifests via `scripts/release/sync-version.mjs`.

--- a/.qwenpaw-plugin/plugin.json
+++ b/.qwenpaw-plugin/plugin.json
@@ -15,6 +15,6 @@
   "dependencies": [],
   "qwenpaw_version": {
     "min": "2.1.1",
-    "max": "3.0.0"
+    "max": "2.99.0"
   }
 }

--- a/.qwenpaw-plugin/plugin.json
+++ b/.qwenpaw-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "id": "cad",
+  "name": "text-to-cad",
+  "version": "0.5.1",
+  "type": "general",
+  "description": "CAD, robotics, fabrication, and local review skills.",
+  "description_i18n": {
+    "zh-CN": "CAD、机器人描述、加工制造与本地审查技能。",
+    "en-US": "CAD, robotics, fabrication, and local review skills."
+  },
+  "author": "earthtojake",
+  "entry": {
+    "backend": "plugin.py"
+  },
+  "dependencies": [],
+  "qwenpaw_version": {
+    "min": "2.1.1",
+    "max": "3.0.0"
+  }
+}

--- a/.qwenpaw-plugin/plugin.py
+++ b/.qwenpaw-plugin/plugin.py
@@ -1,0 +1,376 @@
+# -*- coding: utf-8 -*-
+"""text-to-cad QwenPaw plugin entry point.
+
+Registers the repository's CAD, robotics, and fabrication skills with every
+QwenPaw workspace, plus a ``/cad-setup`` preflight command that reports the
+cadgen runtime state (presence, per-skill pin, viewer/daemon) without the
+agent having to read a skill first.
+
+The plugin ships no tools of its own: the skills are instructions over the
+``cadgen`` distribution, which each skill's ``requirements.txt`` names and the
+agent installs on first use.
+
+This module must stay importable without QwenPaw installed (stdlib only at
+module scope; qwenpaw/agentscope imports sit inside functions): QwenPaw
+validates a plugin by importing it and requiring a ``plugin`` instance, and
+this repository's policy test (``tests/python/global/test_qwenpaw_plugin.py``)
+runs the same import on a checkout that has no ``qwenpaw`` package.
+
+Skills directory resolution
+---------------------------
+
+The QwenPaw loader copies THIS directory (``.qwenpaw-plugin/``) into
+``~/.qwenpaw/plugins/<id>/`` at install time, so the plugin carries its own
+bundled ``skills/`` copy: ``<plugin_dir>/skills``. That copy is GENERATED
+from the repository's canonical ``skills/`` tree (the same content every
+other installer — Skills CLI, Claude Code, Codex — ships) and
+``tests/python/global/test_qwenpaw_plugin.py`` fails the build when the copy
+drifts from the canonical tree.
+
+The checkout sibling (``<plugin_dir>/../skills``) is probed as a fallback so
+a developer running the plugin straight from a repo layout without the
+generated copy still works. If neither exists the plugin logs a clear error
+and skips skill registration instead of raising: a broken path must degrade
+to "plugin without skills", not fail the QwenPaw app startup.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only, never evaluated
+    from qwenpaw.plugins.api import PluginApi
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+
+#: Skills the fabrication/handoff boundary applies to. These are enabled by
+#: default everywhere else in this repo; under QwenPaw they start disabled and
+#: the user opts in per workspace, because they reach real machines: starting
+#: prints on a LAN printer (bambu-labs) and uploading parts for manufacture
+#: (sendcutsend). Everything else (cad, cad-viewer, step-parts, dxf, urdf,
+#: srdf, sdf, dfam-check, gcode) is analysis, authoring, or local-only.
+FABRICATION_SKILLS = ("bambu-labs", "sendcutsend")
+
+#: Marker written into a workspace the first time the plugin provisions it.
+#: Keeps the once-only disable semantics: after the first provision the user's
+#: own enable/disable choices win, on every later startup.
+_PROVISION_MARKER = ".text-to-cad-provisioned"
+
+#: One-line pointer injected into the system prompt after the workspace
+#: section. Short on purpose: it costs tokens on every turn.
+_PROMPT_HINT = (
+    "text-to-cad skills (CAD/URDF/SDF/DXF/G-code) are installed; "
+    "run /cad-setup once to verify the cadgen runtime before first use."
+)
+
+
+def _resolve_skills_dir() -> Path | None:
+    """Return the skills directory the plugin will provision from, or None."""
+    candidates = [
+        PLUGIN_DIR / "skills",
+        PLUGIN_DIR.parent / "skills",
+    ]
+    for candidate in candidates:
+        if candidate.is_dir() and (candidate / "cad" / "SKILL.md").is_file():
+            return candidate
+    return None
+
+
+def _workspace_dirs() -> list[Path]:
+    """Every configured workspace directory (empty list when unavailable)."""
+    try:
+        from qwenpaw.agents.skill_system.registry import list_workspaces
+
+        return [Path(w["workspace_dir"]) for w in list_workspaces()]
+    except Exception as exc:  # noqa: BLE001 - provisioning is best-effort
+        logger.warning("text-to-cad: cannot list workspaces: %s", exc)
+        return []
+
+
+def _apply_fabrication_gate(workspace_dir: Path, skills_dir: Path) -> None:
+    """Disable the fabrication skills the first time a workspace is provisioned.
+
+    Runs after the host's install hook (priority 85 > 80). The marker file
+    makes it exactly-once per provision cycle: on later startups the user's
+    own enable/disable choices are left alone. The marker is removed again
+    by the plugin's uninstall hook, so a reinstall treats the workspace as
+    freshly provisioned and re-applies the gate (the uninstall removes the
+    plugin-sourced skills; without this the reinstall would re-enable them
+    and the stale marker would keep the gate off).
+    """
+    marker = workspace_dir / _PROVISION_MARKER
+    if marker.exists():
+        return
+    try:
+        from qwenpaw.agents.skill_system.store import (
+            default_workspace_manifest,
+            get_workspace_skill_manifest_path,
+            mutate_json,
+        )
+
+        installed = {
+            d.name
+            for d in skills_dir.iterdir()
+            if d.is_dir() and (d / "SKILL.md").is_file()
+        }
+        gated = sorted(installed & set(FABRICATION_SKILLS))
+        if not gated:
+            marker.touch()
+            return
+
+        def _disable(payload: dict) -> dict:
+            skills = payload.setdefault("skills", {})
+            for name in gated:
+                entry = skills.get(name)
+                if entry is None:
+                    continue
+                if str(entry.get("source", "")).startswith("plugin:cad"):
+                    entry["enabled"] = False
+            return payload
+
+        mutate_json(
+            get_workspace_skill_manifest_path(workspace_dir),
+            default_workspace_manifest(),
+            _disable,
+        )
+        marker.touch()
+        logger.info(
+            "text-to-cad: fabrication skills left disabled in %s: %s "
+            "(enable per workspace when the user opts in)",
+            workspace_dir.name,
+            ", ".join(gated),
+        )
+    except Exception as exc:  # noqa: BLE001 - never block startup
+        logger.warning(
+            "text-to-cad: fabrication gate skipped for %s: %s",
+            workspace_dir.name,
+            exc,
+        )
+
+
+def _run_cadgen_doctor(skill_dir: Path) -> tuple[str, str]:
+    """Run ``cadgen doctor <skill_dir>``; return (status, detail).
+
+    status is one of "ok" (exit 0), "mismatch" (exit 3), "missing"
+    (no cadgen on PATH) or "error".
+    """
+    import shutil
+    import subprocess
+
+    exe = shutil.which("cadgen")
+    if exe is None:
+        return (
+            "missing",
+            "the cadgen distribution is not installed — "
+            "`python -m pip install -r <skill>/requirements.txt` (Python >= 3.11)",
+        )
+    try:
+        result = subprocess.run(
+            [exe, "doctor", str(skill_dir)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return ("error", "cadgen doctor timed out after 120s")
+    except OSError as exc:
+        return ("error", f"cadgen doctor failed to run: {exc}")
+
+    tail = (result.stdout or result.stderr or "").strip().splitlines()
+    detail = tail[-1] if tail else ""
+    if result.returncode == 0:
+        return ("ok", detail)
+    if result.returncode == 3:
+        return ("mismatch", detail)
+    return ("error", detail or f"cadgen doctor exited {result.returncode}")
+
+
+async def _cad_setup_handler(ctx, args: str):
+    """/cad-setup — report the cadgen runtime state for this workspace.
+
+    Checks, in order: the cadgen binary, each cadgen-pinned skill's
+    requirements pin (via ``cadgen doctor``), and the viewer/daemon
+    lifecycle so stray background processes are visible. Returns a Msg;
+    never raises into the dispatcher.
+    """
+    from agentscope.message import Msg, TextBlock
+
+    workspace_dir = getattr(ctx, "workspace_dir", None)
+    lines: list[str] = ["text-to-cad runtime check:"]
+
+    if workspace_dir is None:
+        lines.append("  workspace: unknown (no workspace_dir on context)")
+        skills_root: Path | None = None
+    else:
+        workspace_dir = Path(workspace_dir)
+        skills_root = workspace_dir / "skills"
+        lines.append(f"  workspace: {workspace_dir}")
+
+    # 1. cadgen binary presence + version
+    import shutil
+
+    exe = shutil.which("cadgen")
+    if exe is None:
+        lines.append(
+            "  cadgen: NOT INSTALLED — install any pinned skill's "
+            "requirements.txt to get it (Python >= 3.11)"
+        )
+    else:
+        try:
+            import subprocess
+
+            version = subprocess.run(
+                [exe, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            ).stdout.strip()
+        except Exception as exc:  # noqa: BLE001
+            version = f"unreadable ({exc})"
+        lines.append(f"  cadgen: {version} ({exe})")
+
+    # 2. Per-skill pin check for every cadgen-pinned skill in the workspace
+    if skills_root is not None and skills_root.is_dir():
+        for skill_dir in sorted(skills_root.iterdir()):
+            req = skill_dir / "requirements.txt"
+            if not (skill_dir / "SKILL.md").is_file() or not req.is_file():
+                continue
+            if not any(
+                line.strip().startswith("cadgen")
+                for line in req.read_text(encoding="utf-8").splitlines()
+                if line.strip() and not line.strip().startswith("#")
+            ):
+                continue
+            status, detail = _run_cadgen_doctor(skill_dir)
+            mark = {"ok": "OK", "mismatch": "MISMATCH", "missing": "MISSING", "error": "ERROR"}[status]
+            lines.append(f"  {skill_dir.name}: {mark} — {detail}")
+    else:
+        lines.append("  skills: no skills/ directory in this workspace")
+
+    # 3. Background lifecycle visibility (viewer instances, warm daemon)
+    if exe is not None:
+        import subprocess
+
+        for label, argv in (
+            ("viewer", [exe, "viewer", "list", "--json"]),
+            ("daemon", [exe, "daemon", "status"]),
+        ):
+            try:
+                result = subprocess.run(
+                    argv, capture_output=True, text=True, timeout=30
+                )
+                out = (result.stdout or "").strip()
+                lines.append(f"  {label}: {out.splitlines()[0] if out else 'none'}")
+            except Exception as exc:  # noqa: BLE001
+                lines.append(f"  {label}: status unavailable ({exc})")
+
+    return Msg(
+        name="system",
+        role="assistant",
+        content=[TextBlock(type="text", text="\n".join(lines))],
+    )
+
+
+class TextToCadPlugin:
+    """Installs the packaged skills into every QwenPaw workspace."""
+
+    def register(self, api: PluginApi) -> None:
+        """Register skills, the preflight command, and the setup hint.
+
+        Args:
+            api: PluginApi instance provided by the QwenPaw loader.
+        """
+        skills_dir = _resolve_skills_dir()
+        if skills_dir is None:
+            logger.error(
+                "text-to-cad: no skills directory found next to %s or inside "
+                "it — skill registration skipped. Install the plugin from a "
+                "text-to-cad checkout (repo root) or a package that bundles "
+                "skills/ inside the plugin directory.",
+                PLUGIN_DIR,
+            )
+        else:
+            logger.info("Registering text-to-cad skills (%s)...", skills_dir)
+            api.register_skill_provider(
+                skills_dir=skills_dir,
+                enabled_by_default=True,
+                channels=["all"],
+            )
+
+            def _gate(workspace_info: dict) -> None:
+                workspace_dir = Path(workspace_info.get("workspace_dir", ""))
+                if workspace_dir.is_dir():
+                    _apply_fabrication_gate(workspace_dir, skills_dir)
+
+            api.register_startup_hook(
+                hook_name="text_to_cad_fabrication_gate",
+                callback=lambda: [
+                    _gate({"workspace_dir": str(w)}) for w in _workspace_dirs()
+                ],
+                priority=85,  # after the host's install hook (priority 80)
+            )
+            api.register_workspace_created_hook(
+                hook_name="text_to_cad_fabrication_gate",
+                callback=_gate,
+                priority=85,
+            )
+
+            def _clear_markers(plugin_id: str, delete_files: bool = False) -> None:
+                """Remove the provision markers so a reinstall re-gates.
+
+                The host uninstall deletes the plugin-sourced skills but not
+                this plugin's marker files; without this hook a reinstall
+                would find the stale marker, skip the gate, and leave the
+                fabrication skills re-enabled by the fresh install.
+                """
+                _ = delete_files  # part of the uninstall hook contract
+                for workspace_dir in _workspace_dirs():
+                    try:
+                        (workspace_dir / _PROVISION_MARKER).unlink(missing_ok=True)
+                    except OSError as exc:
+                        logger.warning(
+                            "text-to-cad: could not clear provision marker "
+                            "in %s: %s",
+                            workspace_dir.name,
+                            exc,
+                        )
+
+            api.register_uninstall_hook(
+                hook_name="text_to_cad_clear_provision_markers",
+                callback=_clear_markers,
+            )
+            logger.info("✓ text-to-cad skills registered from %s", skills_dir)
+
+        # /cad-setup preflight: the first-run failure mode for every skill is
+        # "cadgen missing or pinned elsewhere"; the command surfaces that (and
+        # any viewer/daemon strays) before the agent burns a turn on it.
+        api.register_slash_command(
+            name="cad-setup",
+            handler=_cad_setup_handler,
+            category="plugin",
+            help_text=(
+                "Verify the text-to-cad runtime: cadgen presence/version, "
+                "per-skill cadgen pins, viewer and daemon status"
+            ),
+        )
+
+        # One-line system-prompt hint so the agent knows the preflight exists
+        # without reading any skill. Registered only when skills resolved; a
+        # plugin without skills should not advertise them.
+        if skills_dir is not None:
+            api.register_prompt_section(
+                name="text_to_cad_setup_hint",
+                after="workspace",
+                provider=lambda agent: _PROMPT_HINT,
+            )
+
+        logger.info("✓ text-to-cad plugin registered")
+
+
+# Export plugin instance (required by the QwenPaw plugin loader).
+plugin = TextToCadPlugin()

--- a/.qwenpaw-plugin/skills/bambu-labs/LICENSE
+++ b/.qwenpaw-plugin/skills/bambu-labs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thompson Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.qwenpaw-plugin/skills/bambu-labs/SKILL.md
+++ b/.qwenpaw-plugin/skills/bambu-labs/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: bambu-labs
+description: Dry-run, upload, and cautiously initiate local Bambu Lab print jobs from validated plain `.gcode`, using Bambu LAN FTPS/MQTT handoffs.
+---
+
+# Bambu Labs
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review.
+
+Use this skill for local-network Bambu Lab print handoffs after a plain `.gcode`
+file already exists and has been validated. This skill does not slice models.
+
+## Safety Rules
+
+- Default to dry-run plans. Real printer traffic requires `--execute`.
+- Never start a print without `--execute --confirm-start-print`.
+- Pause and cancel controls are live printer requests; default to dry-run plans.
+  Canceling a print requires `--execute --confirm-cancel-print`.
+- Treat an explicit user request to print or start a specific job as live-start
+  authorization; do not pause for a second confirmation solely for physical
+  checks. Still validate the G-code, inspect the dry-run payload, read printer
+  status, prefer upload-only before upload-start, state the physical checks, and
+  stop if validation/status/intent is unsafe or ambiguous.
+- Do not ask for the printer serial by default; fetch it from the printer TLS certificate with `serial` or let `send` cache it.
+- Prefer workspace-root `bambu-printers.json` over repeating access codes in commands. The file is local config and should be ignored by Git.
+- Before a live start, state the physical checks: clear build plate, correct plate/filament/nozzle, safe surroundings, and operator nearby.
+- Publishing MQTT is only a start request. Confirm acceptance with printer status/UI and physical observation.
+
+## CAD Viewer Handoff
+
+After completing Bambu work that creates or modifies a local `.3mf` print artifact, you must ALWAYS hand the explicit file path to `$cad-viewer` when that skill is installed. CAD Viewer does not open `.gcode`, so a plain G-code artifact takes no handoff. `$cad-viewer` must start CAD Viewer if it is not already running and return link(s) to the relevant created or updated file(s); if `$cad-viewer` is unavailable or startup fails, report that instead of silently omitting the handoff.
+
+## Workflow
+
+1. Generate and validate plain G-code with `$gcode`.
+   If no slicer is installed, install OrcaSlicer and retry; do not treat the missing slicer as a blocker. On macOS, prefer `brew install --cask orcaslicer`.
+2. Configure the printer. The user can either give the IP/access code in the thread and let the agent write JSON, or edit `bambu-printers.json` directly.
+   For a new printer setup or onboarding request, read
+   `references/new-printer-onboarding.md` first. Walk the user through the
+   model-specific touchscreen steps to find the IP and LAN access code, and make
+   **Enable LAN Only** plus **Enable Developer Mode** explicit before running
+   local start workflows.
+
+```bash
+python scripts/bambu_lan_print.py config set \
+  --printer a1-mini \
+  --host 192.168.1.34 \
+  --access-code 12345678 \
+  --model a1-mini \
+  --fetch-serial
+```
+
+Manual JSON shape:
+
+```json
+{
+  "printers": {
+    "a1-mini": {
+      "host": "192.168.1.34",
+      "access_code": "12345678",
+      "model": "a1-mini"
+    }
+  }
+}
+```
+
+On A1/A1 Mini, find the IP and LAN access code on the printer touchscreen under
+network/LAN settings. Enable LAN Only and Developer Mode when offered, then
+power-cycle before retrying local start commands.
+
+3. Read status before live work:
+
+```bash
+python scripts/bambu_lan_print.py status \
+  --printer a1-mini \
+  --push-all \
+  --wait-seconds 10
+```
+
+4. Dry-run the exact handoff, inspect the JSON payload, then run upload-only.
+Only after upload succeeds should you run upload-start. If the user explicitly
+asked to print or start the job, proceed to `upload-start --execute
+--confirm-start-print` after the validation, status, and upload checks pass. If
+the user only asked to prepare, slice, upload, or review, stop before the start
+request.
+
+## Handoff Modes
+
+`--handoff template-project` is the A1 Mini path validated against a real
+printer over LAN. It starts from validated plain `.gcode`, copies a known-good
+same-printer `.gcode.3mf` template, replaces `Metadata/plate_N.gcode`, writes
+the plate MD5, uploads the project to the FTPS root, and publishes
+`print.project_file` with `url: ftp:///<name>.gcode.3mf`.
+
+```bash
+python scripts/bambu_lan_print.py send \
+  --printer a1-mini \
+  --gcode /tmp/job.gcode \
+  --handoff template-project \
+  --template-project /path/to/same-printer-template.gcode.3mf \
+  --action upload-start
+```
+
+Execute after review when the user explicitly asked to print or start, or after
+physical confirmation when intent is unclear:
+
+```bash
+python scripts/bambu_lan_print.py send \
+  --printer a1-mini \
+  --gcode /tmp/job.gcode \
+  --handoff template-project \
+  --template-project /path/to/same-printer-template.gcode.3mf \
+  --action upload-start \
+  --execute \
+  --confirm-start-print
+```
+
+`--handoff plain` uploads `cache/<name>.gcode` and publishes
+`print.gcode_file`. Keep it for diagnostics or printers/firmware where this is
+known to work. On the tested A1 Mini, direct plain G-code was uploaded
+successfully but `gcode_file` failed or was ignored, so do not use it as the
+A1 Mini live-start path.
+
+`--handoff bambox-project` packages plain `.gcode` with `bambox`, uploads the
+`.gcode.3mf` project to FTPS root, and publishes `print.project_file`.
+Currently enabled only for `p1s-0.4` with `PLA`, `ASA`, or `PETG-CF`.
+Known but disabled until validated profiles exist: `a1-mini-0.4`, `a1-0.4`,
+`x1c-0.4`, and `p1p-0.4`.
+
+## Common Debugging Commands
+
+Fetch/cache serial:
+
+```bash
+python scripts/bambu_lan_print.py serial \
+  --printer a1-mini \
+  --json
+```
+
+Clear a stale printer error after fixing the underlying cause:
+
+```bash
+python scripts/bambu_lan_print.py clear-error \
+  --printer a1-mini \
+  --execute
+```
+
+Use `--mqtt-qos 1 --wait-after-publish 10` on `send` when debugging whether the
+printer acknowledged the MQTT publish and what status it reported immediately
+afterward.
+
+## Print Controls
+
+For a running print, use dedicated print-control commands rather than ad hoc
+MQTT snippets. These commands publish only a control request; they do not upload
+files or start a new job. Read status after execution to confirm the printer
+state changed.
+
+Dry-run pause payload:
+
+```bash
+python scripts/bambu_lan_print.py pause \
+  --printer a1-mini
+```
+
+Execute pause and collect printer reports:
+
+```bash
+python scripts/bambu_lan_print.py pause \
+  --printer a1-mini \
+  --execute \
+  --mqtt-qos 1 \
+  --wait-after-publish 10
+```
+
+Dry-run cancel payload. The Bambu LAN command sent to the printer is `stop`:
+
+```bash
+python scripts/bambu_lan_print.py cancel \
+  --printer a1-mini
+```
+
+Execute cancel only when the user explicitly asks to cancel/stop the print or
+after confirmation when intent is ambiguous:
+
+```bash
+python scripts/bambu_lan_print.py cancel \
+  --printer a1-mini \
+  --execute \
+  --confirm-cancel-print \
+  --mqtt-qos 1 \
+  --wait-after-publish 10
+```
+
+## Failure Modes
+
+- `gcode_file` returns `result: fail` or leaves the printer `IDLE`: plain G-code upload worked, but the firmware rejected or ignored direct local start. For A1 Mini, switch to `template-project`.
+- Project uploaded under `cache/` starts then fails with `print_error: 83935248` or `0500-C010`: clear the error, upload project handoffs to FTPS root, and use `ftp:///<name>.gcode.3mf`.
+- `file:///sdcard/cache/...` or local HTTP URLs appear accepted but nothing starts: stop using those URL forms for this workflow.
+- Bambu Studio or OrcaSlicer project export crashes on macOS: do not keep retrying GUI-backed project export. Use OrcaSlicer for plain `.gcode`, then this skill for handoff.
+- Stale `gcode_state: FAILED` or HMS after enabling Developer Mode: clear the printer error and power-cycle before retrying.
+- FTPS login works but upload fails with `553` or missing `cache/`: check printer storage/SD card status before MQTT start.
+- MQTT status works but start does not: confirm serial, access code, Developer Mode/LAN Only status, and the exact handoff payload before retrying.
+
+Read `references/new-printer-onboarding.md` for new printer setup,
+`references/local-lan-protocol.md` for protocol details, and
+`references/real-printer-checklist.md` before first live use on a new printer.

--- a/.qwenpaw-plugin/skills/bambu-labs/agents/openai.yaml
+++ b/.qwenpaw-plugin/skills/bambu-labs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Bambu Labs"
+  short_description: "Dry-run and start local Bambu G-code handoffs"
+  default_prompt: "Use $bambu-labs to dry-run a validated plain G-code handoff before starting it."

--- a/.qwenpaw-plugin/skills/bambu-labs/references/local-lan-protocol.md
+++ b/.qwenpaw-plugin/skills/bambu-labs/references/local-lan-protocol.md
@@ -1,0 +1,123 @@
+# Bambu Lab Local LAN Protocol Notes
+
+Use this reference only when planning or debugging against a real local printer.
+Bambu does not provide this skill with a stable public local-print API
+contract, so treat these as observed FTPS/MQTT behaviors.
+
+## Required Inputs
+
+- Validated plain `.gcode`.
+- Printer LAN IP/hostname.
+- Printer access code.
+- Printer serial for MQTT topic `device/{serial}/request`; fetch it from the
+  printer TLS certificate with `serial` or let `send` fetch/cache it.
+- Handoff mode: `template-project`, `plain`, or `bambox-project`.
+
+Workspace-root `bambu-printers.json` stores printer IDs, hostnames, access codes, models,
+and cached serials. It is local config and should be ignored by Git.
+
+## Transport
+
+- FTPS upload: implicit TLS on port `990`.
+- MQTT control/status: TLS on port `8883`.
+- Username: `bblp`.
+- Password: printer access code.
+- TLS verification is off by default because local printers commonly use
+  device/self-signed certificates.
+- The helper rejects public IPs/hostnames unless `--allow-nonprivate-host` is
+  set.
+- FTPS data connections may require TLS session reuse. The helper reuses the
+  control TLS session for uploads and listings.
+
+## MQTT Topics
+
+- Request topic: `device/{serial}/request`.
+- Report topic: `device/{serial}/report`.
+- `status --push-all` subscribes to reports, then publishes `pushing.pushall`
+  to request a full state report.
+- Publishing a start payload is a request, not proof of accepted motion.
+
+## Handoff Payloads
+
+### Template Project
+
+Validated on an A1 Mini during local LAN debugging:
+
+1. Start from a validated plain `.gcode`.
+2. Copy a known-good same-printer `.gcode.3mf` template.
+3. Replace `Metadata/plate_N.gcode` and update `Metadata/plate_N.gcode.md5`.
+4. Upload the resulting `.gcode.3mf` to FTPS root, not `cache/`.
+5. Publish `print.project_file` with root FTP URL.
+
+Representative payload:
+
+```json
+{
+  "print": {
+    "command": "project_file",
+    "param": "Metadata/plate_1.gcode",
+    "project_id": "0",
+    "profile_id": "0",
+    "task_id": "0",
+    "subtask_id": "0",
+    "subtask_name": "job",
+    "url": "ftp:///job.gcode.3mf",
+    "md5": "PROJECT_MD5_UPPERCASE",
+    "timelapse": false,
+    "bed_type": "auto",
+    "bed_levelling": true,
+    "flow_cali": true,
+    "vibration_cali": false,
+    "layer_inspect": true,
+    "use_ams": false,
+    "ams_mapping": ""
+  }
+}
+```
+
+### Plain G-code
+
+The plain path uploads `cache/<job>.gcode` and publishes:
+
+```json
+{
+  "print": {
+    "command": "gcode_file",
+    "param": "cache/job.gcode"
+  }
+}
+```
+
+On the tested A1 Mini, byte-for-byte verified uploads still produced
+`gcode_file` failure/idle behavior. Use this path only for diagnostics or
+printer firmware where it has been validated.
+
+### Bambox Project
+
+The optional `bambox-project` path packages plain G-code into `.gcode.3mf` for
+enabled profiles, validates the archive, uploads it to FTPS root, and publishes
+the same `project_file` shape as template projects. Current enabled profile is
+`p1s-0.4`; A1/A1 Mini are disabled until a validated bambox profile exists.
+
+## Observed Failure Modes
+
+- **Direct G-code rejected:** MQTT report after `gcode_file` may include
+  `{"command":"gcode_file","result":"fail","reason":"error string"}`. Stop and
+  use a project handoff.
+- **Direct G-code ignored:** uploaded file exists, HMS is empty, target
+  temperatures stay at zero, and `gcode_state` remains `IDLE`. Do not keep
+  cycling path variants.
+- **Project in `cache/` fails:** `project_file` can be accepted and then fail
+  with `print_error: 83935248` / `0500-C010`. Clear the error and upload project
+  files to FTPS root with `ftp:///<name>.gcode.3mf`.
+- **HTTP/file URLs inert:** `file:///sdcard/cache/...` and local HTTP URLs may
+  be accepted without fetching or starting. Do not use them for this workflow.
+- **Bambu/Orca project export crash:** GUI-backed CLI project export on macOS
+  can crash inside AppKit/BambuStudio. Use slicer CLI only for plain `.gcode`.
+- **Stale printer state:** after LAN Only/Developer Mode changes, clear errors
+  and power-cycle. Status can retain stale `FAILED`/HMS values.
+- **Storage unavailable:** if FTPS auth works but upload fails with `553`, or
+  status reports no SD/storage, resolve storage before MQTT start.
+
+Use `clear-error --execute` only after the underlying cause is fixed. It
+publishes `print.clean_print_error` and does not start motion.

--- a/.qwenpaw-plugin/skills/bambu-labs/references/new-printer-onboarding.md
+++ b/.qwenpaw-plugin/skills/bambu-labs/references/new-printer-onboarding.md
@@ -1,0 +1,139 @@
+# New Printer Onboarding
+
+Use this reference whenever the user asks to set up, add, pair, configure, or
+test a new Bambu Lab printer for local LAN handoff. The goal is a calm,
+step-by-step setup where the user always knows what is safe, what is private,
+and what the agent will do next.
+
+## Agent Flow
+
+1. Start by confirming this is setup only. Say that no upload or print will
+   happen during onboarding unless the user explicitly asks later.
+2. Ask for the printer model or family if it is not already known. Use a stable
+   local printer id such as `a1-mini`, `a1`, `p1s`, `p1p`, `x1c`, or `h2d`.
+3. Tell the user you need two values from the printer touchscreen:
+   printer IP address and LAN access code. Explain that the serial is fetched
+   from the printer certificate and should not be requested by default.
+4. Immediately give the model-specific touchscreen steps below. Do not just ask
+   for the IP and access code without helping the user find them.
+5. Make the LAN prerequisites very explicit: the user must **Enable LAN Only**
+   and **Enable Developer Mode** before live local start commands. If either
+   option exists and is off, stop setup and ask them to enable it first.
+6. After the user provides the IP and access code, store them with `config set`
+   in workspace-root `bambu-printers.json`, using `--fetch-serial`. Do not repeat the
+   access code in the final response.
+7. Run `status --push-all --wait-seconds 10` and summarize the result in plain
+   language: reachable or not, idle/running/error, SD/storage present, and any
+   `print_error` or HMS entries.
+8. If setup succeeds, offer the next safe step as a dry-run handoff plan. Do not
+   upload or start anything during onboarding unless the user explicitly asks.
+
+## What To Say First
+
+Use a short, reassuring prompt like this:
+
+```text
+I can set this up safely. I need the printer's LAN IP address and LAN access
+code from the touchscreen. Before you send them, please enable LAN Only and
+Developer Mode; local starts often fail or become read-only if Developer Mode is
+off. I will store the code only in the workspace-local ignored config and fetch the
+serial from the printer automatically.
+```
+
+Then give the matching steps for their printer family.
+
+## Touchscreen Steps By Printer Family
+
+### A1 / A1 Mini
+
+1. On the printer touchscreen, open **Settings**.
+2. Open **Network** or **WLAN**.
+3. Connect the printer to the same trusted local network as this computer.
+4. **Enable LAN Only**.
+5. **Enable Developer Mode** in the same network/LAN area when shown.
+6. Record the IPv4 address shown on the network screen.
+7. Record the LAN access code shown near the LAN Only or Developer Mode
+   controls. If it is all zeros, refresh/regenerate it or toggle LAN Only off
+   and on, then record the new code.
+8. Power-cycle the printer after changing LAN Only or Developer Mode.
+
+### P1P / P1S
+
+1. On the printer screen, open **Settings**.
+2. Open **Network** or **WLAN**.
+3. Confirm the printer is on the same trusted local network as this computer.
+4. **Enable LAN Only**.
+5. **Enable Developer Mode**. If it is not visible, update firmware or stop
+   before live local start workflows.
+6. Record the printer IPv4 address.
+7. Record the LAN access code. If the code is all zeros or blank, refresh it or
+   toggle LAN Only off and on, then record the new code.
+8. Power-cycle the printer before the first local status check.
+
+### X1 / X1C / X1E
+
+1. On the printer touchscreen, open **Settings**.
+2. Open **Network** or **WLAN**.
+3. Confirm the printer is connected to the same trusted local network.
+4. **Enable LAN Only**.
+5. **Enable Developer Mode**. If it is not visible, update firmware or stop
+   before live local start workflows.
+6. Record the IPv4 address.
+7. Record the LAN access code from the LAN/network screen.
+8. Power-cycle the printer after changing LAN settings.
+
+### H2D / Newer Bambu Printers
+
+1. Open **Settings** on the printer touchscreen.
+2. Open **Network**, **WLAN**, or the printer's LAN settings panel.
+3. Confirm local network connectivity.
+4. **Enable LAN Only**.
+5. **Enable Developer Mode**.
+6. Record the IPv4 address and LAN access code.
+7. Power-cycle after changing LAN settings.
+
+For an unknown Bambu model, guide the user to the printer's network/WLAN
+settings, then require the same four items before continuing: same local
+network, **Enable LAN Only**, **Enable Developer Mode**, and collect IP plus
+LAN access code.
+
+## Agent Commands
+
+Use the active Python environment:
+
+```bash
+python scripts/bambu_lan_print.py config set \
+  --printer a1-mini \
+  --host 192.168.1.34 \
+  --access-code 12345678 \
+  --model a1-mini \
+  --fetch-serial
+```
+
+Then check status:
+
+```bash
+python scripts/bambu_lan_print.py status \
+  --printer a1-mini \
+  --push-all \
+  --wait-seconds 10
+```
+
+Use the model-specific printer id in both commands. If sandboxing blocks local
+network access, rerun the same command with permission to contact the printer.
+
+## Smooth Failure Handling
+
+- If the printer is unreachable, ask the user to confirm the IP, same Wi-Fi or
+  VLAN reachability, and that the printer is awake.
+- If MQTT status fails but TLS serial fetch worked, first confirm **Developer
+  Mode** is enabled, then power-cycle and retry status.
+- If the access code is rejected or all zeros, ask the user to refresh the LAN
+  access code on the printer and rerun `config set --fetch-serial`.
+- If status returns stale `FAILED`, `print_error`, or HMS entries after enabling
+  LAN Only or Developer Mode, stop. Ask the user to resolve the physical issue,
+  power-cycle, then retry status. Use `clear-error --execute` only after the
+  underlying cause is fixed.
+- If setup succeeds, do not imply that live printing is validated. Say that LAN
+  connectivity is configured and status works; live printing still requires the
+  real-printer checklist, a dry-run plan, upload-only, and supervised start.

--- a/.qwenpaw-plugin/skills/bambu-labs/references/real-printer-checklist.md
+++ b/.qwenpaw-plugin/skills/bambu-labs/references/real-printer-checklist.md
@@ -1,0 +1,56 @@
+# Real Printer Checklist
+
+Use this before any `--execute` run against a physical Bambu Lab printer.
+
+## Credentials And Network
+
+- Confirm the printer IP/hostname is on the trusted local network.
+- Confirm LAN Only/Developer Mode is enabled when the printer exposes it,
+  especially on A1/A1 Mini.
+- Store the access code in workspace-root `bambu-printers.json` with `config set`; do not
+  print it in final messages.
+- Fetch/cache serial with `serial` or `config set --fetch-serial`.
+- Run `status --push-all` and verify the intended printer responds.
+- If LAN settings changed after failed starts, clear stale errors and
+  power-cycle before retrying.
+
+## Job
+
+- Confirm `$gcode` generated and validated the plain `.gcode`.
+- Confirm scale, orientation, supports, material profile, nozzle, and bed type.
+- For A1 Mini LAN start, prefer `--handoff template-project` with a known-good
+  same-printer `.gcode.3mf` template.
+- Use `--handoff plain` only for diagnostics or firmware where `gcode_file` is
+  already validated.
+- Use `--handoff bambox-project` only when the exact printer/nozzle profile is
+  enabled by the script.
+- For project handoffs, upload to FTPS root and use `ftp:///<name>.gcode.3mf`.
+
+## Physical Printer
+
+If the current user request explicitly asks to print or start the job, treat that
+request as live-start authorization for this checklist. State these physical
+checks before the live command and proceed if automated validation and printer
+status are healthy. Ask for another confirmation only when the request intent is
+ambiguous or a validation/status check raises concern.
+
+- Build plate is installed, clear, clean, and appropriate for the material.
+- No failed-print remnants, loose tools, tape scraps, or debris are in the
+  printer.
+- Filament is loaded and appropriate for the sliced file.
+- Operator is nearby for heat-up, homing, and first-layer observation.
+- Camera or direct observation is available.
+
+## First Live Sequence
+
+1. Run the exact `send` command without `--execute` and inspect the plan.
+2. Run `send --action upload --execute` first.
+3. Check status/UI/storage if possible.
+4. Re-run the dry `send --action upload-start` plan.
+5. Run `send --action upload-start --execute --confirm-start-print` when the
+   user explicitly asked to print/start, or after confirmation when intent is
+   unclear.
+6. Poll status and watch the printer until the first layer is clearly normal.
+
+If status reports `print_error` or HMS after a failed attempt, stop. Resolve the
+cause, optionally run `clear-error --execute`, then poll status before retrying.

--- a/.qwenpaw-plugin/skills/bambu-labs/scripts/bambu_lan_print.py
+++ b/.qwenpaw-plugin/skills/bambu-labs/scripts/bambu_lan_print.py
@@ -1,0 +1,1783 @@
+#!/usr/bin/env python3
+"""Dry-run-first helpers for local Bambu Lab print workflows.
+
+The default behavior is non-networked. Start from a validated plain .gcode file,
+then either upload/start it directly with the printer's gcode_file command or,
+for explicitly supported printer profiles, package it with bambox into a
+.gcode.3mf project and start that with project_file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ftplib
+import hashlib
+import ipaddress
+import json
+import os
+import re
+import shutil
+import socket
+import ssl
+import subprocess
+import sys
+import tempfile
+import time
+import zipfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Union
+
+
+BAMBU_USERNAME = "bblp"
+DEFAULT_FTPS_PORT = 990
+DEFAULT_MQTT_PORT = 8883
+DEFAULT_REMOTE_DIR = "cache"
+PLATE_RE = re.compile(r"^Metadata/plate_(\d+)\.gcode$")
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+
+def default_workspace_root() -> Path:
+    init_cwd = str(os.environ.get("INIT_CWD") or "").strip()
+    return Path(init_cwd).expanduser().resolve() if init_cwd else Path.cwd().resolve()
+
+
+DEFAULT_CONFIG_PATH = default_workspace_root() / "bambu-printers.json"
+
+
+class BambuPrintError(RuntimeError):
+    """Raised for expected user-facing workflow errors."""
+
+
+@dataclass(frozen=True)
+class GCodeInspection:
+    path: str
+    size_bytes: int
+    md5: str
+
+
+@dataclass(frozen=True)
+class PlateInfo:
+    index: int
+    path: str
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class ProjectInspection:
+    path: str
+    size_bytes: int
+    md5: str
+    plates: list[PlateInfo]
+
+
+@dataclass(frozen=True)
+class BamboxProfile:
+    key: str
+    machine: str
+    nozzle_diameter: str
+    enabled: bool
+    reason: str
+    allowed_filaments: set[str]
+
+
+BAMBOX_PROFILES: dict[str, BamboxProfile] = {
+    "p1s-0.4": BamboxProfile(
+        key="p1s-0.4",
+        machine="p1s",
+        nozzle_diameter="0.4",
+        enabled=True,
+        reason="bambox 0.5.0 bundles and hardware-validates the Bambu Lab P1S 0.4 profile.",
+        allowed_filaments={"PLA", "ASA", "PETG-CF"},
+    ),
+    "a1-mini-0.4": BamboxProfile(
+        key="a1-mini-0.4",
+        machine="a1-mini",
+        nozzle_diameter="0.4",
+        enabled=False,
+        reason="no validated bambox A1 Mini profile is present.",
+        allowed_filaments=set(),
+    ),
+    "a1-0.4": BamboxProfile(
+        key="a1-0.4",
+        machine="a1",
+        nozzle_diameter="0.4",
+        enabled=False,
+        reason="no validated bambox A1 profile is present.",
+        allowed_filaments=set(),
+    ),
+    "x1c-0.4": BamboxProfile(
+        key="x1c-0.4",
+        machine="x1c",
+        nozzle_diameter="0.4",
+        enabled=False,
+        reason="no validated bambox X1C profile is present.",
+        allowed_filaments=set(),
+    ),
+    "p1p-0.4": BamboxProfile(
+        key="p1p-0.4",
+        machine="p1p",
+        nozzle_diameter="0.4",
+        enabled=False,
+        reason="no validated bambox P1P profile is present.",
+        allowed_filaments=set(),
+    ),
+}
+
+
+class ImplicitFTP_TLS(ftplib.FTP_TLS):
+    """FTP_TLS variant for implicit FTPS servers such as Bambu printers."""
+
+    def connect(self, host: str = "", port: int = 0, timeout: float | None = -999, source_address=None):
+        if host:
+            self.host = host
+        if port:
+            self.port = port
+        if timeout != -999:
+            self.timeout = timeout
+        if source_address is not None:
+            self.source_address = source_address
+        raw_sock = socket.create_connection(
+            (self.host, self.port),
+            self.timeout,
+            source_address=self.source_address,
+        )
+        self.af = raw_sock.family
+        self.sock = self.context.wrap_socket(raw_sock, server_hostname=self.host)
+        self.file = self.sock.makefile("r", encoding=self.encoding)
+        self.welcome = self.getresp()
+        return self.welcome
+
+    def ntransfercmd(self, cmd: str, rest: Any = None):
+        conn, size = ftplib.FTP.ntransfercmd(self, cmd, rest)
+        if self._prot_p:
+            conn = self.context.wrap_socket(conn, server_hostname=self.host, session=self.sock.session)
+        return conn, size
+
+
+def config_path_from_args(args: argparse.Namespace) -> Path:
+    return Path(getattr(args, "config", None) or DEFAULT_CONFIG_PATH).expanduser().resolve()
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {"printers": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise BambuPrintError(f"Printer config is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise BambuPrintError(f"Printer config must be a JSON object: {path}")
+    printers = data.setdefault("printers", {})
+    if not isinstance(printers, dict):
+        raise BambuPrintError("Printer config field printers must be an object.")
+    return data
+
+
+def save_config(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def sanitized_printer_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in entry.items() if key != "access_code"}
+
+
+def printer_entry(data: dict[str, Any], printer_id: str) -> dict[str, Any]:
+    printers = data.get("printers", {})
+    entry = printers.get(printer_id)
+    if not isinstance(entry, dict):
+        known = ", ".join(sorted(printers)) or "<none>"
+        raise BambuPrintError(f"Printer {printer_id!r} is not configured. Known printers: {known}")
+    return entry
+
+
+def apply_printer_config(args: argparse.Namespace) -> None:
+    printer_id = getattr(args, "printer", "") or ""
+    if not printer_id:
+        return
+    data = load_config(config_path_from_args(args))
+    entry = printer_entry(data, printer_id)
+    for attr, key in (
+        ("host", "host"),
+        ("access_code", "access_code"),
+        ("serial", "serial"),
+        ("model", "model"),
+    ):
+        if hasattr(args, attr) and not getattr(args, attr, "") and entry.get(key):
+            setattr(args, attr, str(entry[key]))
+
+
+def cache_printer_serial(args: argparse.Namespace, serial: str) -> None:
+    printer_id = getattr(args, "printer", "") or ""
+    if not printer_id:
+        return
+    path = config_path_from_args(args)
+    data = load_config(path)
+    entry = printer_entry(data, printer_id)
+    if entry.get("serial") == serial:
+        return
+    entry["serial"] = serial
+    entry["serial_source"] = "printer_tls_certificate_common_name"
+    entry["updated_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    save_config(path, data)
+
+
+def md5_and_size(path: Path) -> tuple[str, int]:
+    digest = hashlib.md5()
+    size = 0
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            size += len(chunk)
+            digest.update(chunk)
+    return digest.hexdigest(), size
+
+
+def inspect_gcode_file(path: Path) -> GCodeInspection:
+    if not path.is_file():
+        raise BambuPrintError(f"G-code input file does not exist: {path}")
+    name = path.name.lower()
+    if name.endswith(".gcode.3mf") or path.suffix.lower() == ".3mf":
+        raise BambuPrintError("Expected plain .gcode, not a Bambu .gcode.3mf or .3mf archive.")
+    if path.suffix.lower() != ".gcode":
+        raise BambuPrintError(f"Expected a plain .gcode input, got: {path.name}")
+    md5, size = md5_and_size(path)
+    if size == 0:
+        raise BambuPrintError(f"G-code input is empty: {path}")
+    return GCodeInspection(path=str(path), size_bytes=size, md5=md5)
+
+
+def inspect_sliced_3mf(path: Path) -> ProjectInspection:
+    if not path.is_file():
+        raise BambuPrintError(f"Packaged project file does not exist: {path}")
+
+    md5, size = md5_and_size(path)
+    try:
+        archive = zipfile.ZipFile(path)
+    except zipfile.BadZipFile as exc:
+        raise BambuPrintError(f"Packaged project is not a readable 3MF/ZIP archive: {path}") from exc
+
+    plates: list[PlateInfo] = []
+    with archive:
+        for info in archive.infolist():
+            match = PLATE_RE.match(info.filename)
+            if match:
+                plates.append(
+                    PlateInfo(
+                        index=int(match.group(1)),
+                        path=info.filename,
+                        size_bytes=info.file_size,
+                    )
+                )
+
+    if not plates:
+        raise BambuPrintError("Packaged project has no Metadata/plate_N.gcode entries.")
+
+    plates.sort(key=lambda item: item.index)
+    return ProjectInspection(path=str(path), size_bytes=size, md5=md5, plates=plates)
+
+
+def sanitize_remote_name(name: str) -> str:
+    base = Path(name).name.strip()
+    if not base:
+        raise BambuPrintError("Remote filename cannot be empty.")
+    return re.sub(r"[^A-Za-z0-9._+-]", "_", base)
+
+
+def join_remote_path(remote_dir: str, remote_name: str) -> str:
+    clean_dir = remote_dir.strip("/")
+    clean_name = sanitize_remote_name(remote_name)
+    return f"{clean_dir}/{clean_name}" if clean_dir else clean_name
+
+
+def default_project_name(gcode_path: Path) -> str:
+    if gcode_path.name.lower().endswith(".gcode"):
+        return f"{gcode_path.name}.3mf"
+    return f"{gcode_path.name}.gcode.3mf"
+
+
+def project_subtask_name(remote_path: str) -> str:
+    name = Path(remote_path).name
+    for suffix in (".gcode.3mf", ".3mf", ".gcode"):
+        if name.lower().endswith(suffix):
+            name = name[: -len(suffix)]
+    return name or "local_print"
+
+
+def is_local_address(address: IPAddress) -> bool:
+    return address.is_private or address.is_loopback or address.is_link_local
+
+
+def resolve_host_addresses(host: str) -> list[IPAddress]:
+    clean_host = host.strip("[]")
+    try:
+        return [ipaddress.ip_address(clean_host)]
+    except ValueError:
+        pass
+
+    try:
+        results = socket.getaddrinfo(clean_host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise BambuPrintError(f"Could not resolve printer host {host!r}: {exc}") from exc
+
+    addresses = sorted({ipaddress.ip_address(item[4][0]) for item in results}, key=str)
+    if not addresses:
+        raise BambuPrintError(f"Could not resolve printer host {host!r}.")
+    return addresses
+
+
+def validate_local_host(host: str, allow_nonprivate: bool) -> None:
+    if not host:
+        raise BambuPrintError("Printer host/IP is required for network actions.")
+    if allow_nonprivate:
+        return
+
+    addresses = resolve_host_addresses(host)
+    nonprivate = [str(address) for address in addresses if not is_local_address(address)]
+    if nonprivate:
+        raise BambuPrintError(
+            f"{host} resolves to non-private address(es): {', '.join(nonprivate)}. "
+            "Refusing unless --allow-nonprivate-host is set."
+        )
+
+
+def common_name_from_decoded_cert(decoded: dict[str, Any]) -> str:
+    for subject_item in decoded.get("subject", ()):
+        for key, value in subject_item:
+            if key == "commonName":
+                return str(value)
+    return ""
+
+
+def decode_der_certificate(der_cert: bytes) -> dict[str, Any]:
+    pem = ssl.DER_cert_to_PEM_cert(der_cert)
+    temp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".pem", delete=False) as handle:
+            temp_path = handle.name
+            handle.write(pem)
+        return ssl._ssl._test_decode_cert(temp_path)  # type: ignore[attr-defined]
+    finally:
+        if temp_path:
+            try:
+                Path(temp_path).unlink()
+            except FileNotFoundError:
+                pass
+
+
+def discover_printer_serial(
+    *,
+    host: str,
+    port: int = DEFAULT_MQTT_PORT,
+    timeout: float = 20.0,
+    tls_verify: bool = False,
+    allow_nonprivate_host: bool = False,
+) -> str:
+    validate_local_host(host, allow_nonprivate_host)
+    context = ssl.create_default_context()
+    if not tls_verify:
+        # Bambu printer firmware serves self-signed LAN certificates; validate_local_host()
+        # above restricts this to private/loopback/link-local hosts, so disabling verification
+        # here only trusts the printer's subnet, not its actual certificate.
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    with socket.create_connection((host, port), timeout=timeout) as raw_sock:
+        with context.wrap_socket(raw_sock, server_hostname=host) as sock:
+            der_cert = sock.getpeercert(binary_form=True)
+    if not der_cert:
+        raise BambuPrintError("Printer did not provide a TLS certificate for serial discovery.")
+    serial = common_name_from_decoded_cert(decode_der_certificate(der_cert)).strip()
+    if not serial:
+        raise BambuPrintError("Could not find printer serial in the local TLS certificate common name.")
+    return serial
+
+
+def ensure_printer_serial(args: argparse.Namespace) -> str:
+    if getattr(args, "serial", ""):
+        return args.serial
+    if not getattr(args, "host", ""):
+        return ""
+    args.serial = discover_printer_serial(
+        host=args.host,
+        port=args.mqtt_port,
+        timeout=args.timeout,
+        tls_verify=args.tls_verify,
+        allow_nonprivate_host=args.allow_nonprivate_host,
+    )
+    cache_printer_serial(args, args.serial)
+    return args.serial
+
+
+def selected_plate(inspection: ProjectInspection, requested: int | None) -> PlateInfo:
+    if requested is None:
+        return inspection.plates[0]
+    for plate in inspection.plates:
+        if plate.index == requested:
+            return plate
+    available = ", ".join(str(plate.index) for plate in inspection.plates)
+    raise BambuPrintError(f"Plate {requested} not found. Available plates: {available}")
+
+
+def sequence_id(value: str | None) -> str:
+    if value:
+        return value
+    return str(int(time.time() * 1000))
+
+
+def build_gcode_file_payload(*, remote_path: str, args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "print": {
+            "sequence_id": sequence_id(args.sequence_id),
+            "command": "gcode_file",
+            "param": args.gcode_param or remote_path,
+        }
+    }
+
+
+def build_clean_print_error_payload(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "print": {
+            "sequence_id": sequence_id(args.sequence_id),
+            "command": "clean_print_error",
+        }
+    }
+
+
+def build_print_control_payload(args: argparse.Namespace) -> dict[str, Any]:
+    command = "stop" if args.action == "cancel" else args.action
+    payload = {
+        "print": {
+            "sequence_id": sequence_id(args.sequence_id),
+            "command": command,
+        }
+    }
+    if command == "stop":
+        payload["print"]["param"] = ""
+    return payload
+
+
+def build_project_file_payload(
+    *,
+    plate: PlateInfo,
+    remote_path: str,
+    remote_url: str,
+    md5: str | None,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    return {
+        "print": {
+            "sequence_id": sequence_id(args.sequence_id),
+            "command": "project_file",
+            "param": plate.path,
+            "project_id": "0",
+            "profile_id": "0",
+            "task_id": "0",
+            "subtask_id": "0",
+            "subtask_name": project_subtask_name(remote_path),
+            "url": remote_url,
+            "md5": md5.upper() if md5 else None,
+            "timelapse": False,
+            "bed_type": "auto",
+            "bed_levelling": True,
+            "flow_cali": True,
+            "vibration_cali": False,
+            "layer_inspect": True,
+            "use_ams": False,
+            "ams_mapping": "",
+        }
+    }
+
+
+def bambox_profile(profile_key: str) -> BamboxProfile:
+    try:
+        profile = BAMBOX_PROFILES[profile_key]
+    except KeyError as exc:
+        known = ", ".join(sorted(BAMBOX_PROFILES))
+        raise BambuPrintError(f"Unknown bambox profile {profile_key!r}. Known profiles: {known}") from exc
+    if not profile.enabled:
+        raise BambuPrintError(f"{profile.key} is not enabled because {profile.reason}")
+    return profile
+
+
+def bambox_profile_payload(profile: BamboxProfile) -> dict[str, Any]:
+    return {
+        "key": profile.key,
+        "machine": profile.machine,
+        "nozzle_diameter": profile.nozzle_diameter,
+        "enabled": profile.enabled,
+        "reason": profile.reason,
+        "allowed_filaments": sorted(profile.allowed_filaments),
+    }
+
+
+def bambox_filament_type(spec: str) -> str:
+    parts = spec.split(":")
+    if len(parts) >= 2 and parts[0].isdigit():
+        value = parts[1]
+    else:
+        value = parts[0]
+    return value.strip().upper()
+
+
+def validate_bambox_filaments(profile: BamboxProfile, filaments: list[str] | None) -> list[str]:
+    if not filaments:
+        raise BambuPrintError("At least one --filament is required for bambox packaging.")
+    for spec in filaments:
+        filament_type = bambox_filament_type(spec)
+        if filament_type not in profile.allowed_filaments:
+            allowed = ", ".join(sorted(profile.allowed_filaments))
+            raise BambuPrintError(
+                f"Filament {filament_type!r} is not enabled for {profile.key}. Allowed filaments: {allowed}"
+            )
+    return filaments
+
+
+def resolve_bambox_bin(requested: str | None, *, require_exists: bool) -> str:
+    candidate = requested or os.environ.get("BAMBOX_BIN") or "bambox"
+    if not require_exists:
+        return candidate
+    resolved = shutil.which(candidate) if Path(candidate).name == candidate else candidate
+    if not resolved or not Path(resolved).exists():
+        raise BambuPrintError("bambox CLI was not found. Install it separately or set BAMBOX_BIN.")
+    return resolved
+
+
+def build_bambox_pack_command(
+    *,
+    gcode_path: Path,
+    output_path: Path,
+    profile_key: str,
+    filaments: list[str] | None,
+    bambox_bin: str | None = None,
+    require_bambox: bool = False,
+) -> list[str]:
+    profile = bambox_profile(profile_key)
+    safe_filaments = validate_bambox_filaments(profile, filaments)
+    command = [
+        resolve_bambox_bin(bambox_bin, require_exists=require_bambox),
+        "pack",
+        str(gcode_path),
+        "-o",
+        str(output_path),
+        "-m",
+        profile.machine,
+        "--nozzle-diameter",
+        profile.nozzle_diameter,
+    ]
+    for filament in safe_filaments:
+        command.extend(["-f", filament])
+    return command
+
+
+def build_bambox_validate_command(*, project_path: Path, bambox_bin: str | None = None, require_bambox: bool = False) -> list[str]:
+    return [
+        resolve_bambox_bin(bambox_bin, require_exists=require_bambox),
+        "validate",
+        str(project_path),
+        "--json",
+        "--strict",
+    ]
+
+
+def run_checked_command(command: list[str], label: str) -> dict[str, Any]:
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    payload: dict[str, Any] = {"command": command, "returncode": result.returncode}
+    if result.stdout:
+        payload["stdout_tail"] = tail_text(result.stdout)
+    if result.stderr:
+        payload["stderr_tail"] = tail_text(result.stderr)
+    if result.returncode != 0:
+        raise BambuPrintError(f"{label} failed: {json.dumps(payload, indent=2)}")
+    return payload
+
+
+def package_with_bambox(args: argparse.Namespace, output_path: Path) -> dict[str, Any]:
+    gcode_path = Path(args.gcode).expanduser().resolve()
+    inspect_gcode_file(gcode_path)
+    pack_command = build_bambox_pack_command(
+        gcode_path=gcode_path,
+        output_path=output_path,
+        profile_key=args.bambox_profile,
+        filaments=args.filament,
+        bambox_bin=args.bambox_bin,
+        require_bambox=True,
+    )
+    validate_command = build_bambox_validate_command(
+        project_path=output_path,
+        bambox_bin=args.bambox_bin,
+        require_bambox=True,
+    )
+    pack_result = run_checked_command(pack_command, "bambox pack")
+    if not output_path.is_file():
+        raise BambuPrintError(f"bambox pack did not create expected output: {output_path}")
+    project_inspection = inspect_sliced_3mf(output_path)
+    validate_result = run_checked_command(validate_command, "bambox validate")
+    return {
+        "pack": pack_result,
+        "validate": validate_result,
+        "project": asdict(project_inspection),
+    }
+
+
+def package_with_template_project(args: argparse.Namespace, output_path: Path) -> dict[str, Any]:
+    gcode_path = Path(args.gcode).expanduser().resolve()
+    inspection = inspect_gcode_file(gcode_path)
+    if not args.template_project:
+        raise BambuPrintError("--template-project is required for template-project packaging.")
+    template_path = Path(args.template_project).expanduser().resolve()
+    template_inspection = inspect_sliced_3mf(template_path)
+    plate = selected_plate(template_inspection, args.plate)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    gcode_bytes = gcode_path.read_bytes()
+    gcode_md5 = hashlib.md5(gcode_bytes).hexdigest().upper()
+    md5_path = f"{plate.path}.md5"
+    found_plate = False
+    found_md5 = False
+
+    with zipfile.ZipFile(template_path, "r") as source, zipfile.ZipFile(
+        output_path, "w", compression=zipfile.ZIP_DEFLATED
+    ) as target:
+        for info in source.infolist():
+            data = source.read(info.filename)
+            if info.filename == plate.path:
+                data = gcode_bytes
+                found_plate = True
+            elif info.filename == md5_path:
+                data = gcode_md5.encode("ascii")
+                found_md5 = True
+            target.writestr(info, data)
+        if not found_md5:
+            target.writestr(md5_path, gcode_md5)
+
+    if not found_plate:
+        raise BambuPrintError(f"Template project plate G-code entry not found: {plate.path}")
+
+    project_inspection = inspect_sliced_3mf(output_path)
+    return {
+        "pack": {
+            "template": str(template_path),
+            "output": str(output_path),
+            "replaced_plate": plate.path,
+            "plate_gcode_md5": gcode_md5,
+            "input": asdict(inspection),
+        },
+        "project": asdict(project_inspection),
+    }
+
+
+def build_package_plan(args: argparse.Namespace) -> dict[str, Any]:
+    gcode_path = Path(args.gcode).expanduser().resolve()
+    inspection = inspect_gcode_file(gcode_path)
+    output_path = Path(args.output).expanduser().resolve()
+    pack_command = build_bambox_pack_command(
+        gcode_path=gcode_path,
+        output_path=output_path,
+        profile_key=args.bambox_profile,
+        filaments=args.filament,
+        bambox_bin=args.bambox_bin,
+        require_bambox=False,
+    )
+    validate_command = build_bambox_validate_command(
+        project_path=output_path,
+        bambox_bin=args.bambox_bin,
+        require_bambox=False,
+    )
+    return {
+        "dry_run": not args.execute,
+        "action": "package",
+        "input": asdict(inspection),
+        "output": str(output_path),
+        "bambox": {
+            "profile": bambox_profile_payload(bambox_profile(args.bambox_profile)),
+            "filaments": args.filament,
+            "pack_command": pack_command,
+            "validate_command": validate_command,
+        },
+        "notes": [
+            "bambox is optional and must be installed separately.",
+            "Only enabled bambox profiles can be packaged.",
+            "A1 Mini is intentionally disabled until a validated bambox profile is available.",
+        ],
+    }
+
+
+def build_plain_send_plan(args: argparse.Namespace) -> dict[str, Any]:
+    gcode_path = Path(args.gcode).expanduser().resolve()
+    inspection = inspect_gcode_file(gcode_path)
+    remote_name = sanitize_remote_name(args.remote_name or gcode_path.name)
+    remote_path = join_remote_path(args.remote_dir or DEFAULT_REMOTE_DIR, remote_name)
+    payload = build_gcode_file_payload(remote_path=remote_path, args=args)
+    return build_common_send_plan(
+        args=args,
+        input_payload={**asdict(inspection), "kind": "plain_gcode"},
+        local_path=str(gcode_path),
+        remote_path=remote_path,
+        remote_url=None,
+        payload=payload,
+    )
+
+
+def build_bambox_project_send_plan(args: argparse.Namespace, project_path: Path | None = None) -> dict[str, Any]:
+    gcode_path = Path(args.gcode).expanduser().resolve()
+    inspection = inspect_gcode_file(gcode_path)
+    remote_name = sanitize_remote_name(args.remote_name or default_project_name(gcode_path))
+    remote_path = join_remote_path(args.remote_dir or "", remote_name)
+    remote_url = f"ftp:///{remote_path}"
+    output_path = project_path or Path(tempfile.gettempdir()) / default_project_name(gcode_path)
+    pack_command = build_bambox_pack_command(
+        gcode_path=gcode_path,
+        output_path=output_path,
+        profile_key=args.bambox_profile,
+        filaments=args.filament,
+        bambox_bin=args.bambox_bin,
+        require_bambox=False,
+    )
+    validate_command = build_bambox_validate_command(
+        project_path=output_path,
+        bambox_bin=args.bambox_bin,
+        require_bambox=False,
+    )
+
+    project: dict[str, Any] | None = None
+    payload: dict[str, Any]
+    if project_path is not None:
+        project_inspection = inspect_sliced_3mf(project_path)
+        plate = selected_plate(project_inspection, args.plate)
+        project = {**asdict(project_inspection), "selected_plate": asdict(plate)}
+        payload = build_project_file_payload(
+            plate=plate,
+            remote_path=remote_path,
+            remote_url=remote_url,
+            md5=project_inspection.md5,
+            args=args,
+        )
+    else:
+        payload = build_project_file_payload(
+            plate=PlateInfo(index=1, path="Metadata/plate_1.gcode", size_bytes=0),
+            remote_path=remote_path,
+            remote_url=remote_url,
+            md5=None,
+            args=args,
+        )
+
+    return build_common_send_plan(
+        args=args,
+        input_payload={
+            **asdict(inspection),
+            "kind": "plain_gcode",
+            "bambox_project": project,
+            "bambox": {
+                "profile": bambox_profile_payload(bambox_profile(args.bambox_profile)),
+                "filaments": args.filament,
+                "pack_command": pack_command,
+                "validate_command": validate_command,
+            },
+        },
+        local_path=str(project_path) if project_path is not None else None,
+        remote_path=remote_path,
+        remote_url=remote_url,
+        payload=payload,
+    )
+
+
+def build_template_project_send_plan(args: argparse.Namespace, project_path: Path | None = None) -> dict[str, Any]:
+    gcode_path = Path(args.gcode).expanduser().resolve()
+    inspection = inspect_gcode_file(gcode_path)
+    template_path = Path(args.template_project).expanduser().resolve() if args.template_project else None
+    if template_path is None:
+        raise BambuPrintError("--template-project is required for --handoff template-project.")
+    inspect_sliced_3mf(template_path)
+    remote_name = sanitize_remote_name(args.remote_name or default_project_name(gcode_path))
+    remote_path = join_remote_path(args.remote_dir or "", remote_name)
+    remote_url = f"ftp:///{remote_path}"
+    output_path = project_path or Path(tempfile.gettempdir()) / default_project_name(gcode_path)
+
+    project: dict[str, Any] | None = None
+    if project_path is not None:
+        project_inspection = inspect_sliced_3mf(project_path)
+        plate = selected_plate(project_inspection, args.plate)
+        project = {**asdict(project_inspection), "selected_plate": asdict(plate)}
+        payload = build_project_file_payload(
+            plate=plate,
+            remote_path=remote_path,
+            remote_url=remote_url,
+            md5=project_inspection.md5,
+            args=args,
+        )
+    else:
+        payload = build_project_file_payload(
+            plate=PlateInfo(index=1, path="Metadata/plate_1.gcode", size_bytes=0),
+            remote_path=remote_path,
+            remote_url=remote_url,
+            md5=None,
+            args=args,
+        )
+
+    return build_common_send_plan(
+        args=args,
+        input_payload={
+            **asdict(inspection),
+            "kind": "plain_gcode",
+            "template_project": {
+                "template": str(template_path),
+                "output": str(output_path),
+                "packaged_project": project,
+                "note": "Experimental A1/A1 Mini path: replaces Metadata/plate_1.gcode in a same-printer template project.",
+            },
+        },
+        local_path=str(project_path) if project_path is not None else None,
+        remote_path=remote_path,
+        remote_url=remote_url,
+        payload=payload,
+    )
+
+
+def build_common_send_plan(
+    *,
+    args: argparse.Namespace,
+    input_payload: dict[str, Any],
+    local_path: str | None,
+    remote_path: str,
+    remote_url: str | None,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    serial = getattr(args, "serial", "") or ""
+    topic = f"device/{serial}/request" if serial else None
+    will_upload = args.action in {"upload", "upload-start"}
+    will_publish = args.action in {"start", "upload-start"}
+
+    ftps: dict[str, Any] = {
+        "host": args.host,
+        "port": args.ftps_port,
+        "username": BAMBU_USERNAME,
+        "remote_path": remote_path,
+        "will_upload": will_upload,
+    }
+    if remote_url:
+        ftps["url"] = remote_url
+
+    return {
+        "dry_run": not args.execute,
+        "action": args.action,
+        "handoff": args.handoff,
+        "input": input_payload,
+        "local_upload_path": local_path,
+        "ftps": ftps,
+        "mqtt": {
+            "host": args.host,
+            "port": args.mqtt_port,
+            "username": BAMBU_USERNAME,
+            "topic": topic,
+            "payload": payload,
+            "will_publish": will_publish,
+        },
+        "safety": [
+            "Dry-run is the default; network actions require --execute.",
+            "Starting a print requires --confirm-start-print.",
+            "MQTT start publishes a request only; watch the printer UI/state for acceptance and progress.",
+            "Verify the build plate is clear, filament/path are correct, and the printer is physically safe before execution.",
+        ],
+    }
+
+
+def build_clear_error_plan(args: argparse.Namespace) -> dict[str, Any]:
+    serial = getattr(args, "serial", "") or ""
+    topic = f"device/{serial}/request" if serial else None
+    return {
+        "dry_run": not args.execute,
+        "action": "clear-error",
+        "printer": args.printer or None,
+        "host": args.host,
+        "mqtt": {
+            "host": args.host,
+            "port": args.mqtt_port,
+            "username": BAMBU_USERNAME,
+            "topic": topic,
+            "payload": build_clean_print_error_payload(args),
+            "will_publish": bool(args.execute),
+        },
+        "notes": [
+            "This publishes clean_print_error only; it does not upload files or start a print.",
+            "Use after resolving the underlying cause of a stale printer error, then read status before retrying.",
+        ],
+    }
+
+
+def build_print_control_plan(args: argparse.Namespace) -> dict[str, Any]:
+    serial = getattr(args, "serial", "") or ""
+    topic = f"device/{serial}/request" if serial else None
+    return {
+        "dry_run": not args.execute,
+        "action": args.action,
+        "printer": args.printer or None,
+        "host": args.host,
+        "mqtt": {
+            "host": args.host,
+            "port": args.mqtt_port,
+            "username": BAMBU_USERNAME,
+            "topic": topic,
+            "payload": build_print_control_payload(args),
+            "will_publish": bool(args.execute),
+        },
+        "notes": [
+            "This publishes a print-control request only; it does not upload files or start a print.",
+            "Read printer status after publishing to confirm the state changed as intended.",
+        ],
+    }
+
+
+def build_send_plan(args: argparse.Namespace, project_path: Path | None = None) -> dict[str, Any]:
+    apply_printer_config(args)
+    if args.handoff == "plain":
+        return build_plain_send_plan(args)
+    if args.handoff == "bambox-project":
+        return build_bambox_project_send_plan(args, project_path=project_path)
+    if args.handoff == "template-project":
+        return build_template_project_send_plan(args, project_path=project_path)
+    raise BambuPrintError(f"Unsupported handoff: {args.handoff}")
+
+
+def upload_ftps(args: argparse.Namespace, local_path: Path, remote_path: str) -> None:
+    access_code = access_code_from_args(args)
+    validate_local_host(args.host, args.allow_nonprivate_host)
+    context = ssl.create_default_context()
+    if not args.tls_verify:
+        # Bambu printer firmware serves self-signed LAN certificates; validate_local_host()
+        # above restricts this to private/loopback/link-local hosts, so disabling verification
+        # here only trusts the printer's subnet, not its actual certificate.
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    ftp = ImplicitFTP_TLS(context=context, timeout=args.timeout)
+    ftp.connect(args.host, args.ftps_port)
+    try:
+        ftp.login(BAMBU_USERNAME, access_code)
+        ftp.prot_p()
+        remote_dir = remote_path.rsplit("/", 1)[0] if "/" in remote_path else ""
+        remote_name = Path(remote_path).name
+        if remote_dir:
+            try:
+                ftp.cwd(remote_dir)
+            except ftplib.error_perm:
+                ftp.mkd(remote_dir)
+                ftp.cwd(remote_dir)
+        with local_path.open("rb") as handle:
+            storbinary_with_bambu_timeout_tolerance(ftp, f"STOR {remote_name}", handle)
+    finally:
+        try:
+            ftp.quit()
+        except Exception:
+            ftp.close()
+
+
+def storbinary_with_bambu_timeout_tolerance(ftp: ftplib.FTP_TLS, command: str, handle: Any) -> None:
+    try:
+        ftp.storbinary(command, handle)
+    except socket.timeout as exc:
+        try:
+            ftp.voidresp()
+        except Exception as confirm_exc:
+            raise BambuPrintError(
+                "FTPS upload timed out before the printer confirmed completion. "
+                "The file may be partially uploaded; retry upload-only after checking printer storage."
+            ) from confirm_exc
+        # Some Bambu FTPS firmware completes STOR but does not close the TLS data
+        # channel the way Python's ftplib expects. A 226 control response is enough.
+
+
+def encode_mqtt_string(value: str) -> bytes:
+    encoded = value.encode("utf-8")
+    if len(encoded) > 65535:
+        raise BambuPrintError("MQTT string is too long.")
+    return len(encoded).to_bytes(2, "big") + encoded
+
+
+def encode_remaining_length(length: int) -> bytes:
+    out = bytearray()
+    while True:
+        byte = length % 128
+        length //= 128
+        if length:
+            byte |= 0x80
+        out.append(byte)
+        if not length:
+            return bytes(out)
+
+
+def read_exact(sock: ssl.SSLSocket, size: int) -> bytes:
+    chunks = bytearray()
+    while len(chunks) < size:
+        chunk = sock.recv(size - len(chunks))
+        if not chunk:
+            raise BambuPrintError("MQTT connection closed unexpectedly.")
+        chunks.extend(chunk)
+    return bytes(chunks)
+
+
+def read_mqtt_packet(sock: ssl.SSLSocket) -> tuple[int, bytes]:
+    header = read_exact(sock, 1)[0]
+    multiplier = 1
+    remaining = 0
+    while True:
+        digit = read_exact(sock, 1)[0]
+        remaining += (digit & 127) * multiplier
+        if not digit & 128:
+            break
+        multiplier *= 128
+        if multiplier > 128 * 128 * 128:
+            raise BambuPrintError("Malformed MQTT remaining length.")
+    return header, read_exact(sock, remaining)
+
+
+def mqtt_connect_packet(client_id: str, username: str, password: str, keepalive: int = 30) -> bytes:
+    variable = encode_mqtt_string("MQTT") + bytes([4, 0xC2]) + keepalive.to_bytes(2, "big")
+    payload = encode_mqtt_string(client_id) + encode_mqtt_string(username) + encode_mqtt_string(password)
+    remaining = variable + payload
+    return bytes([0x10]) + encode_remaining_length(len(remaining)) + remaining
+
+
+def mqtt_publish_packet(topic: str, payload: bytes, *, qos: int = 0, packet_id: int = 1) -> bytes:
+    if qos not in {0, 1}:
+        raise BambuPrintError("Only MQTT QoS 0 and QoS 1 are supported.")
+    variable = encode_mqtt_string(topic)
+    if qos:
+        variable += packet_id.to_bytes(2, "big")
+    remaining = variable + payload
+    return bytes([0x30 | (qos << 1)]) + encode_remaining_length(len(remaining)) + remaining
+
+
+def mqtt_subscribe_packet(packet_id: int, topic: str) -> bytes:
+    variable = packet_id.to_bytes(2, "big")
+    payload = encode_mqtt_string(topic) + bytes([0])
+    remaining = variable + payload
+    return bytes([0x82]) + encode_remaining_length(len(remaining)) + remaining
+
+
+def parse_mqtt_publish(header: int, body: bytes) -> tuple[str, bytes]:
+    if header & 0xF0 != 0x30:
+        raise BambuPrintError(f"Expected MQTT PUBLISH packet, got header=0x{header:02x}.")
+    if len(body) < 2:
+        raise BambuPrintError("Malformed MQTT PUBLISH packet.")
+    topic_length = int.from_bytes(body[:2], "big")
+    topic_start = 2
+    topic_end = topic_start + topic_length
+    topic = body[topic_start:topic_end].decode("utf-8", errors="replace")
+    payload_start = topic_end
+    qos = (header & 0x06) >> 1
+    if qos:
+        payload_start += 2
+    return topic, body[payload_start:]
+
+
+def format_hms_code(attr: Any, code: Any) -> str:
+    try:
+        attr_int = int(attr)
+        code_int = int(code)
+    except (TypeError, ValueError) as exc:
+        raise BambuPrintError("HMS attr/code values must be integers.") from exc
+    return f"{(attr_int >> 16) & 0xFFFF:04X}-{attr_int & 0xFFFF:04X}-{(code_int >> 16) & 0xFFFF:04X}-{code_int & 0xFFFF:04X}"
+
+
+def annotate_hms_codes(message: dict[str, Any]) -> None:
+    payload = message.get("json")
+    if not isinstance(payload, dict):
+        return
+    print_payload = payload.get("print")
+    if not isinstance(print_payload, dict):
+        return
+    hms_items = print_payload.get("hms")
+    if not isinstance(hms_items, list):
+        return
+    decoded: list[dict[str, Any]] = []
+    for item in hms_items:
+        if not isinstance(item, dict) or "attr" not in item or "code" not in item:
+            continue
+        decoded.append({**item, "hms_code": format_hms_code(item["attr"], item["code"])})
+    if decoded:
+        message["hms"] = decoded
+
+
+def mqtt_puback_packet(packet_id: int) -> bytes:
+    return bytes([0x40, 0x02]) + packet_id.to_bytes(2, "big")
+
+
+def read_mqtt_reports_until(
+    sock: ssl.SSLSocket,
+    *,
+    deadline: float,
+    timeout: float,
+    expected_puback_packet_id: int | None = None,
+    stop_after_puback: bool = False,
+) -> dict[str, Any]:
+    messages: list[dict[str, Any]] = []
+    puback_received = expected_puback_packet_id is None
+    while time.monotonic() < deadline:
+        sock.settimeout(max(0.1, min(timeout, deadline - time.monotonic())))
+        try:
+            header, body = read_mqtt_packet(sock)
+        except socket.timeout:
+            break
+        if header == 0x40:
+            packet_id = int.from_bytes(body[:2], "big") if len(body) >= 2 else None
+            if packet_id == expected_puback_packet_id:
+                puback_received = True
+                if stop_after_puback:
+                    break
+            continue
+        if header & 0xF0 != 0x30:
+            continue
+        message_topic, report_payload = parse_mqtt_publish(header, body)
+        text = report_payload.decode("utf-8", errors="replace")
+        item: dict[str, Any] = {"topic": message_topic, "payload": text}
+        try:
+            item["json"] = json.loads(text)
+        except json.JSONDecodeError:
+            pass
+        annotate_hms_codes(item)
+        messages.append(item)
+        qos = (header & 0x06) >> 1
+        if qos == 1:
+            topic_length = int.from_bytes(body[:2], "big")
+            publish_packet_id_start = 2 + topic_length
+            packet_id = int.from_bytes(body[publish_packet_id_start : publish_packet_id_start + 2], "big")
+            sock.sendall(mqtt_puback_packet(packet_id))
+    return {"puback_received": puback_received, "messages": messages}
+
+
+def publish_mqtt(
+    args: argparse.Namespace,
+    topic: str,
+    payload: dict[str, Any],
+    *,
+    report_topic: str | None = None,
+) -> dict[str, Any]:
+    access_code = access_code_from_args(args)
+    validate_local_host(args.host, args.allow_nonprivate_host)
+    context = ssl.create_default_context()
+    if not args.tls_verify:
+        # Bambu printer firmware serves self-signed LAN certificates; validate_local_host()
+        # above restricts this to private/loopback/link-local hosts, so disabling verification
+        # here only trusts the printer's subnet, not its actual certificate.
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    payload_bytes = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    client_id = args.client_id or args.serial or f"codex-bambu-{int(time.time())}"
+    raw_mqtt_qos = getattr(args, "mqtt_qos", 0)
+    if not isinstance(raw_mqtt_qos, (int, float, str)):
+        raw_mqtt_qos = 0
+    mqtt_qos = int(raw_mqtt_qos)
+    publish_packet_id = 2
+    raw_wait_after_publish = getattr(args, "wait_after_publish", 0.0)
+    if not isinstance(raw_wait_after_publish, (int, float, str)):
+        raw_wait_after_publish = 0.0
+    wait_after_publish = float(raw_wait_after_publish or 0.0)
+    diagnostics: dict[str, Any] = {
+        "qos": mqtt_qos,
+        "puback_required": mqtt_qos == 1,
+        "puback_received": mqtt_qos == 0,
+        "report_topic": report_topic if wait_after_publish and report_topic else None,
+        "messages": [],
+    }
+    with socket.create_connection((args.host, args.mqtt_port), timeout=args.timeout) as raw_sock:
+        with context.wrap_socket(raw_sock, server_hostname=args.host) as sock:
+            sock.sendall(mqtt_connect_packet(client_id, BAMBU_USERNAME, access_code))
+            header, body = read_mqtt_packet(sock)
+            if header != 0x20 or len(body) != 2 or body[1] != 0:
+                raise BambuPrintError(f"MQTT CONNACK failed: header=0x{header:02x} body={body.hex()}")
+            if wait_after_publish and report_topic:
+                sock.sendall(mqtt_subscribe_packet(1, report_topic))
+                header, body = read_mqtt_packet(sock)
+                if header != 0x90 or len(body) < 3 or body[-1] == 0x80:
+                    raise BambuPrintError(f"MQTT SUBACK failed: header=0x{header:02x} body={body.hex()}")
+            sock.sendall(mqtt_publish_packet(topic, payload_bytes, qos=mqtt_qos, packet_id=publish_packet_id))
+            if mqtt_qos == 1 or wait_after_publish:
+                wait_seconds = wait_after_publish if wait_after_publish else args.timeout
+                observed = read_mqtt_reports_until(
+                    sock,
+                    deadline=time.monotonic() + wait_seconds,
+                    timeout=args.timeout,
+                    expected_puback_packet_id=publish_packet_id if mqtt_qos == 1 else None,
+                    stop_after_puback=mqtt_qos == 1 and not wait_after_publish,
+                )
+                diagnostics.update(observed)
+            sock.sendall(bytes([0xE0, 0x00]))
+    return diagnostics
+
+
+def subscribe_mqtt_reports(
+    args: argparse.Namespace,
+    topic: str,
+    wait_seconds: float,
+    *,
+    push_all_topic: str | None = None,
+    max_messages: int = 1,
+) -> list[dict[str, Any]]:
+    access_code = access_code_from_args(args)
+    validate_local_host(args.host, args.allow_nonprivate_host)
+    context = ssl.create_default_context()
+    if not args.tls_verify:
+        # Bambu printer firmware serves self-signed LAN certificates; validate_local_host()
+        # above restricts this to private/loopback/link-local hosts, so disabling verification
+        # here only trusts the printer's subnet, not its actual certificate.
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    client_id = args.client_id or args.serial or f"codex-bambu-status-{int(time.time())}"
+    messages: list[dict[str, Any]] = []
+    deadline = time.monotonic() + wait_seconds
+    with socket.create_connection((args.host, args.mqtt_port), timeout=args.timeout) as raw_sock:
+        with context.wrap_socket(raw_sock, server_hostname=args.host) as sock:
+            sock.sendall(mqtt_connect_packet(client_id, BAMBU_USERNAME, access_code))
+            header, body = read_mqtt_packet(sock)
+            if header != 0x20 or len(body) != 2 or body[1] != 0:
+                raise BambuPrintError(f"MQTT CONNACK failed: header=0x{header:02x} body={body.hex()}")
+            sock.sendall(mqtt_subscribe_packet(1, topic))
+            header, body = read_mqtt_packet(sock)
+            if header != 0x90 or len(body) < 3 or body[-1] == 0x80:
+                raise BambuPrintError(f"MQTT SUBACK failed: header=0x{header:02x} body={body.hex()}")
+            if push_all_topic:
+                payload = {
+                    "pushing": {
+                        "sequence_id": sequence_id(args.sequence_id),
+                        "command": "pushall",
+                        "version": 1,
+                        "push_target": 1,
+                    }
+                }
+                sock.sendall(mqtt_publish_packet(push_all_topic, json.dumps(payload, separators=(",", ":")).encode()))
+            while time.monotonic() < deadline:
+                sock.settimeout(max(0.1, min(args.timeout, deadline - time.monotonic())))
+                try:
+                    header, body = read_mqtt_packet(sock)
+                except socket.timeout:
+                    break
+                if header & 0xF0 != 0x30:
+                    continue
+                message_topic, payload = parse_mqtt_publish(header, body)
+                text = payload.decode("utf-8", errors="replace")
+                item: dict[str, Any] = {"topic": message_topic, "payload": text}
+                try:
+                    item["json"] = json.loads(text)
+                except json.JSONDecodeError:
+                    pass
+                annotate_hms_codes(item)
+                messages.append(item)
+                if len(messages) >= max_messages:
+                    break
+                payload_json = item.get("json")
+                if (
+                    push_all_topic
+                    and isinstance(payload_json, dict)
+                    and isinstance(payload_json.get("print"), dict)
+                    and payload_json["print"].get("command") == "push_status"
+                    and payload_json["print"].get("msg") == 0
+                ):
+                    break
+            sock.sendall(bytes([0xE0, 0x00]))
+    return messages
+
+
+def access_code_from_args(args: argparse.Namespace) -> str:
+    access_code = args.access_code or ""
+    if not access_code:
+        raise BambuPrintError("Access code is required for --execute. Configure --printer with config set or pass --access-code.")
+    if set(access_code) == {"0"}:
+        raise BambuPrintError("Access code is all zeros; refresh the printer access code before execution.")
+    return access_code
+
+
+def tail_text(value: str, *, max_lines: int = 80) -> str:
+    lines = value.splitlines()
+    if len(lines) <= max_lines:
+        return value
+    return "\n".join(lines[-max_lines:])
+
+
+def package_main(args: argparse.Namespace) -> int:
+    plan = build_package_plan(args)
+    if not args.execute:
+        print(json.dumps(plan, indent=2))
+        return 0
+
+    output_path = Path(args.output).expanduser().resolve()
+    result = package_with_bambox(args, output_path)
+    plan["dry_run"] = False
+    plan["executed"] = ["bambox_pack", "bambox_validate"]
+    plan["result"] = result
+    print(json.dumps(plan, indent=2))
+    return 0
+
+
+def config_set_main(args: argparse.Namespace) -> int:
+    path = config_path_from_args(args)
+    data = load_config(path)
+    printers = data.setdefault("printers", {})
+    entry = printers.get(args.printer)
+    if not isinstance(entry, dict):
+        entry = {}
+        printers[args.printer] = entry
+    if args.host:
+        entry["host"] = args.host
+    if args.access_code:
+        entry["access_code"] = args.access_code
+    if args.model:
+        entry["model"] = args.model
+    if args.notes:
+        entry["notes"] = args.notes
+    serial = args.serial or ""
+    if args.fetch_serial:
+        host = args.host or str(entry.get("host") or "")
+        if not host:
+            raise BambuPrintError("Cannot fetch serial without --host or an existing host in the printer config.")
+        serial = discover_printer_serial(
+            host=host,
+            port=args.mqtt_port,
+            timeout=args.timeout,
+            tls_verify=args.tls_verify,
+            allow_nonprivate_host=args.allow_nonprivate_host,
+        )
+        entry["serial_source"] = "printer_tls_certificate_common_name"
+    if serial:
+        entry["serial"] = serial
+    entry["updated_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    save_config(path, data)
+    print(json.dumps({"ok": True, "config": str(path), "printer": args.printer, "entry": sanitized_printer_entry(entry)}, indent=2))
+    return 0
+
+
+def config_list_main(args: argparse.Namespace) -> int:
+    path = config_path_from_args(args)
+    data = load_config(path)
+    printers = data.get("printers", {})
+    payload = {
+        "config": str(path),
+        "printers": {printer_id: sanitized_printer_entry(entry) for printer_id, entry in sorted(printers.items())},
+    }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def config_show_main(args: argparse.Namespace) -> int:
+    path = config_path_from_args(args)
+    data = load_config(path)
+    entry = printer_entry(data, args.printer)
+    print(json.dumps({"config": str(path), "printer": args.printer, "entry": sanitized_printer_entry(entry)}, indent=2))
+    return 0
+
+
+def serial_main(args: argparse.Namespace) -> int:
+    apply_printer_config(args)
+    serial = discover_printer_serial(
+        host=args.host,
+        port=args.mqtt_port,
+        timeout=args.timeout,
+        tls_verify=args.tls_verify,
+        allow_nonprivate_host=args.allow_nonprivate_host,
+    )
+    args.serial = serial
+    cache_printer_serial(args, serial)
+    payload = {
+        "ok": True,
+        "printer": args.printer or None,
+        "host": args.host,
+        "config": str(config_path_from_args(args)) if args.printer else None,
+        "port": args.mqtt_port,
+        "serial": serial,
+        "source": "printer_tls_certificate_common_name",
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(serial)
+    return 0
+
+
+def status_main(args: argparse.Namespace) -> int:
+    apply_printer_config(args)
+    serial = ensure_printer_serial(args)
+    if not serial:
+        raise BambuPrintError("Printer serial is required for status; configure --printer or pass --serial.")
+    topic = args.topic or f"device/{serial}/report"
+    push_all_topic = f"device/{serial}/request" if args.push_all else None
+    messages = subscribe_mqtt_reports(
+        args,
+        topic,
+        args.wait_seconds,
+        push_all_topic=push_all_topic,
+        max_messages=args.max_messages,
+    )
+    payload = {
+        "ok": bool(messages),
+        "printer": args.printer or None,
+        "host": args.host,
+        "topic": topic,
+        "push_all_requested": bool(args.push_all),
+        "messages": messages,
+    }
+    if not messages:
+        payload["warning"] = f"No report message received within {args.wait_seconds:g} seconds."
+    print(json.dumps(payload, indent=2))
+    return 0 if messages else 1
+
+
+def clear_error_main(args: argparse.Namespace) -> int:
+    apply_printer_config(args)
+    if args.execute and not ensure_printer_serial(args):
+        raise BambuPrintError("Printer serial is required to publish clean_print_error.")
+    plan = build_clear_error_plan(args)
+    if not args.execute:
+        print(json.dumps(plan, indent=2))
+        return 0
+    publish_result = publish_mqtt(
+        args,
+        plan["mqtt"]["topic"],
+        plan["mqtt"]["payload"],
+        report_topic=f"device/{args.serial}/report" if getattr(args, "serial", "") else None,
+    )
+    plan["dry_run"] = False
+    plan["executed"] = ["publish_clean_print_error"]
+    plan["mqtt_publish_result"] = publish_result
+    print(json.dumps(plan, indent=2))
+    return 0
+
+
+def print_control_main(args: argparse.Namespace) -> int:
+    apply_printer_config(args)
+    if args.execute and args.action == "cancel" and not args.confirm_cancel_print:
+        raise BambuPrintError("Canceling a print requires --confirm-cancel-print.")
+    if args.execute and not ensure_printer_serial(args):
+        raise BambuPrintError("Printer serial is required to publish a print-control command.")
+    plan = build_print_control_plan(args)
+    if not args.execute:
+        print(json.dumps(plan, indent=2))
+        return 0
+    publish_result = publish_mqtt(
+        args,
+        plan["mqtt"]["topic"],
+        plan["mqtt"]["payload"],
+        report_topic=f"device/{args.serial}/report" if getattr(args, "serial", "") else None,
+    )
+    plan["dry_run"] = False
+    plan["executed"] = [f"publish_{args.action}_request"]
+    plan["mqtt_publish_result"] = publish_result
+    print(json.dumps(plan, indent=2))
+    return 0
+
+
+def send_main(args: argparse.Namespace) -> int:
+    apply_printer_config(args)
+    if args.execute and args.action == "plan":
+        raise BambuPrintError("--execute has no effect with --action plan.")
+    if args.execute and args.action in {"start", "upload-start"} and not args.confirm_start_print:
+        raise BambuPrintError("Starting a print requires --confirm-start-print.")
+    if args.execute and args.action in {"start", "upload-start"} and not ensure_printer_serial(args):
+        raise BambuPrintError("Printer serial is required to publish a start command.")
+    plan = build_send_plan(args)
+
+    if args.handoff == "plain":
+        local_path = Path(args.gcode).expanduser().resolve()
+        if not args.execute:
+            print(json.dumps(plan, indent=2))
+            return 0
+        return execute_send(args, plan, local_path)
+
+    if not args.execute:
+        print(json.dumps(plan, indent=2))
+        return 0
+
+    if args.handoff == "template-project":
+        with tempfile.TemporaryDirectory(prefix="bambu-template-project-") as tmp:
+            project_path = Path(tmp) / default_project_name(Path(args.gcode).expanduser())
+            package_result = package_with_template_project(args, project_path)
+            plan = build_send_plan(args, project_path=project_path)
+            plan["template_project_execution"] = package_result
+            return execute_send(args, plan, project_path)
+
+    with tempfile.TemporaryDirectory(prefix="bambu-bambox-") as tmp:
+        project_path = Path(tmp) / default_project_name(Path(args.gcode).expanduser())
+        package_result = package_with_bambox(args, project_path)
+        plan = build_send_plan(args, project_path=project_path)
+        plan["bambox_execution"] = package_result
+        return execute_send(args, plan, project_path)
+
+
+def execute_send(args: argparse.Namespace, plan: dict[str, Any], local_path: Path) -> int:
+    executed: list[str] = []
+    if args.action in {"upload", "upload-start"}:
+        upload_ftps(args, local_path, plan["ftps"]["remote_path"])
+        executed.append("upload")
+    if args.action in {"start", "upload-start"}:
+        publish_result = publish_mqtt(
+            args,
+            plan["mqtt"]["topic"],
+            plan["mqtt"]["payload"],
+            report_topic=f"device/{args.serial}/report" if getattr(args, "serial", "") else None,
+        )
+        if isinstance(publish_result, dict):
+            plan["mqtt_publish_result"] = publish_result
+        executed.append("publish_start_request")
+    plan["dry_run"] = False
+    plan["local_upload_path"] = str(local_path)
+    plan["executed"] = executed
+    if "publish_start_request" in executed:
+        plan["execution_notes"] = [
+            "MQTT start was published as a request; this helper does not confirm printer acceptance or print progress."
+        ]
+    print(json.dumps(plan, indent=2))
+    return 0
+
+
+def add_package_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("package", help="Package plain G-code into a supported bambox .gcode.3mf project.")
+    parser.add_argument("--gcode", required=True, help="Validated plain .gcode input.")
+    parser.add_argument("--output", required=True, help="Output .gcode.3mf path.")
+    parser.add_argument("--bambox-profile", required=True, help="Enabled bambox compatibility profile such as p1s-0.4.")
+    parser.add_argument("--filament", action="append", help="bambox filament spec. Repeat for multi-filament jobs.")
+    parser.add_argument("--bambox-bin", help="Path to bambox CLI. Defaults to BAMBOX_BIN or bambox on PATH.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", dest="execute", action="store_false", help="Print the packaging plan without running bambox.")
+    mode.add_argument("--execute", dest="execute", action="store_true", help="Run bambox pack and bambox validate.")
+    parser.set_defaults(execute=False, func=package_main)
+
+
+def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("config", help="Read and write local Bambu printer JSON config.")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Printer config JSON path.")
+    config_subparsers = parser.add_subparsers(dest="config_command", required=True)
+
+    set_parser = config_subparsers.add_parser("set", help="Create or update a configured printer.")
+    set_parser.add_argument("--printer", required=True, help="Local printer id, for example a1-mini.")
+    set_parser.add_argument("--host", help="Printer LAN IP or hostname.")
+    set_parser.add_argument("--access-code", help="Printer LAN access code.")
+    set_parser.add_argument("--model", help="Printer model, for example a1-mini.")
+    set_parser.add_argument("--serial", help="Printer serial. Usually omitted; use --fetch-serial.")
+    set_parser.add_argument("--notes", help="Optional operator notes.")
+    set_parser.add_argument("--fetch-serial", action="store_true", help="Fetch and cache serial from the printer TLS certificate.")
+    set_parser.add_argument("--mqtt-port", type=int, default=DEFAULT_MQTT_PORT)
+    set_parser.add_argument("--timeout", type=float, default=20.0)
+    set_parser.add_argument("--tls-verify", action="store_true", help="Verify printer TLS certificates.")
+    set_parser.add_argument(
+        "--allow-nonprivate-host",
+        action="store_true",
+        help="Allow printer hosts that resolve outside private/link-local/loopback ranges.",
+    )
+    set_parser.set_defaults(func=config_set_main)
+
+    list_parser = config_subparsers.add_parser("list", help="List configured printers.")
+    list_parser.set_defaults(func=config_list_main)
+
+    show_parser = config_subparsers.add_parser("show", help="Show one configured printer without printing the access code.")
+    show_parser.add_argument("--printer", required=True)
+    show_parser.set_defaults(func=config_show_main)
+
+
+def add_serial_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("serial", help="Fetch the printer serial from its local TLS certificate.")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Printer config JSON path.")
+    parser.add_argument("--printer", help="Configured printer id.")
+    parser.add_argument("--host", default="", help="Printer LAN IP or hostname.")
+    parser.add_argument("--mqtt-port", type=int, default=DEFAULT_MQTT_PORT)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    parser.add_argument("--tls-verify", action="store_true", help="Verify printer TLS certificates.")
+    parser.add_argument(
+        "--allow-nonprivate-host",
+        action="store_true",
+        help="Allow printer hosts that resolve outside private/link-local/loopback ranges.",
+    )
+    parser.add_argument("--json", action="store_true")
+    parser.set_defaults(func=serial_main)
+
+
+def add_status_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("status", help="Read one MQTT report message from a configured local printer.")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Printer config JSON path.")
+    parser.add_argument("--printer", help="Configured printer id.")
+    parser.add_argument("--host", default="", help="Printer LAN IP or hostname.")
+    parser.add_argument(
+        "--serial",
+        default="",
+        help="Printer serial number for MQTT topic. Usually loaded from config or fetched automatically.",
+    )
+    parser.add_argument("--access-code", help="Printer access code for one-off use. Prefer --printer config.")
+    parser.add_argument("--topic", help="MQTT report topic. Defaults to device/{serial}/report.")
+    parser.add_argument("--push-all", action="store_true", help="Request a full status report after subscribing.")
+    parser.add_argument("--wait-seconds", type=float, default=10.0)
+    parser.add_argument("--max-messages", type=int, default=1, help="Maximum report messages to collect before returning.")
+    parser.add_argument("--sequence-id", help="MQTT sequence id for --push-all. Defaults to current timestamp milliseconds.")
+    parser.add_argument("--mqtt-port", type=int, default=DEFAULT_MQTT_PORT)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    parser.add_argument("--tls-verify", action="store_true", help="Verify printer TLS certificates.")
+    parser.add_argument(
+        "--allow-nonprivate-host",
+        action="store_true",
+        help="Allow printer hosts that resolve outside private/link-local/loopback ranges.",
+    )
+    parser.add_argument("--client-id", help="MQTT client id. Defaults to the printer serial.")
+    parser.set_defaults(func=status_main)
+
+
+def add_clear_error_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("clear-error", help="Publish Bambu clean_print_error; dry-run by default.")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Printer config JSON path.")
+    parser.add_argument("--printer", help="Configured printer id.")
+    parser.add_argument("--host", default="", help="Printer LAN IP or hostname.")
+    parser.add_argument(
+        "--serial",
+        default="",
+        help="Printer serial number for MQTT topic. Usually loaded from config or fetched automatically.",
+    )
+    parser.add_argument("--access-code", help="Printer access code for one-off use. Prefer --printer config.")
+    parser.add_argument("--execute", action="store_true", help="Publish clean_print_error to the printer.")
+    parser.add_argument("--mqtt-port", type=int, default=DEFAULT_MQTT_PORT)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    parser.add_argument("--tls-verify", action="store_true", help="Verify printer TLS certificates.")
+    parser.add_argument(
+        "--allow-nonprivate-host",
+        action="store_true",
+        help="Allow printer hosts that resolve outside private/link-local/loopback ranges.",
+    )
+    parser.add_argument("--client-id", help="MQTT client id. Defaults to the printer serial.")
+    parser.add_argument("--sequence-id", help="MQTT sequence id. Defaults to current timestamp milliseconds.")
+    parser.add_argument(
+        "--mqtt-qos",
+        type=int,
+        choices=[0, 1],
+        default=0,
+        help="MQTT publish QoS. Default 0; use 1 for protocol diagnostics.",
+    )
+    parser.add_argument(
+        "--wait-after-publish",
+        type=float,
+        default=0.0,
+        help="After publishing, stay connected for this many seconds and capture report messages.",
+    )
+    parser.set_defaults(func=clear_error_main)
+
+
+def add_print_control_parser(subparsers: argparse._SubParsersAction, action: str) -> None:
+    help_text = "Pause the active local print; dry-run by default." if action == "pause" else "Cancel the active local print; dry-run by default."
+    parser = subparsers.add_parser(action, help=help_text)
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Printer config JSON path.")
+    parser.add_argument("--printer", help="Configured printer id.")
+    parser.add_argument("--host", default="", help="Printer LAN IP or hostname.")
+    parser.add_argument(
+        "--serial",
+        default="",
+        help="Printer serial number for MQTT topic. Usually loaded from config or fetched automatically.",
+    )
+    parser.add_argument("--access-code", help="Printer access code for one-off use. Prefer --printer config.")
+    parser.add_argument("--execute", action="store_true", help=f"Publish the {action} request to the printer.")
+    if action == "cancel":
+        parser.add_argument(
+            "--confirm-cancel-print",
+            action="store_true",
+            help="Required with --execute because canceling stops the active print job.",
+        )
+    parser.add_argument("--mqtt-port", type=int, default=DEFAULT_MQTT_PORT)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    parser.add_argument("--tls-verify", action="store_true", help="Verify printer TLS certificates.")
+    parser.add_argument(
+        "--allow-nonprivate-host",
+        action="store_true",
+        help="Allow printer hosts that resolve outside private/link-local/loopback ranges.",
+    )
+    parser.add_argument("--client-id", help="MQTT client id. Defaults to the printer serial.")
+    parser.add_argument("--sequence-id", help="MQTT sequence id. Defaults to current timestamp milliseconds.")
+    parser.add_argument(
+        "--mqtt-qos",
+        type=int,
+        choices=[0, 1],
+        default=0,
+        help="MQTT publish QoS. Default 0; use 1 for protocol diagnostics.",
+    )
+    parser.add_argument(
+        "--wait-after-publish",
+        type=float,
+        default=0.0,
+        help="After publishing, stay connected for this many seconds and capture report messages.",
+    )
+    parser.set_defaults(action=action, func=print_control_main)
+
+
+def add_send_parser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("send", help="Inspect, upload, and optionally start a validated plain G-code job.")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH), help="Printer config JSON path.")
+    parser.add_argument("--printer", help="Configured printer id. Preferred over repeating host/access-code flags.")
+    parser.add_argument("--gcode", required=True, help="Validated plain .gcode input.")
+    parser.add_argument("--handoff", choices=["plain", "bambox-project", "template-project"], default="plain")
+    parser.add_argument("--host", default="", help="Printer LAN IP or hostname.")
+    parser.add_argument(
+        "--serial",
+        default="",
+        help="Printer serial number for MQTT topic. Usually omitted; the helper fetches it from the printer TLS certificate.",
+    )
+    parser.add_argument("--access-code", help="Printer access code for one-off use. Prefer --printer config for repeated use.")
+    parser.add_argument("--action", choices=["plan", "upload", "start", "upload-start"], default="plan")
+    parser.add_argument("--execute", action="store_true", help="Perform network action selected by --action.")
+    parser.add_argument("--confirm-start-print", action="store_true", help="Required for --action start or upload-start with --execute.")
+    parser.add_argument(
+        "--remote-dir",
+        default=None,
+        help="Remote directory. Defaults to cache for plain G-code and printer root for project handoffs.",
+    )
+    parser.add_argument("--remote-name", help="Filename to store on the printer.")
+    parser.add_argument("--gcode-param", help="Override MQTT gcode_file param. Defaults to the uploaded remote path.")
+    parser.add_argument("--plate", type=int, help="Plate number for packaged projects. Defaults to the first plate.")
+    parser.add_argument("--bambox-profile", default="p1s-0.4", help="Enabled bambox profile for --handoff bambox-project.")
+    parser.add_argument("--filament", action="append", help="bambox filament spec. Repeat for multi-filament jobs.")
+    parser.add_argument("--bambox-bin", help="Path to bambox CLI. Defaults to BAMBOX_BIN or bambox on PATH.")
+    parser.add_argument(
+        "--template-project",
+        help="Same-printer sliced .gcode.3mf template for --handoff template-project.",
+    )
+    parser.add_argument("--ftps-port", type=int, default=DEFAULT_FTPS_PORT)
+    parser.add_argument("--mqtt-port", type=int, default=DEFAULT_MQTT_PORT)
+    parser.add_argument("--timeout", type=float, default=20.0)
+    parser.add_argument("--tls-verify", action="store_true", help="Verify printer TLS certificates.")
+    parser.add_argument(
+        "--allow-nonprivate-host",
+        action="store_true",
+        help="Allow printer hosts that resolve outside private/link-local/loopback ranges.",
+    )
+    parser.add_argument("--client-id", help="MQTT client id. Defaults to the printer serial for start commands.")
+    parser.add_argument("--sequence-id", help="MQTT sequence id. Defaults to current timestamp milliseconds.")
+    parser.add_argument(
+        "--mqtt-qos",
+        type=int,
+        choices=[0, 1],
+        default=0,
+        help="MQTT publish QoS for start commands. Default 0; use 1 for protocol diagnostics.",
+    )
+    parser.add_argument(
+        "--wait-after-publish",
+        type=float,
+        default=0.0,
+        help="After publishing a start command, stay connected for this many seconds and capture report messages.",
+    )
+    parser.set_defaults(func=send_main)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    add_package_parser(subparsers)
+    add_config_parser(subparsers)
+    add_serial_parser(subparsers)
+    add_status_parser(subparsers)
+    add_clear_error_parser(subparsers)
+    add_print_control_parser(subparsers, "pause")
+    add_print_control_parser(subparsers, "cancel")
+    add_send_parser(subparsers)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        return args.func(args)
+    except BambuPrintError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.qwenpaw-plugin/skills/cad-viewer/LICENSE
+++ b/.qwenpaw-plugin/skills/cad-viewer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thompson Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.qwenpaw-plugin/skills/cad-viewer/SKILL.md
+++ b/.qwenpaw-plugin/skills/cad-viewer/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: cad-viewer
+description: Start CAD Viewer and return review links for CAD and robot-description files. Use when visually reviewing `.step`, `.stp`, `.glb`, `.stl`, `.3mf`, `.dxf`, `.urdf`, `.srdf`, or `.sdf` files, especially when handed off from CAD, URDF, SRDF, or SDF generation skills.
+---
+
+# CAD Viewer
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review. If the user asks to
+modify, debug, or iterate on CAD Viewer source itself, that is the repository's
+work, not this skill's — this skill runs the Viewer, it is not where you edit it.
+
+Use this skill to open existing or newly generated CAD,
+robot-description, or DXF files in CAD Viewer and hand back live review links. The expected input is one or more explicit file paths.
+
+## Setup
+
+The Viewer is part of `cadgen`: install this skill's `requirements.txt` into a
+Python >= 3.11 and the `cadgen` command carries the server and the prebuilt
+client. There is nothing else to install and no Node at run time.
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+`cadgen doctor <this skill's directory>` confirms the installed cadgen matches
+the version this skill was published against.
+
+## Start Viewer
+
+Launching is unconditional: the command below always ends with the URL of a
+live Viewer for the launch directory. If one is already running for that
+directory with the same Viewer code on disk (the reuse key is
+realpath(directory) x an identity token — the cadgen version salted with the
+Viewer files' newest mtime, so an upgraded Viewer never hands back a stale
+instance), its URL is returned (`"action": "reused"`);
+otherwise a new server starts on the first free port from `3245` upward
+(`"action": "started"`). Never pick or reason about ports — read the URL the
+command prints. Each instance serves ONE directory — the directory it is
+launched from — fixed for the life of the process. There is no flag for it:
+the cwd IS the served directory.
+
+> The base port `3245` is `0xCAD` — "CAD" in hexadecimal.
+
+```bash
+cd /absolute/project/models && cadgen viewer --host 127.0.0.1 --json
+```
+
+(`cadgen` must be the one installed from this skill's `requirements.txt`. If it
+is not on `PATH`, `python -m cadgen.viewer` with that interpreter is the same
+launcher.)
+
+**Choose the launch directory deliberately — it is the whole ballgame.** The
+cwd decides what the catalog SCANS (a project root drags in `node_modules`,
+`.git` and build output) and it is the instance REUSE key, so launching from
+wherever you happen to be can hand back a Viewer serving somewhere else. `cd`
+to the directory the user thinks of as their model workspace — usually the
+project's `models/` directory — and launch from there. Never launch from
+inside this skill's directory: that serves the skill, not the models.
+
+Flags: `--json` prints the machine-readable last stdout line
+(`{"url", "port", "action": "started"|"reused"}`) — always pass it and take the
+URL from there. `--new` forces a fresh instance instead of reusing. An
+explicit `--port <n>` is strict — "this port or fail" — and disables
+both reuse and rolling. `cadgen viewer --help` lists the rest.
+
+## URL shape
+
+The page is the bare origin, and `file=` selects one artifact inside the served root:
+
+```text
+http://127.0.0.1:3245/?file=gripper/STEP/gear_rack_gripper.step
+```
+
+The `file=` value is relative to the served directory. Nothing about the
+directory appears in the URL, so the same link means different files under
+different instances — the root is the server's, not the link's.
+
+**The launch directory is the workspace, not the file's folder.** The Viewer
+scans it recursively, so the file browser lists every model beneath it and the
+user can switch files without a new link. Launch from the directory the user
+thinks of as their model workspace — typically the project's `models/`
+directory, or the nearest common parent of the files you were asked to review —
+and put the rest of the path in `file=`. Launching from the artifact's own deep
+folder (`cd .../models/gripper/STEP`, `?file=gear_rack_gripper.step`) opens
+the same model but hides the rest of the project, which is almost never what
+the user wants.
+
+Port collisions are not your problem: the launcher rolls to a free port and the
+URL it prints is the truth. In sandboxed agent environments, local binding
+failures such as `EPERM`/`EACCES` can still occur; rerun with the needed
+permission/escalation.
+
+`cadgen viewer list` shows every running instance with the directory it
+serves; `cadgen viewer stop --port <n>` ends one. (Both run from anywhere —
+only launching cares about the cwd.)
+To review a directory outside the current root, just `cd` there and launch
+again — reuse-or-start makes the second launch cheap and correct.
+
+## Generation is the CAD skill's job; documents compile in the Viewer
+
+The Viewer is a static visualization tool: it renders artifacts that already
+exist. Generated models must be built first by running their model script (see
+the CAD skill); the Viewer never runs a script and never learns whether a
+document has one.
+
+A `.step`/`.stp` document's status in the Viewer is one of four, decided from
+the file's bytes and the store alone: **not compiled** (the store has no tree
+for these bytes — the Viewer offers to compile, and compiles on open),
+**compiling · <phase> n/total** (a job in cadgen's build pool is producing a
+tree whose outputs include this document — the Viewer's own compile, a
+`python model.py` in a terminal, or a parent's child build alike),
+**rendered**, or **failed** (the last job for it failed; the message is shown).
+A compile is a job submitted to the same pool every cadgen door uses, so
+progress and errors come back as data. There is no "stale vs source" state:
+whether a document is behind its script is `cadgen store why`'s question, not
+the Viewer's. When an agent is doing the work there is nothing to run first:
+just use the file and return the link.
+
+## Links
+
+- Before returning any link, resolve `<directory>/<file>` and confirm it
+  exists. Pass the `.step`/`.stp` artifact itself — generated and imported
+  alike. The catalog lists artifacts and names them exactly as they read on
+  disk: `moonwatch.step` is `moonwatch.step` in the tab, the breadcrumb, the
+  catalog row and the file picker, whether it was generated or imported.
+  The Viewer never learns whether a document was generated: its status is
+  artifact-side only (not compiled / compiling / rendered / failed), and the
+  model script is not shown anywhere in the UI. A generated model's document
+  must already exist (run the model script); a document the store has no tree
+  for is compiled from its bytes on open. If the resolved path is missing, do
+  not return the link; report the problem and point to the correct path.
+- Return one Viewer URL per requested file.
+- Start the Viewer once and pick one workspace root for the session. Every link is
+  the same origin plus `?file=<path relative to that root>`, so all of them share one
+  browsable catalog. An artifact outside that root needs its own Viewer — launch
+  again with that root (reuse-or-start makes this idempotent); a link alone cannot
+  reach it.
+- For directory-only review links, return the origin without `?file=`.
+- Do not stop an existing Viewer server unless the user asks.
+- If Viewer startup fails, report the failure and continue with the owning skill's non-GUI validation or artifacts.
+
+## References
+
+- Read `references/viewer-features.md` when you need supported file types, Viewer controls, or file-specific feature details.

--- a/.qwenpaw-plugin/skills/cad-viewer/agents/openai.yaml
+++ b/.qwenpaw-plugin/skills/cad-viewer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CAD Viewer"
+  short_description: "Open CAD, G-code, and robot files in Viewer."
+  default_prompt: "Use $cad-viewer to start CAD Viewer and return review links for explicit CAD, G-code, or robot-description files."

--- a/.qwenpaw-plugin/skills/cad-viewer/references/viewer-features.md
+++ b/.qwenpaw-plugin/skills/cad-viewer/references/viewer-features.md
@@ -1,0 +1,38 @@
+# CAD Viewer Features
+
+Load this only when a task needs Viewer file-support details or UI control guidance.
+
+## Supported Files
+
+- `.step`, `.stp`: STEP/STP review through the document's tree in the store (compiled from the file's bytes on open when missing); supports assembly trees, part hide/show, inspect/focus, face/edge/vertex/part selection, copied `#...` CAD references, display modes, clip planes, and live pose sliders and animation clips when the model's sidecar declares kinematics or animation.
+- `.stl`, `.3mf`, `.glb`: mesh viewing with orbit/pan/zoom, screenshots, theme controls, and solid/wireframe display where available. Measure snaps to triangle vertices only (two clicks, distance in mm) — not STEP faces/edges. A plain GLB's `COLOR_0` vertex colors render as source colors, exactly like authored material colors.
+- `.dxf`: read-only 3D flat-pattern viewing. The drawing file is parsed directly and rendered client-side — no render artifact exists for a `.dxf`, so generated and imported drawings alike render straight from their own bytes.
+- `.urdf`: robot link/mesh viewing with movable joint sliders, reset pose, and copied joint values.
+- `.srdf`: paired-URDF viewing with planning groups, group-state presets, and joint controls.
+- `.sdf`: SDF model/world viewing with metadata, counts, warnings, and joint controls when available.
+
+## Controls
+
+- Navigation: left-drag to orbit, right/middle-drag to pan, wheel or pinch to zoom, and Arrow/WASD keys to orbit. Use the view sphere for top/bottom/front/back/left/right views; click its center for the default isometric view.
+- File browser: toggle the left CAD Viewer sidebar, search files/ids/paths, expand folders, select entries, or switch files from the breadcrumb menus.
+- File names read exactly as they do on disk. The tab title, breadcrumb, catalog rows and the file picker all show the artifact's own basename and its own path — `moonwatch.step`, never the `moonwatch.py` that generated it. The Viewer never learns whether a document was generated: its status badge is one of not compiled / compiling / rendered / failed, decided from the file's bytes, the store and the build pool's job ledger, and no part of the UI names or opens a model script. (Copied topology references are the one exception, and a deliberate one: see the bare-stem rule below.)
+- Floating toolbar: `Select` copies STEP topology references, `Pan` drags the camera, `Measure` picks measurement points, `Draw` opens annotation tools, `Orbit` starts an auto-rotating preview (with `Exit orbit` to leave it), `Play`/`Pause` appears when the model has animation clips, and `Copy screenshot` puts a viewport capture on the clipboard — screenshots are clipboard-only; nothing downloads. DXF drawings get their own 2D/3D view pill beside the toolbar.
+- File context menu (file browser rows and the breadcrumb): `Reveal in Explorer View` highlights the entry in the file browser, and the copy items hand out references to the file — `Copy Filename`, `Copy Path` (absolute), `Copy Relative Path` (relative to the served directory), and `Copy Link`, which copies the viewer deep link for the entry (the bare origin plus `?file=<root-relative path>`, byte-identical to the URL the app itself lands on). There is no download and no native file-manager reveal; paths and links are how bytes leave the Viewer.
+- Drawing tools: freehand, line, arrow, expand, rectangle, circle, fill, erase, undo, redo, and clear.
+- File sheet: open the right sheet for file-specific tabs. STEP files get Tree, Reference, and Measure, plus a Kinematics tab when the document's sidecar declares kinematics, an Animation tab when a render module (`<name>.step.js`) sits beside the document — its load errors (a syntax error, an export the renderer does not know) and any clip target the compiled tree does not carry are reported in that tab — and Display. In Kinematics, a DOF that exactly one coupling gears is marked "driven by <coupling>": its slider shows the effective value and drags the coupling, so sliding one member of a gear train turns the whole train. In Animation, the "Clip" dropdown lists the model's authored clips and nothing else, opening on the first one; the section header's switch turns animation off, which idles the transport so the model holds the Kinematics tab's pose, and Play turns it back on. URDF/SRDF/SDF files get joints and metadata. Mesh files show a Measure tab for vertex-to-vertex distance. DXF drawings have material/bend controls.
+- Display vs theme: the file sheet's Display tab holds per-file view state (display mode, clip, exploded view); the navbar theme button opens the theme sidebar, holding the global, persistent theme — preset, surface colors, backdrop, floor/grid, lighting, and color mode.
+- Theme sidebar: a "Preset" dropdown (System, then the built-in presets, each with a two-box swatch showing its backdrop and default part colour) followed by the settings groups. Presets are read-only and there is only one custom theme: editing any setting writes it into that single custom slot and the dropdown reads "Custom", and picking a preset again is how you reset. Custom is a state, not a list entry — you leave it by choosing a preset. There is no save, restore, rename, or delete.
+- Sidebars: the file sheet and the theme sidebar are mutually exclusive. Each navbar button toggles its own sidebar; opening one replaces the other, and closing one leaves nothing open.
+- Copied references carry their file: the Viewer prefixes every copied ref with the shortest
+  path suffix that names that file uniquely (`bracket#o1.2.f1`, or
+  `lyra/STEP/palm.step#o1.3` where a filename is not unique), so a ref pasted into a prompt
+  still says which model it belongs to. A generated model shows as a bare stem — the common
+  case, so it gets the shortest name — while everything else keeps its suffix (`bracket.step`,
+  `plate.stl`, `plate.3mf`). That means a bare stem is NOT a literal path suffix, so resolving
+  one back to a file means expanding it; the CAD skill's
+  `references/inspection-and-validation.md` documents the split-and-expand steps. Bare `#...`
+  refs remain valid everywhere.
+- Tutorial tips: the first time a selection produces a copyable reference — a component, a subassembly, or a face/edge — a one-shot tip above the "Copy #…" button explains that references can be pasted into prompts to edit specific parts. Only its X closes it; clicking away, Escape, and reloads leave it to reappear on the next selection, and once dismissed it never returns. Append `?resetTips=1` to a Viewer URL to clear the record and re-arm every tip; the param applies once and is stripped from the address bar.
+- Display tab: a "Mode" dropdown (solid/rendered/x-ray/hidden/lines/flat/wire), then Clip and Exploded as subsections of the same tab.
+- Clip: X/Y/Z position sliders plus Flip and Reset, always visible — an offset of 0 means no cut.
+- Exploded view: a switch beside the "Exploded" subheading pulls an assembly apart (it moves the Amount scrub to/from zero) and reveals an Amount scrub, an Automatic/Custom layout switch, a Direction dropdown (Auto/X/Y/Z/Radial), Reverse, Spread, Detail, Order, explode-line, and Reset controls, where Custom lets you edit per-part moves.

--- a/.qwenpaw-plugin/skills/cad-viewer/requirements.txt
+++ b/.qwenpaw-plugin/skills/cad-viewer/requirements.txt
@@ -1,0 +1,4 @@
+# The CAD Viewer is `cadgen viewer`: the server and the prebuilt client ship
+# inside the cadgen distribution, so this is the only dependency. Pinned to the
+# release this skill was published with (the release PR stamps it).
+cadgen==0.5.1

--- a/.qwenpaw-plugin/skills/cad/LICENSE
+++ b/.qwenpaw-plugin/skills/cad/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thompson Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.qwenpaw-plugin/skills/cad/SKILL.md
+++ b/.qwenpaw-plugin/skills/cad/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: cad
+description: Create, modify, inspect, and validate parametric CAD parts and assemblies authored as cadgen model scripts. Use for natural-language CAD specs, reference images, 2D technical drawings, STEP/STP generation or direct inspection, Python CAD source, source-level joints, selector references, geometry facts, measurements, mating deltas, snapshots, and STL/3MF/native GLB outputs from CAD geometry. Also covers project structure for multi-part CAD work - src/ for model scripts and shared code, format folders (STEP/, DXF/, STL/) for raw outputs, naming, and commit policy for projects with several @step/@dxf model scripts and imported source files; use it when starting a CAD project with more than a couple of models, when asked how to organize CAD code and artifacts, or when growing a flat folder of models into a project.
+---
+
+# CAD generation, inspection, and validation
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review.
+
+## Setup
+
+This skill's commands are thin entrypoints over the `cadgen` distribution, which
+carries the Python build runtime and the JavaScript it executes. Install it once:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+Rendering additionally needs a browser, which pip cannot supply:
+
+```bash
+python -m playwright install chromium
+```
+
+## Purpose
+
+Create or modify parametric CAD models from natural-language requirements, build validated STEP/STP (or mesh) outputs, inspect geometry references, and return checked outputs. STEP is the default output of CAD geometry and the one the inspection tools read; STL, 3MF, and native GLB are mesh outputs a model declares beside it — or instead of it, when the part is print-only. For assemblies, prefer `cadgen.assembly.AssemblyHelper` with source-level build123d joints, named mating datums, and native labels when the parts have functional assembly relationships.
+
+There are two ways into the STEP workflow: build from a build123d model script (the default when designing from scratch or modifying a generated model), or import an existing STEP/STP file directly (when no script exists or the user explicitly targets the STEP file). Both are inspected, snapshotted and exported the same way.
+
+## Use this skill when
+
+Use this skill when the user asks for CAD files, STEP/STP files, build123d source, selector refs such as `#o1.2.f1`, mechanical parts, assemblies, enclosures, brackets, fixtures, holes, counterbores, countersinks, slots, pockets, bosses, standoffs, ribs, fillets, chamfers, shells, source-level joints, mating, or measurements. Also use it when the user supplies reference images or 2D technical drawings of a part to reproduce or take design intent from.
+
+Also use it when the user asks for STL, 3MF, or native GLB output from CAD geometry; load `supported-exports.md` for details. For 2D DXF drawings, use the `$dxf` skill; when a DXF projects from a 3D part, this skill owns the part and `$dxf` owns the drawing.
+
+Do not use this skill for render-only concept art, CAM toolpaths, engineering certification, FEA conclusions, architectural BIM, or freehand illustration unless the user also needs CAD geometry.
+
+## Default assumptions
+
+Use these defaults unless the user specifies otherwise. These are first-pass modeling defaults, not manufacturability, tolerance, or certification claims:
+
+- Units: millimeters.
+- Origin: per the part-type defaults in `references/positioning.md`; center of the main part or assembly when nothing better applies.
+- Base plane: XY.
+- Up/extrusion axis: positive Z.
+- Output geometry: closed, positive-volume solids unless the user requests surfaces or construction geometry.
+- STEP structure: one valid solid, a compound of solids, or a labeled assembly compound.
+- Assembly structure: fixed root part, part-local frames, named mating datums, `AssemblyHelper` relationships backed by build123d joints where applicable, explicit generated placements, and verbose native labels.
+- Small plastic enclosure wall: 2.0-3.0 mm when unspecified.
+- Cosmetic fillet: 1.0-3.0 mm when safe for local geometry.
+- M3/M4/M5 normal clearance holes: 3.4/4.5/5.5 mm unless another standard is requested.
+
+Ask one focused clarification question only when missing information makes the model impossible, fit-critical, safety-critical, or compliance-bound. Otherwise proceed with explicit assumptions.
+
+## Tools and paths
+
+The command surface (the `cadgen` console script, installed with the package):
+
+```bash
+python <model>.py            # its __main__ calls the model, which builds it
+cadgen step build IN OUT     # re-emit an existing STEP as a new one, with kinematics
+cadgen stl build ...         # one door per mesh format; `3mf` and `glb` are the others
+cadgen step inspect ...      # refs, measure, align, frame, diff
+cadgen step snapshot ...     # PNG visual review packets, for STEP
+cadgen stl snapshot ...      # the same, for a mesh file; `3mf` and `glb` again
+cadgen store why <model>.py  # why the model is stale or current, clause by clause
+cadgen daemon status         # the warm workers and the jobs they are running
+```
+
+**Scripts are RUN; commands take DOCUMENTS.** `python model.py` is the one
+source door — it writes every output the model declares and (only when the
+model declares kinematics, animation, or mesh exports) its sidecar. Every
+command above takes a `.step`/`.stl`/`.dxf` FILE, and one handed a `.py` says
+so. A door asks one question of a document: does the store have a tree for
+this file's bytes? If so it reads it; if not it compiles one from the bytes as
+a job in the pool — generated or imported alike. **A door never refuses a
+document and never runs a script.** Whether a document is behind its script
+is the model's business (`cadgen store why`), not the door's.
+
+Use the active project Python interpreter; treat `python` in examples as an interpreter placeholder. Every operational verb is a `cadgen` subcommand (`python -m cadgen.cli <verb>` is the PATH-independent equivalent). Use `cadgen <verb> --help` for the complete current interface; reference docs show recommended workflows, not every flag. Install per `requirements.txt`; `cadgen doctor <skill-dir>` verifies the installed cadgen matches this skill's pin (docs drift silently on a mismatched install).
+
+Target paths resolve from the command's current working directory, not from the skill directory. Run commands from the workspace that owns the artifacts and pass cwd-relative target paths so project CAD files never resolve accidentally under the skill directory.
+
+CAD references are `#...` selector tokens local to a target, for example `#o1.2` or `#o1.2.f1`. Pass the STEP/CAD file as a separate target argument when using CAD CLIs.
+
+## A model
+
+Generation has NO CLI. A model is a plain Python script: one parameterless
+decorated function, built by calling it from `__main__`:
+
+```python
+from cadgen import build123d as bd
+from cadgen import step
+
+WIDTH = 10.0
+
+
+@step                      # or @step(out="../STEP/bracket.step") to relocate the output
+def bracket():
+    return bd.Box(WIDTH, 10, 10)
+
+
+if __name__ == "__main__":
+    bracket()
+```
+
+The rules, each enforced by the decorator or the build:
+
+- **The decorator only declares; a call builds.** Importing a model module
+  never builds; a file without `if __name__ == "__main__": <model>()` never
+  builds either — always end the script that way. `python bracket.py` writes
+  `bracket.step` beside the script and the model's result into the store; an
+  unchanged model is a fast no-op. `--force` rebuilds this model only.
+- **A model takes no parameters** and its function is called with no
+  arguments. Parametric geometry lives in a plain factory the model calls
+  with its values (`def _bracket(width, thickness): ...`); another
+  configuration is another model in another file, the way two part numbers
+  are two parts.
+- **The return is a bare build123d `Shape`** — a solid, a compound, or a
+  labeled assembly compound. Never a dict, never a path.
+- **Outputs are exactly what the decorators declare.** `@step` writes the
+  `.step`; `@stl`/`@threemf`/`@glb` stacked on it write meshes. **STEP is not
+  required**: a function with only `@stl` (or `@glb`, `@threemf`) — no `@step`
+  — is a full model with the same tree, record, build and no-op, whose outputs
+  are the meshes and which writes no `.step` and no sidecar. Use it for
+  print-only parts and render assets. `references/supported-exports.md`.
+- **Decorator arguments never change the geometry.** They decide where the
+  files land (`out=`), how they are written (`mesh_tolerance=`,
+  `mesh_angular_tolerance=`) and what the sidecar declares (`kinematics=`).
+  The geometry is the return value and nothing else: a `Compound` placing
+  children is packaged as occurrences, a single solid as one component, and
+  `part`/`assembly` is read off the tree. There is no `kind=` and no bake
+  point — a posed or differently configured export is authored geometry, or
+  another model.
+- **A sidecar only when strictly necessary.** `<name>.step.json` is written
+  only when the model declares `kinematics=`; a model that declares none has
+  no sidecar, and a rebuild that dropped the declaration deletes the stale
+  file. What a model declares about its outputs lives in its record, not in
+  a file beside the geometry.
+- **One model per file, as a rule of thumb.** A model's identity is its file
+  plus its function (`plate.py::plate`); a file holding one model is named by
+  its path alone. A file MAY hold several (a small family of variants): each is
+  its own record, output and job (a sole model writes `<file>.step`; models sharing a
+  file write `<function>.step`), but
+  they share the file's closure, so editing one rebuilds them all — which is
+  why one per file is the recommendation.
+- **Composition is a call.** Import a sibling model and call it inside your
+  body (`from arm import arm` … `arm()`); it returns the child's geometry.
+  `references/step-generation.md` has the whole composition contract.
+- **`from cadgen import build123d as bd`** is the canonical import — a lazy,
+  transparent re-export of build123d (same names, same behaviour) — so the
+  freshness gate and the warm-worker handoff run before any kernel import is
+  paid. Raw `import build123d` works but costs ~2.5s on every re-run.
+- Per-run flags ride the script's argv: `--force`, `--json`, `--verbose`,
+  `--mesh-tolerance`, `--mesh-angular-tolerance`.
+
+## Composition, freshness and builds
+
+The essentials; `references/step-generation.md` has the code and the edge cases.
+
+- **Children are models you call.** A parent's body imports sibling models
+  and calls them; each call returns that child's geometry (built if stale,
+  loaded from the store if current), and the parent's result LINKS to the
+  child's — stored once, shared by every parent. Place a child with
+  `Pos/Rot/Location * child` or `child.moved(loc)`; never `child.located(loc)`
+  (it deep-copies the geometry, so the parent owns a copy instead of linking).
+- **Every build is parallel.** A child call submits the child's build and
+  returns at once; siblings build on their own workers while the body keeps
+  going; the parent waits when it first reads the geometry — normally the
+  closing `bd.Compound(children=[...])`. Nothing to configure, nothing to
+  annotate.
+- **Builds never wait on or cancel each other.** Two runs of one model both
+  run; the store keeps the result whose sources match the files as they are
+  now, so the disk ends at the newer source. Editing a child while its parent
+  builds leaves the parent finished against the child it pinned.
+- **A rebuilt part does not update the assemblies that use it.** Dependency
+  is pull: rebuild the parent (`python assembly.py`) to pick up a child's
+  change. A child edit that yields identical geometry leaves parents current.
+- **What a rebuild tracks — models by result, constants by value, functions by
+  file.** Importing a model function tracks that model by its result;
+  importing a module-level literal (`from plate import WIDTH`) tracks the
+  value; importing anything else from a file (a helper function, a `bd.`
+  object) makes that whole file part of your model's source, so any edit to it
+  rebuilds you. Shared constants may live in a model file or in `lib/`.
+- **The environment is not an input.** Model and `lib/` code takes no
+  parameter from `os.environ`, the working directory, the current time or a
+  random source: the gate tracks source by hash, constants by value and children by
+  result, and cannot see any of those — a value that changes geometry through
+  them leaves a stale result reading as current. A configuration is a factory
+  argument; another configuration is another model.
+- **A mirrored part is its own model.** STEP cannot express a reflection, so
+  a right-hand part is a separate model file calling the same factory with
+  `mirror=True` (or mirroring the factory's result), not a mirrored child.
+- **`read_step` files are inputs, not models.** Replacing the file makes the
+  reader stale. To make an imported part first-class, wrap it:
+  `@step def servo(): return read_step(...)`.
+- **`cadgen store why <model>.py`** is the freshness door: it prints the
+  gate's verdict clause by clause (record, closure files, constants, each
+  child's pinned vs current tree, tree objects, declared outputs). Reach for
+  it whenever a model did or did not rebuild when you expected it to.
+
+**Workers.** A warm daemon is on by default: each model gets a persistent
+worker (a second, an *extra*, when the model is asked for while already
+building); spares stand by so a new model never pays the import; idle workers
+unbind after ten minutes. Running builds are limited to one per core
+(`CADGEN_JOBS` overrides); a parent waiting on its children holds no slot.
+`CADGEN_DAEMON=0` uses transient workers spawned for that one run — still
+parallel, still the same store — and is the mode for tests and debugging.
+`cadgen daemon status` lists workers, spares and the running/queued jobs.
+
+**Debugging notes.** Do not alternate `CADGEN_DAEMON=0` and daemon runs of one
+model while a daemon build of it is in flight (the two are unbrokered; each
+publishes what it built, and the publish rule keeps the newer source). **One
+project, one store.** A build under another `CADGEN_CACHE_DIR` (a temp store,
+a test) rewrites the same output files; the first store's records then see
+outputs whose bytes they did not write, so its gate reports the model stale
+(`output changed: …`) and every parent `child stale: …` — nothing is wrong,
+the two stores simply disagree, and the next build under either settles it.
+**Module bodies stay cheap.** A model file is imported on every rerun, before
+the gate: a module-level `read_step` (computing a layout from a vendor STEP at
+import) pays the kernel and the parse each time even when the model is
+current — call `read_step` inside the body or a function it calls; the
+`hint:` printed on such a run names the import site. **Resets, smallest
+first:** `python model.py --force` rebuilds one model now; `cadgen store
+forget <model.py>` drops its record so the *next* run rebuilds it (children
+untouched); `cadgen store forget <file.step>` drops the tree entry for that
+file's bytes so the next open or door call compiles it again; `cadgen store
+gc` sweeps unreachable objects; **clearing the store (`rm -rf
+~/.cache/cadgen`, or `$CADGEN_CACHE_DIR`) is always safe** — every model
+reads as stale and rebuilds, and no project file is touched. The gate has no
+cadgen-version clause, so a model built by a cadgen with a bug stays current
+after the fix: `forget` the affected models (or the parents that link them),
+or clear the store.
+
+**The store** (`~/.cache/cadgen`, `CADGEN_CACHE_DIR` overrides) holds
+`objects/` — immutable, content-addressed components and trees — and `index/`
+— the per-model records the gate reads, the op memo, and the mesh ledger. It
+contains only derived results. The full contract is `STORE.md` in the
+installed `cadgen` package.
+
+## Streams, progress and failures
+
+**Streams.** stdout carries the result; stderr carries progress, timing, and failures. A model run prints `<outcome> <document path>` on stdout (`built`, `current`, or `skipped-peer` when a concurrent build of the same model finished first), and the two streams never interleave, so `2>/dev/null` leaves a clean parseable result and `>/dev/null` leaves a readable log. JSON on stdout is always compact; pipe through `jq .` to read it. For machine-readable output: model runs, the `build` doors (`step`, `stl`, `3mf`, `glb`) and `snapshot` take `--json`; `inspect` already emits JSON and takes `--format text` for prose. A model run's `--json` line carries `outcome`, `document` and `tree` (the result's hash). `--verbose` adds stage timing (and full tracebacks) on stderr. Output volume does not grow with model size.
+
+**The build tree.** On a terminal, stderr shows the graph as the body's child calls reveal it — one refreshed block, each model `submitted`, `queued`, `building · <phase> n/total`, `current`, or `✓ <time>`, finished subtrees folded to one line. With `--json` or a non-TTY, one JSON line per model transition (`model`, `parent`, `state`, `phase`, `progress`, `elapsed`) on stderr replaces the drawing; the result line on stdout comes last. After publishing, the root re-runs its gate once and says `already stale: <child> changed during the build; rerun` if it did.
+
+**Reporting progress from a model.** A long build spends most of its wall time inside
+the model body. Import the reporter — it binds to whichever build is running, and does
+nothing when there is none:
+
+```python
+from cadgen import report, track, step
+
+@step
+def housing():
+    report("bearing housing")                              # name the current phase
+    for rib in track(ribs, label=lambda r: r.name):        # count through a work list
+        ...
+```
+
+`track()` advances the count when an item's work is DONE and labels the item in flight, so a
+reader sees "3 finished, now on engines". The phase surfaces on the model's line in the build
+tree and — through the daemon's job ledger — as `compiling · <phase>` in the CAD Viewer for any
+document the job writes, whoever started the job. Without this a multi-minute assembly says
+nothing during its longest phase.
+
+**Failures** print the exception and the frames *in your own model*, not the runtime's:
+
+```text
+[cadgen] FAILED: ValueError: bad radius
+[cadgen]   src/widget.py:9 in bracket
+[cadgen]       return _profile(radius)
+[cadgen] re-run with --verbose for the full traceback
+```
+
+A failed child raises at the site in the parent that first read its geometry, naming the call and carrying the child worker's output.
+
+## Snapshots
+
+**Snapshot inputs.** One format, one door, and the same `TARGET [OUT]` grammar `build` uses. `cadgen step snapshot` renders `.step`/`.stp` documents — nothing else (a model script is refused by name: run `python <model>.py`, then snapshot the STEP it wrote). A mesh file goes to its own door: `cadgen stl snapshot`, `cadgen 3mf snapshot`, `cadgen glb snapshot`. A mesh has no CAD topology, so the STEP-only options (`--focus`/`--hide`, `--display`, `--kinematics`, `--animation`/`--time`, `--mode section`) are not on those commands at all — check `--help` and the door tells you what it can do. Robot descriptions belong to the `urdf`/`srdf`/`sdf` skills. Each door refuses what is not its own format, and names the door that takes it.
+
+```bash
+cadgen step snapshot STEP/bracket.step tmp/review.png
+cadgen stl snapshot  STL/bracket.stl   tmp/mesh.png
+```
+
+**Snapshot output.** The path you name is the path you get:
+
+```bash
+cadgen step snapshot STEP/bracket.step tmp/review.png
+# then Read tmp/review.png
+```
+
+OUT is written exactly as given (a relative path against the current working directory), cleared before the render and written atomically after it — so reuse one name while iterating, name the iterations (`tmp/before.png`, `tmp/after.png`) when you need to compare, and treat a missing file as the failure signal: there is never an older image at the path to mistake for output. A directory (`tmp/`) is the don't-care case and gets a generated timestamped name inside it, printed on the `saved snapshot:` line. The same rule applies per output in a JSON packet.
+
+**Theme and display.** Theme settings live under one `--theme`, display settings under one `--display` — the viewer's two tabs, one option each. The default theme is `snapshot`: Workbench Light with the ground grid and origin axis removed, because in a still image those read as geometry rather than as orientation. Pass `--theme workbench-light` for the viewer's own look. Projection is a theme trait honoured by every format, so a snapshot frames the same way the viewport does.
+
+## Required workflow
+
+Scale depth to the task: a simple part needs a short brief and few spec-driven checks; assemblies and fit-critical work need full positioning and alignment validation.
+
+1. **Classify the task.** New part, new assembly, source modification, direct STEP/STP inspection, reference selection, measurement/alignment check, snapshot review, or mesh output request.
+2. **Load only the needed references.** Use the triggers below instead of reading the whole reference set.
+3. **Write a natural-language CAD brief.** Extract dimensions, units, coordinate convention, feature intent, output paths, assumptions, and validation targets from all provided inputs — prose, reference images, technical drawings. Use `references/cad-brief.md`.
+4. **Check named purchasable components.** When an assembly includes named off-the-shelf actuators, servos, motors, electronics boards, connectors, or other purchasable components, search `$step-parts` before creating simplified placeholder geometry. If no exact match is found, record the miss and then use a documented bounding volume.
+5. **Plan before coding.** Define the constants and factory arguments, intent labels, source paths, expected bounding boxes, and any mating/positioning datums before editing.
+6. **Edit source, not generated artifacts.** Author a plain `.py` model script with one decorated function (shared code lives in plain helper modules; see `references/step-generation.md`). When a model script exists, run IT, never hand-edit its exported STEP. Imported STEP/STP files (no script) are handed straight to `cadgen step inspect`, `step snapshot` and the mesh doors — each compiles whatever it needs on demand.
+7. **Build explicit targets.** Run each model script directly (`python <model>.py`); do not sweep directories. A parent builds its children as it calls them, so running the root is the whole build. Declare `@stl`/`@threemf`/`@glb` outputs on the model, or run `cadgen stl|3mf|glb build` for one-off mesh files. For multi-model project structure, read `references/project-layout.md`.
+8. **Validate geometrically.** Run `cadgen step inspect refs <step-or-cad-target> --facts --planes --positioning` as the baseline, then verify the dimensions and relationships the user's spec calls out with targeted `measure`, `align`, `frame`, or `diff` checks. Run `cadgen step inspect validate <step-or-cad-target>` for geometry soundness: `refs --facts` reports counts and bounds, and its `ok` field covers ref resolution only — an open shell and an inverted solid both pass it.
+9. **Snapshot the primary STEP — snapshot validation is mandatory.** After creating or visibly updating a STEP/STP part or assembly, ALWAYS run `cadgen step snapshot` against it and review the output; deterministic checks passing is not a reason to skip. The only skip cases are documented in `references/snapshot-review.md` (no visible geometry changed, or no valid artifact exists); report the reason when skipping. A mesh-only model is reviewed with its format's snapshot door.
+10. **Repair and rerun.** If a check fails, change the smallest responsible source section, rebuild, and rerun the failed validation.
+
+## Handoff
+
+After completing CAD work that creates or modifies `.step`, `.stp`, `.stl`, `.3mf`, or native `.glb` artifacts, you must ALWAYS hand the explicit file path(s) to `$cad-viewer` when that skill is installed. `$cad-viewer` must start CAD Viewer if it is not already running and return link(s) to the relevant created or updated file(s); include those live viewer link(s) in the final response. If `$cad-viewer` is unavailable or startup fails, report that and rely on CLI inspection plus snapshots instead of silently omitting the handoff. This rule applies to every workflow in this skill, including mesh outputs.
+
+When verification snapshots are generated, include the saved PNG snapshot(s) in the final response. If no snapshot applies, or if snapshot generation fails, say why and report the deterministic validation that still ran.
+
+## Non-negotiables
+
+- The model script is the source of truth. Every written file — STEP/STP, STL, 3MF, GLB, the sidecar — is a derived output; edit and rerun the script, never the outputs. Where a model declares a STEP, the STEP is the artifact that is inspected and snapshotted.
+- Use named constants, closed solids, verbose native build123d labels, and source-controlled geometry intent.
+- Author assembly positioning in source. `references/positioning.md` is authoritative for `AssemblyHelper`, build123d joints, explicit `Location` transforms, and alignment validation.
+- Do not use `git status`, `git diff`, or file-size churn as CAD comparison for large exported STEP/STP, GLB, STL, or 3MF artifacts. Compare source changes, `cadgen step inspect` summaries, or snapshots instead; use path-limited git status only for bookkeeping.
+- Report only checks that actually ran or are directly supported by tool output.
+
+## Progressive references
+
+Load these files only when their trigger applies:
+
+- `references/cad-brief.md` — converting prose, reference images, and technical drawings into a CAD brief.
+- `references/build123d-modeling.md` — build123d modeling patterns, topology, selectors, features, labels.
+- `references/step-generation.md` — the model contract in full: composition (linked children, `read_step` inputs), what a rebuild tracks, mirrored parts, factories, the daemon and workers, imported STEP/STP files, and post-build steps.
+- `references/inspection-and-validation.md` — validation sequence, selector refs, facts, planes, measurements, alignment, diff, frame, and validation reporting.
+- `references/snapshot-review.md` — mandatory snapshot policy, packet sizing, targeted views, and converting visual findings into geometry checks.
+- `references/positioning.md` — part-local datums and origins, assembly transforms, build123d joints, CLI alignment validation, and positioning reports.
+- `references/kinematics.md` — articulating, posing, or animating a STEP model: typed mates (`kinematics=` on the decorators — mates, couplings, pose presets, export-at-pose), and the render module beside the document (`<name>.step.js`: the choreography contract, loaded by the viewer, read by no build).
+- `references/supported-exports.md` — STL/3MF/native GLB outputs: declared exports, mesh-only models, and the `cadgen stl|3mf|glb build` doors.
+- `references/repair-loop.md` — diagnosis and repair procedures.
+- `references/project-layout.md` — project structure for anything bigger than a couple of loose models: `src/` for model scripts and shared code, format folders (`STEP/`, `DXF/`, `STL/`) for raw outputs, naming, and commit policy; `references/project-template.md` is the copyable exemplar. Read them when a project has more than a couple of models or when asked how to organise CAD code and artifacts.
+- `references/migrations.md` — the tooling disagreeing with a model you believe is correct: recognizing a project authored against an older cadgen, and where the migration guides live.
+
+Final responses should include generated files, returned `$cad-viewer` viewer links, verification snapshots, validation actually run, assumptions, and caveats. Use `references/inspection-and-validation.md` for report structure.

--- a/.qwenpaw-plugin/skills/cad/agents/openai.yaml
+++ b/.qwenpaw-plugin/skills/cad/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CAD"
+  short_description: "Generate and validate CAD artifacts."
+  default_prompt: "Use $cad to create, regenerate, inspect, and validate explicit CAD files and selector refs, handing supported outputs to $cad-viewer when available."

--- a/.qwenpaw-plugin/skills/cad/references/build123d-modeling.md
+++ b/.qwenpaw-plugin/skills/cad/references/build123d-modeling.md
@@ -1,0 +1,498 @@
+# build123d modeling patterns
+
+Read this file when writing or repairing build123d Python source.
+
+## Modeling objective
+
+Create a valid STEP-ready BREP model, not a visual mesh. Prefer closed solids, explicit labels, and stable parametric dimensions. Define the `@step` model function returning the STEP-ready shape or labeled compound; the CLI owns output paths (see `step-generation.md`). Name a buildable entry generator `<name>.py` (the marker the viewer and build tools scan for); keep `<name>.py` for helper/library modules that are only imported, not built on their own (see "Entry generators are named `<name>.py`" in `step-generation.md`).
+
+## Design strategy
+
+Decide how the part is constructed before writing geometry code:
+
+- **Choose the construction that makes the spec's dimensions direct parameters.** Profile-driven shapes get one closed sketch plus `extrude`/`revolve`/`sweep`/`loft`; block-and-feature parts get a base solid plus subtractive features. Prefer whichever construction lets the user's controlling dimensions appear as named parameters instead of derived values.
+- **Decide part vs assembly before modeling.** Bodies that are separately manufactured, purchased, or movable belong in a labeled assembly (see `positioning.md`); monolithic manufacturing intent gets a single fused solid. Avoid unlabeled compounds of solids — multi-body output without occurrence labels loses traceability in inspection and viewer review.
+- **Pick the origin and orientation from the functional datum before sculpting.** Model on the mating interface, mounting plane, or symmetry axis; see `positioning.md` for part-type origin defaults.
+- **Order operations so fragile steps come last and failures localize.** Base solid → major additions → subtractive features → shell → through-wall holes → fillets and chamfers last. Fillets are the most failure-prone operation and every boolean invalidates selectors, so postpone them. Structure the source so each feature is a named step — a per-feature function or a distinct intermediate variable — so a failed operation points at exactly one feature and a parameter change touches one obvious place.
+- **Overshoot boolean tools.** Extend cutting tools past the faces they enter and exit; for through-cuts, go roughly 1 mm beyond both faces. Coincident or coplanar tool/target faces are a classic kernel failure. Cut repeated or patterned features in one combined operation.
+- **Sanity-check proportions before generating.** Compare the expected bounding box against the real-world object, wall thickness against overall size, and feature positions against edges and neighboring features. Order-of-magnitude and collision errors pass geometric validation but fail visual review.
+
+## Topology stack
+
+Think in this order:
+
+```text
+Vertex → Edge → Wire → Face → Shell → Solid → Compound
+```
+
+For assemblies, use these repo topology terms consistently:
+
+- **Occurrence**: a placed node in the assembly tree. An occurrence has a parent, transform, path, and user-facing role such as `lid` or `m3_screw:front_left`.
+- **Shape**: an exported geometry/body inside an occurrence. Shape rows own topology; faces and edges belong to a shape, and the shape belongs to an occurrence.
+- **Face/edge**: selectable topology owned by a shape. Do not assume arbitrary faces or edges have persistent intent labels; inspect them by occurrence, shape, ordinal, surface/curve type, and measured geometry.
+
+When inspecting topology, follow `assembly occurrence -> shape/body -> faces -> edges`. Every face/edge row should be traceable through both `occurrenceId` and `shapeId`.
+
+For normal STEP output, return one of:
+
+- a valid `Solid`
+- a compound of valid solids
+- a labeled assembly compound
+
+Avoid returning loose wires, open faces, or construction surfaces unless the user explicitly requested them.
+
+## Parameters first
+
+Put meaningful dimensions in named variables:
+
+```python
+width = 80.0
+depth = 50.0
+thickness = 6.0
+hole_diameter = 4.5
+hole_offset_x = 30.0
+hole_offset_y = 17.5
+```
+
+Avoid burying important numbers inside geometry calls.
+
+## Coordinate system
+
+Declare or comment the convention:
+
+```text
+Origin: center of primary part or chosen mating datum
+XY: main base/sketch plane
++Z: up/extrusion direction
+```
+
+Use `Location`, `Plane`, and `Axis` intentionally. For positioning-sensitive tasks and source-level assembly relationships, read `positioning.md`.
+
+## Builder contexts
+
+Use the context that matches the geometry:
+
+```python
+with BuildLine() as path:
+    ...
+
+with BuildSketch() as profile:
+    ...
+
+with BuildPart() as part:
+    ...
+```
+
+Typical flow:
+
+```text
+curves/paths → sketches/profiles → solids/features → labels → STEP
+```
+
+## Selection practices
+
+Avoid fragile topology order when possible. Select by:
+
+- axis or normal
+- location or bounding position
+- plane grouping
+- feature intent
+- stable construction plane
+- inspected local selector ref for downstream validation
+
+For source operations, prefer robust selectors such as top/bottom by axis or position rather than arbitrary list indexes.
+
+
+## Assemblies and positioning
+
+For assemblies, keep this file focused on BREP modeling patterns and labels. Use `positioning.md` as the single source of truth for:
+
+- part-local coordinate conventions
+- when to use `cadgen.assembly.AssemblyHelper`, build123d joints, or explicit `Location` transforms
+- `connect_to()` behavior
+- CLI `inspect align` as read-only selector-pair alignment validation
+- frame, measure, and positioning report expectations
+
+## Labels and assemblies
+
+Label every exported part and assembly child with native build123d labels. Prefer concise intent labels through `cadgen.assembly` helpers:
+
+```python
+from cadgen.assembly import AssemblyHelper, label_shape
+
+asm = AssemblyHelper("electronics_enclosure")
+base = asm.add(make_base(), "base")
+lid = asm.add(make_lid(), "lid")
+
+boss = label_shape(Cylinder(radius=3.0, height=12.0), "m3_boss", "front_left")
+```
+
+Do not prefix labels with topology categories like assembly, component, feature, datum, mate, or hardware. The assembly tree and topology inspection already expose those structural categories. Use labels for the intent topology cannot reliably infer: role, placement, interface, repetition, or mating purpose. Feature labels survive STEP export best when the feature remains a labeled child shape in a `Compound`; boolean-subtracted or fused feature history should be represented by source parameters, named datums, and validation refs instead of assumed persistent feature labels.
+
+Label for inspection:
+
+- Label the root assembly.
+- Label every exported part, subassembly/module, and repeated component occurrence.
+- Use occurrence labels for assembly role and placement, especially repeated parts: `m3_screw:front_left`, `m3_screw:rear_right`.
+- Use shape labels for retained exported geometry/body roles where useful.
+- Use feature/datum labels only when that geometry remains exported as a child shape.
+- Use named mate datums for source-level positioning intent, then validate the exported STEP topology and occurrence frames.
+
+Occurrence and shape labels are exported through STEP names and surfaced in `STEP_topology` when available. The viewer uses occurrence labels for assembly/tree references and shape labels for shape references. Faces and edges inherit their context from `occurrenceId` and `shapeId`; do not promise persistent face/edge intent labels unless explicit tested support exists.
+
+For repeated parts, keep occurrence labels, transforms, or joint connections explicit and inspect frames/positioning after generation.
+
+## Colour
+
+Two rules, both of which fail silently — no error, just a model that looks wrong.
+
+**Channels are LINEAR RGB, not sRGB.** The renderer converts them to sRGB on the
+way to the screen, so `Color(0.5, 0.5, 0.5)` displays as roughly `#BCBCBC`, not
+`#808080`. Picking channel values off a hex palette by eye gives a washed-out,
+desaturated model. Author with `cadgen.srgb()`, which takes the hex you want to
+see:
+
+```python
+from cadgen import srgb
+
+body.color = srgb("#2E3742")
+glass.color = srgb("#38414D", 0.42)   # with alpha
+```
+
+**Colour on a group compound is ignored.** Only *leaf* occurrences carry colour
+into the model's tree, so a colour set on a `Compound` that has children never
+reaches the screen. It does reach the STEP file's XCAF label, which is why this
+looks like it worked if you only check the STEP. Colour every leaf.
+
+## Finish
+
+Colour alone cannot tell cast from machined from carbon: those differ in how
+they RESPOND to light, and by default every part takes the viewer theme's one
+roughness/metalness/clearcoat. A leaf shape may carry a `cad_material` dict to
+override those per part; the values ride the tree's occurrence and
+the viewer applies them over the theme, so the same model reads differently
+under every theme without re-authoring:
+
+```python
+housing.cad_material = {"roughness": 0.85, "metalness": 0.2}            # as-cast
+journal.cad_material = {"roughness": 0.25, "metalness": 0.9}            # ground steel
+lacquer.cad_material = {"roughness": 0.4, "clearcoat": 1.0, "clearcoatRoughness": 0.1}
+window.cad_material = {"opacity": 0.35}
+```
+
+Keys: `roughness`, `metalness`, `clearcoat`, `clearcoatRoughness`, `opacity`,
+each clamped to 0..1; unknown keys are ignored. Like colour, it belongs on the
+LEAF — a group compound's `cad_material` reaches nothing — and it is a
+presentation hint only: STEP has no channel for it, so it lives in the package,
+not the file.
+
+## Rotating a plane
+
+`Plane.rotated()` composes its matrix in **WORLD axes, not the plane's own**.
+On a plane whose axes are not the global ones this is the single most expensive
+trap in the library, because the result is a valid solid of the wrong shape.
+
+For a spanwise aerofoil section — `x_dir=(-1,0,0)`, `z_dir=(0,1,0)`, i.e. local
++x rearward and the normal along +Y — `plane.rotated((0, 0, twist))` reads like
+a pitch and is actually a **yaw about world Z**. Measured on a 200 mm chord: a
+20 deg "twist" put the trailing edge at `(812.0, -68.4, 99.4)` when it should
+be at `(812.1, 0.0, 168.4)`. The section slid 68 mm sideways out of its own
+spanwise station and rose nothing.
+
+Nothing downstream catches it. The loft succeeds, the solid is closed,
+watertight and free of self-intersections, and `cadgen step inspect refs --facts`
+passes it. Only looking at a render finds it.
+
+Build the frame from explicit direction vectors instead:
+
+```python
+# incidence about the span axis, then yaw the whole frame
+t, s = math.radians(twist_deg), math.radians(sweep_deg)
+x_dir  = Vector(-math.cos(t) * math.cos(s), -math.cos(t) * math.sin(s), math.sin(t))
+normal = Vector(-math.sin(s), math.cos(s), 0.0)
+plane = Plane(origin=Vector(*origin), x_dir=x_dir, z_dir=normal)
+```
+
+The same applies to rolling a section about a swept member's own axis: use a
+Rodrigues rotation about that axis rather than `Plane.rotated()`.
+
+## Multi-section lofts match sections BY INDEX
+
+A loft interpolates its sections point index by point index. If you sample each
+station at fractions of THAT station's own width, a feature — a crest, a
+silhouette edge — sits at a different index at every station, and the surface
+twists between them to reconcile them. The result is valid, watertight,
+bilaterally symmetric, passes `inspect validate`, and renders as **crumpled
+foil** over every square metre. Nothing reports it; only a render finds it.
+
+Sample on **rails**: compute the lateral position of each feature line per
+station and allocate a fixed number of points to each rail-to-rail band, so
+index *i* means the same feature everywhere. Cluster samples toward the rails —
+that is where curvature is worst, so even spacing inside a band leaves the
+sharpest part of the curve least resolved.
+
+Two more ways a control curve silently ruins a lofted surface:
+
+- **`smoothstep` between control points makes a staircase.**
+  `lerp(v0, v1, smoothstep(x0, x1, x))` has zero derivative at BOTH ends of every
+  interval, so the curve is flat at each control point and steep between them.
+  Lofting through such curves puts a crease at every knot. Use a monotone cubic
+  (PCHIP) instead.
+- **Measurement noise becomes surface ripple.** Station data traced off a scan
+  carries ~a pixel of noise; a monotone interpolant reproduces it exactly and the
+  loft turns it into visible waves. Smooth the control curve before lofting.
+
+## Blending volumes: a closed lobe that ends inside the body is a cliff
+
+When sections are built by smooth-max/min over component volumes, any closed
+convex profile meets its own silhouette on a **vertical tangent**. Where such a
+lobe closes *inside* the body — against a neighbouring shelf or lobe — you get a
+near-vertical wall no blend width and no sample density can round off. Extra
+sampling does not help: the corner is in the function, not the sampling.
+
+- Widen the lobe until it OVERLAPS its neighbour and cut the real feature back in
+  afterwards, rather than letting it close between them.
+- Give a feature that needs its own width its own lobe. One half-width cannot
+  serve both a wide fuselage and a narrow canopy.
+- Prefer a **compact-support polynomial** smooth-max to the softplus/log-sum-exp
+  form: softplus perturbs the surface everywhere and its curvature is unbounded
+  as the blend narrows. Use the **cubic** (`h**3`) form, not the quadratic
+  (`h*(1-h)`) one — the quadratic is only C1, so curvature JUMPS at the edge of
+  the blend band, and a curvature jump on a specular surface draws a visible
+  line.
+
+## Validity is not positive volume
+
+`Shape.is_valid` (and `BRepCheck_Analyzer`) can return **True for a shell with a
+large negative volume** — an inverted orientation. Such a body exports and
+renders as a hole in the world. Check both:
+
+```python
+def is_valid_shape(shape):
+    return (shape is not None
+            and BRepCheck_Analyzer(shape.wrapped).IsValid()
+            and shape.volume > 0.0)
+```
+
+Related: a boolean can leave a body that is geometrically right but
+topologically invalid — correct bounds and volume, one bad face. It survives
+until the next boolean, which then fails with `Null TopoDS_Shape object` from a
+call nowhere near the cause. `ShapeFix_Shape` repairs many of these; gate every
+boolean result rather than trusting the last operation.
+
+`cadgen step inspect validate` runs both of these gates plus closure and
+self-intersection over every occurrence, so this does not have to be hand-rolled
+per model. Note it measures volume **per solid**: an inverted member inside a
+compound cancels against a sound one, so anything reading a compound's aggregate
+volume sees nothing wrong.
+
+## A revolve puts its seam at +X
+
+A 360-degree `revolve` leaves a seam edge where its profile started, and
+sketching on `Plane.XZ` places that seam at **+X**. If the presentation camera
+looks down +X, every revolved casting renders with a thin panel line down its
+visible face — on parts whose whole point is a smooth, sealed surface.
+
+This is not limited to `revolve`: a plain `Cylinder` primitive seams at +X too,
+verified with a marker probe. Any large smooth camera-facing cylinder is
+affected.
+
+Rotate the finished body about Z so the seam lands away from the camera. Two
+cautions:
+
+- A body carrying discrete features (a bolt ring, a stud circle) must be rotated
+  by a whole number of feature pitches, or left alone and its *prototype*
+  rotated instead — `bolt_ring`-style helpers only translate their prototype, so
+  seam-hiding the prototype does not move the ring.
+- A body offset from the origin must be rotated about **its own** axis: build it
+  at the origin, rotate, then translate. Rotating in place about global Z flies
+  it across the model.
+
+Prove the fix with two renders — the seam absent from the camera face **and**
+present on the far side. Without the second render you cannot tell a hidden seam
+from one that was never visible at that angle.
+
+## Fillet retry ladders degrade silently
+
+The `pipe()`-style retry ladder (`[bend, .7, .5, .3, 20]` around
+`FilletPolyline`) exists for a good reason: one oversized corner otherwise kills
+an entire build with `BRep_API: command not done`. But it converts a hard
+failure into an invisible cosmetic regression.
+
+Where a profile cannot accept the nominal radius, the ladder silently falls back
+— a 6 mm rim fillet became ~2 mm on a 660 mm-diameter flange, which tessellates
+as a visible sawtooth. The build reports success; only a render cropped to ~5x
+shows it.
+
+Do not rely on the ladder for cosmetic radii. Reshape the profile so the
+intended radius genuinely fits (a knife-edged wafer cannot take any fillet;
+merge it into its neighbour), then verify by cropping the render.
+
+## Multi-tool booleans: one list operation, internally disjoint batches
+
+Never accumulate boolean tools pairwise — `body - a - b - c` re-runs the whole
+intersection network per step and decays O(n²). Pass every tool in one list
+operand: `body - [a, b, c, ...]`.
+
+Two caveats, both measured:
+
+- **Tools that overlap each other deep below the surface are pathological.**
+  ~200 shallow spherical dimples cut with full spheres (radii ~15 mm for
+  0.02 mm-deep stamps) ran >40 CPU-minutes with zero output; pre-clipping each
+  stamp to a small disjoint "lens cap" (`Sphere & Cylinder` prototype,
+  translated copies) cut the same field in 0.69 s. Keep tools small and
+  mutually disjoint.
+- **A single multi-tool cut whose tools overlap each other can emit wrong
+  results.** A bore cylinder crossing a stack of thin ring cutters returned
+  5 solids: the body, the bore's uncut PLUG kept as a detached solid, and
+  knife-edge slivers. Every tool was individually valid; splitting the same
+  tools into two staged subtracts (functional cuts, then finishing cuts)
+  yielded one clean solid. Batch tool FAMILIES so each batch is
+  internally disjoint-ish — still list-based, never pairwise.
+
+## Near-tangent booleans silently drop material
+
+Intersecting or subtracting nearly tangent surfaces (a huge shallow sphere
+kissing a small revolve, a flat dome tool grazing a face) can succeed with
+exit 0 and a validate-clean result while half a tool's material was simply not
+removed — or a stray disjoint sliver is left floating inside the part. Only
+visual review catches it. Build shallow domes as a single revolved profile
+(`RadiusArc` in the section) instead of near-tangent boolean stacks; it is
+also crisper.
+
+## Do not 3D-chamfer tangent chains or multi-arc outlines
+
+OCC `chamfer`/`fillet` on edges that belong to a tangent chain (a domed face
+meeting cap cylinders) or to a multi-arc "blob" outline behaves three ways
+depending only on exact dimensions: silent failure, minutes of CPU churn per
+attempt, or an **uncatchable SIGSEGV** that kills the whole build. Chamfering
+edges NEXT TO already-beveled arcs can also hard-crash. Retry ladders multiply
+the churn and hide the degradation.
+
+Bake the bevel into construction instead: put it in the extruded/lofted
+SECTION profile, or build the body straight-walled to `z_top - w` and cap it
+with `extrude(..., taper=45)` (or per-arc `Cone` caps when the draft prism
+itself fails). Constructive bevels also survive later booleans, which
+chamfered edges often do not.
+
+## 2D sketch algebra decays; winding decides extrude direction
+
+Chained 2D unions are fragile in three stacked ways, all silent:
+
+- `Circle + Circle` returns a fused `Face`, and the next `Face + Polygon`
+  falls into raw shape fuse returning an unregularized face pile; once any
+  step yields a `ShapeList`, later `+` is Python list concatenation, not
+  geometry. Build each profile as ONE multi-operand fuse:
+  `first + [rest...]`.
+- A CLOCKWISE-wound `Polygon` fuses as a reversed face: the union "succeeds"
+  but shatters into mixed-normal fragments and `extrude()` runs along the
+  reversed normals — solids appear mirrored below the plane. Wind every
+  polygon CCW. **Mirroring a point list reverses its winding**: mirror with
+  `[(-y, z) for y, z in reversed(pts)]`, or the extrude silently runs the
+  other way and the cutter lands off the part.
+- `ShapeList & Sketch` used as a regularizing clip returns an EMPTY list with
+  no error, and the following extrude quietly produces a zero-volume part.
+  Apply the `& clip` intersection exactly once, LAST, on the single fused
+  profile.
+
+## `align=(None, None, None)` is the raw OCC datum, not "centered"
+
+`Cylinder`/`Cone` with `align=(None, None, None)` sit base-at-z=0 (XY
+centered); `Box` sits with its CORNER at the origin. Code written assuming
+"None means centered" produces silently wrong geometry — off-center slots,
+inverted countersinks, cutters that remove nothing because they sit entirely
+above the surface. Two independent modules shipped defects from this exact
+assumption. Default alignment IS centered; reserve `align=None` for when the
+raw datum is genuinely wanted.
+
+## Place with `Location * shape` or `.moved()`, never `.located()`
+
+Two independent reasons, both silent.
+
+**`.located()` SETS the placement; `.moved()` composes with it.**
+`Shape.rotate()` returns a rotated copy. Placing that copy with
+`.located(Location(pos))` throws the rotation away: `located` assigns an
+ABSOLUTE location, so what lands at `pos` is the ORIGINAL orientation.
+`.moved()` and the operator form compose.
+
+```python
+box = Solid.make_box(1, 1, 1)          # x[0,1]
+r   = box.rotate(Axis.Z, 90)           # x[-1,0]   rotation applied
+
+r.located(Location((5, 0, 0)))         # x[5,6]    rotation DISCARDED
+r.moved(Location((5, 0, 0)))           # x[4,5]    rotation kept
+Location((5, 0, 0)) * r                # x[4,5]    the same, as an operator
+Pos(5, 0, 0) * Rot(0, 0, 90) * box     # x[4,5]    position and rotation, composed
+```
+
+Nothing raises, and the bounding box moves the distance you asked for, so the
+result looks placed. Verified on build123d 0.11.1.
+
+The failure mode is a sweep that reads as physics. Placing a part with
+`.rotate(...).located(...)` inside a loop over angles feeds `intersect()` the
+same unrotated shape every iteration, so a gear-mesh collision check returns an
+identical volume to 15 significant digits at every phase — a flat, plausible
+curve rather than an error.
+
+**`.located()` deep-copies the geometry.** In an assembly body, a child model
+placed with `.moved()` or `Location * child` keeps its identity, so the
+parent's result LINKS to the child's tree (stored once, shared by every
+parent). `.located()` copies the underlying shape, which makes the parent own
+a duplicate of the child's geometry as its own component — the file still
+builds, the dependency is still tracked, but the link is gone and the
+component is written again. Reach for `.moved()` or the operator form; there
+is no case that needs `.located()`.
+
+## Dense periodic spline profiles: kernel ops to avoid
+
+On faces bounded by one periodic `Spline` fit through hundreds of samples,
+several kernel operations fail or corrupt (verified on build123d 0.10 /
+OCP 7.9): `extrude(face, taper=...)` throws `BRepFill_TrimSurfaceTool:
+incoherent intersection`; kernel wire `offset` returns Null for some inward
+deltas; fusing two valid solids that share a coincident spline-bounded planar
+face can return an EMPTY result; and a ruled loft to an inward offset is
+analyzer-invalid where the outer wire's corner radius is smaller than the
+offset. Compute offsets NUMERICALLY on the sample loop (normal offset, prune
+points closer than |delta| to the source polyline, resample, smooth) and build
+beveled bodies as one multi-section ruled loft so no coincident-face fuse
+exists.
+
+## Gate boolean results with the BOP check, not volume
+
+`result.volume > 0` and even `BRepCheck_Analyzer.IsValid()` both accept
+chamfer and V-groove-cut results whose skinny faces are BOP-faulty
+(`BOPAlgo_SelfIntersect`, `BOPAlgo_TooSmallEdge`). The failure then surfaces
+only in `cadgen step inspect validate` (`selfIntersecting`), with no pointer to
+the causing operation. After tangency-prone cuts and chamfers on wavy
+outlines, gate with the same check validation uses — `BRepAlgoAPI_Check` —
+and step the operation down or skip it when the check fails.
+
+Related wrap trap: re-wrapping a bare `Solid` as `Part(solid.wrapped)` yields
+a shape whose `.volume` is 0 (build123d 0.10), so volume-based guards silently
+discard real geometry. Use the `Solid` directly as a compound child (Shape
+carries `label`/`color`), or fuse before measuring.
+
+## Common failure modes
+
+- Fillet radius larger than local edge geometry.
+- Open sketch profile produces invalid or missing face.
+- A loft whose SECTION WIRE self-intersects. `make_face` accepts a
+  self-intersecting periodic spline and reports a valid, positive-area face, so
+  each station looks fine in isolation; the loft then fails on whichever
+  adjacent pair is worst. Bisect by lofting adjacent pairs to find the station.
+  Common cause: two points straddling a crease offset along the corner's
+  TANGENT lines rather than placed on the curve, so the outline doubles back.
+- Smooth `loft()` failing with `BRep_API: command not done` even though every
+  section is individually valid and they all share one edge count. Try
+  `loft(..., ruled=True)`; with densely spaced sections the result is visually
+  equivalent.
+- `solid += helper()` where the helper returns a *list*: the accumulator becomes
+  a `ShapeList`, and the failure surfaces much later as an anytree
+  `Cannot add non-node object` from inside `Compound(children=...)`.
+- Face selector changes after a boolean or fillet.
+- Part origin is arbitrary and later alignment checks become ambiguous.
+- Source-level joints are treated as if they were persistent STEP constraints rather than one-time source placement operations.
+- Joint labels are missing, duplicated, or attached to the wrong local datum.
+- `.connect_to()` fixes the wrong side of the relationship, moving the part intended to remain fixed.
+
+Use `repair-loop.md` when generation or validation fails.

--- a/.qwenpaw-plugin/skills/cad/references/cad-brief.md
+++ b/.qwenpaw-plugin/skills/cad/references/cad-brief.md
@@ -1,0 +1,130 @@
+# CAD brief
+
+Read this file when converting a user's request — prose, reference images, technical drawings, or a combination — into a CAD brief. The brief is an internal note-taking scaffold; do not ask the user to fill it out, and do not require the user to provide JSON. If the user supplied JSON voluntarily, extract the same information but continue the workflow in prose notes and build123d source.
+
+## Goal
+
+Convert the request into an actionable modeling brief before writing source or running tools. Every input modality funnels into the same brief; the downstream workflow does not change.
+
+The brief should answer:
+
+- What is being modeled, and is it a part, assembly, modification, inspection task, or secondary output request?
+- What dimensions and units are specified, and which missing dimensions are inferable?
+- Which features are required?
+- Which faces, axes, origins, joints, or interfaces control positioning?
+- What output files are requested?
+- What must be validated before success is reported?
+
+When inputs conflict, dimensioned sources win over image proportions. When two dimensioned sources conflict — prose says one value, a drawing callout says another — flag the conflict instead of silently choosing.
+
+## Reference images
+
+An image without stated dimensions is design intent, not a spec:
+
+- Establish scale from one stated dimension or a known object in frame; if neither exists and fit matters, that is the one clarification question to ask.
+- Estimate remaining proportions from the image and record them as assumptions like any other inferred value.
+- Distinguish reproduction ("model this part") from inspiration ("something like this") in the brief; reproduction raises fidelity expectations, inspiration leaves freedom.
+- For reproduction, plan a snapshot from the reference image's viewpoint and compare it against the image during visual review.
+
+## Technical drawings
+
+A drawing is a dimensioned contract. Extract it systematically:
+
+- Read the title block and notes first: units, projection convention, revision, disclaimers.
+- Identify which view is which — front/top/side, sections, details, iso — and which model axes each maps to before extracting numbers. Trust callouts and view labels, not layout conventions. Section views are the source of truth for internal features: bores, counterbore and blind-hole depths, wall sections.
+- Convert every dimension callout into a named parameter and a validation target. Multiplicity (`4X`), `TYP.`, and thread/counterbore/countersink callouts expand into features plus checks.
+- Never scale undimensioned geometry off the image. Derive it from stated dimensions when constrained; otherwise assume and report.
+- Cross-check features across views; when views disagree, prefer the dimensioned view and flag the conflict.
+- Success for a drawing-driven model: every drawing dimension is either verified by `measure`/`refs` after generation or explicitly reported as not verified.
+
+## Brief format
+
+Use concise Markdown notes, not a user-facing structured schema:
+
+```text
+CAD brief:
+- Model: <part or assembly name>
+- Task type: <new part, assembly, modification, inspection, secondary output>
+- Inputs: <reference images or drawing views used; omit when prose-only>
+- Units: <explicit or assumed>
+- Coordinate convention: <origin, base plane, up axis>
+- Overall dimensions: <width/depth/height or equivalent>
+- Functional features: <holes, slots, ribs, bosses, pockets, shells, text, etc.>
+- Manufacturing assumptions: <only when relevant>
+- Positioning/mating: <interfaces, datums, child placements, joints, alignment rules>
+- Paths: <generator .py, STEP target, secondary outputs if requested>
+- Validation targets: <bbox, solid count, labels, spec-driven measurements, refs>
+- Assumptions: <only meaningful inferred choices>
+```
+
+## Example: simple part
+
+User says:
+
+```text
+Make a 100 mm by 60 mm by 6 mm mounting plate with rounded corners, four M4 clearance holes 10 mm in from the corners, and a 20 by 12 mm rectangular cutout in the center.
+```
+
+Agent brief:
+
+```text
+CAD brief:
+- Model: mounting_plate, single STEP part.
+- Units: millimeters.
+- Origin: center of plate; base plane XY; +Z is thickness direction.
+- Body: rounded rectangular plate, 100 × 60 × 6 mm.
+- Corner radius: not specified; assume 3 mm.
+- Holes: four 4.5 mm M4 clearance through-holes, 10 mm in from each corner.
+- Cutout: centered rectangular through-cut, 20 × 12 mm.
+- Validation: one positive-volume solid, bbox 100 × 60 × 6 mm, four holes, one center cutout, label mounting_plate.
+```
+
+## Example: assembly
+
+User says:
+
+```text
+Design a two-piece enclosure, 120 by 80 by 35 mm, with a lid that sits on top and four screw bosses aligned between base and lid.
+```
+
+Agent brief:
+
+```text
+CAD brief:
+- Model: enclosure assembly with base and lid.
+- Units: millimeters.
+- Assembly origin: center of enclosure footprint; +Z upward.
+- Base: hollow lower shell, exterior 120 × 80 mm footprint; height derived from total height minus lid thickness.
+- Lid: separate plate on top; assume 3 mm lid thickness unless user gave another value.
+- Bosses: four aligned screw bosses; assume M3 unless unspecified dimensions make this unsafe.
+- Positioning: base top face and lid bottom face are mating datums; screw axes must align; native build123d joints may be used if they clarify reusable mount points or motion.
+- Validation: labeled base and lid children, bbox near 120 x 80 x 35 mm, aligned hole/boss axes.
+```
+
+## Clarification policy
+
+Ask one focused question only when the missing information affects fit, safety, compliance, or makes the part impossible to model. Otherwise proceed with assumptions and report them.
+
+Ask when:
+
+- No dimensions are provided for a physical object, and no scale reference exists in the supplied images.
+- A mating interface is described but the mating geometry is unspecified.
+- The part is safety-critical, load-bearing, pressure-bearing, medical, or compliance-bound.
+- The requested output depends on an absent source file or missing imported geometry.
+
+Do not ask when:
+
+- A default clearance hole standard is sufficient.
+- A cosmetic fillet radius can be safely assumed.
+- Origin/orientation can be chosen and reported.
+- The user is asking for a conceptual first-pass CAD model.
+
+## Success criteria
+
+A brief is ready for modeling when it contains enough information to define:
+
+- source file path and STEP target path
+- units and local coordinate system
+- named parameters
+- feature plan and labels
+- expected bounding box or key measurements

--- a/.qwenpaw-plugin/skills/cad/references/inspection-and-validation.md
+++ b/.qwenpaw-plugin/skills/cad/references/inspection-and-validation.md
@@ -1,0 +1,328 @@
+# Inspection and validation
+
+Read this file for every generated STEP artifact and whenever the user asks for geometry facts, references, dimensions, mating, diffing, or frame inspection.
+
+## Principle
+
+Deterministic geometry checks decide pass/fail; mandatory snapshot review (see `snapshot-review.md`) catches semantic errors the deterministic checks did not encode. Scale the deterministic checks to the user's spec: every dimension, clearance, or relationship the user specified — including dimensions taken from a technical drawing — must be verified with `measure`, `align`, or `frame`. The facts/planes/positioning baseline runs for every generated artifact regardless of spec.
+
+## Tool
+
+The launcher lives in the CAD skill directory:
+
+```bash
+cadgen step inspect {refs|diff|frame|measure|align} ...
+```
+
+Targets take native path semantics, like every other cadgen path argument: a relative target resolves against the command cwd, an absolute target works from anywhere, and `~` expands. A target naming a file that does not exist reports file-not-found for that path. Prefer cwd-relative targets from the workspace that owns the artifact anyway — reports name a target by its cwd-relative path when it is inside the cwd, and by its bare file name when it is not, so cwd-relative targets read better in a report. Common data-output flags: `--format json|text` (default is machine-readable), `--quiet`, `--verbose`.
+
+Accepted target forms:
+
+```text
+path/to/document.step
+path/to/document.stp
+```
+
+Targets are documents, spelled with their extension: a bare `<name>` and a `.py`
+model script are refused (run `python <model>.py`, then inspect the STEP it
+wrote). A door never opens the scripts beside a document to learn which one
+wrote it.
+
+Selector-backed queries (`refs --facts`, planes, measures) resolve from the document's tree in the store — its per-component `.surf` objects — on demand; a document with no tree yet is compiled from its bytes first, generated or imported alike. There is no separate topology sidecar to build or invalidate, and a document is never refused for being behind its script.
+
+Selector refs are local to the STEP/CAD entry target passed to the command:
+
+```text
+#o1.2
+#o1.2.f1
+#f1
+```
+
+Pass selector refs as `#...` tokens. The STEP/CAD file path or entry target is a separate CLI argument.
+
+An occurrence ref may name a **subassembly** as well as a part — the same `#o1.4` the CAD
+Viewer copies, `snapshot --focus` takes, and a kinematics mate poses. A subassembly owns no
+geometry of its own, so it resolves as the parts beneath it: `refs` reports one entry per
+part (each tagged `fromGroup`), and `measure`/`align` use the branch's combined extent.
+`frame` answers for the branch — its name from the instance tree, plus the extent and
+center of its parts; a subassembly has no transform of its own, because group placement is
+baked into each part's absolute transform. Counts (`occurrenceCount`, `refs --facts`) stay
+leaf-based. An occurrence ref that names nothing lists what the document does have at that
+depth.
+
+### File-prefixed refs (the CAD Viewer copy format)
+
+A ref copied from the CAD Viewer carries the file it came from, so it stays meaningful in a
+prompt that spans several files:
+
+```text
+bracket#o1.2.f1               the generator src/bracket.py
+imported_housing.step#o1.3    a raw STEP, STEP/imported/imported_housing.step
+mounting_plate.stl#           a whole mesh file
+```
+
+The prefix is the **shortest path suffix that names exactly one file**, plus as many leading
+directories as it takes to be unique. A prefix with no selectors after the `#` names the whole
+file.
+
+A `.py` generator shows as a bare stem, because generators are what you normally work in
+and the common case deserves the shortest name. Everything else keeps its suffix:
+
+| File | Prefix |
+| --- | --- |
+| `bracket.py` | `bracket` |
+| `bracket.step`, `bracket.stp` | `bracket.step`, `bracket.stp` |
+| `plate.stl`, `plate.3mf`, `plate.glb`, `outline.dxf` | unchanged |
+
+Keeping those suffixes is what makes the stripping safe: `bracket` (the generator) stays
+distinct from `bracket.step` (its export) and from `bracket.stl` (a mesh of it).
+
+**These CLIs do not resolve prefixes. You do.** When you receive a file-prefixed ref:
+
+1. Split it at the first `#`. The left side is the file prefix; the right side is the ref.
+2. Resolve the prefix to a real path. A bare stem is **not** a literal path suffix, so expand
+   it before searching:
+   - `<name>` with no extension → the model script `<name>.py`; its DOCUMENT (the sibling
+     `<name>.step` by default, or the decorator's `out=` target) is what the commands take
+   - anything carrying a suffix (`.step`, `.stp`, `.stl`, `.3mf`, `.glb`, `.dxf`) → use as-is
+
+   Match on **segment boundaries**, so `plate.stl` names `STL/plate.stl` and never
+   `STL/mounting_plate.stl`.
+3. Pass the resolved document as the entry/input argument and the `#...` part as the ref,
+   exactly as you would for a bare ref.
+
+```bash
+# received: bracket#o1.2.f1   ->  expand the bare stem, then search
+git ls-files '*/bracket.py'
+cadgen step inspect refs STEP/bracket.step '#o1.2.f1'
+```
+
+If the search returns more than one file the prefix was ambiguous — ask rather than guess; the
+Viewer only emits prefixes that were unique when it copied them.
+
+Passing the prefixed ref through unsplit also works **when the prefix names the file the
+command already targets** — the CLI strips it, and it accepts every spelling of that file
+(`bracket`, `bracket.py`, `bracket.step`). A prefix naming a *different* file is a hard
+error, never ignored: silently inspecting the file the command was pointed at would produce a
+confident answer about geometry nobody asked about.
+
+```text
+ref 'other_part#o1.2' names file 'other_part' but this command targets
+'STEP/bracket'; pass the file as the entry argument and the '#...' part as the ref
+```
+
+Bare `#...` refs are unchanged and work everywhere they always did.
+
+### Referencing a part by its label
+
+A part's build123d label can stand in for its occurrence id anywhere a ref is accepted:
+
+```text
+#eye_shank             the part labelled eye_shank
+#eye_shank.f45         a face on it
+#eye_shank.f45,f46     two faces on it -- the label carries forward like an occurrence id
+```
+
+Numeric refs are unchanged and always work; labels are an additional spelling, not a
+replacement. `snapshot --mode list` shows each part's `name`, and `inspect refs` reports the
+exact ref to paste as `labelRef`.
+
+A label may contain letters, digits, `_` and `:`, and may not start with a digit. Parts whose
+label cannot be spelled that way, or which collides with the numeric grammar (`f12`, `o1`,
+`m2`), are addressable by their numeric ref only.
+
+When several parts share a label -- two wheels, one `cast_rim:5spoke` -- each gets a numbered
+ref in tree order and the bare label refuses to resolve rather than guessing:
+
+```text
+$ cadgen step snapshot motorbike.step --focus '#cast_rim:5spoke'
+selection.focus label 'cast_rim:5spoke' matches 2 occurrences;
+use one of: #cast_rim:5spoke_1 (o1.7.2), #cast_rim:5spoke_2 (o1.14.2)
+```
+
+## Validation sequence
+
+1. Generation completed and the STEP/STP file exists.
+2. `refs --facts --planes --positioning` confirms scale, labels, major planes, and placement-ready references. Run this for every generated artifact.
+3. `validate` confirms the geometry is sound: valid topology, closed shells, no self-intersection, and positive volume on every solid. Run this for every generated artifact.
+4. Spec-driven checks: `measure` for every user-specified dimension, offset, or clearance; `align` for interfaces that should be flush or centered; `frame` for orientation and occurrence-placement expectations; `diff` for modifications that could affect unrelated geometry.
+5. Snapshot the primary STEP/STP per `snapshot-review.md`, then convert every visual concern into a deterministic geometry check before it becomes a validation claim.
+
+### `refs --facts` "ok" is not a geometry claim
+
+`refs --facts` reports counts, bounds, labels and references. Its `ok` field is
+a command-success flag: it is true when every requested ref resolved, and it
+says nothing about whether the geometry is sound. A five-face open box reports
+`"ok": true` with `"faceCount": 5`, and a solid with inverted orientation —
+which renders as a hole in the world — reports `"ok": true` as well.
+
+Use `validate` for that question:
+
+```bash
+cadgen step inspect validate models/part/part.step
+cadgen step inspect validate models/part/part.step --refs o1.2      # one subassembly
+cadgen step inspect validate models/panel/panel.step --allow-open   # surfaces intended
+cadgen step inspect validate models/rig/rig.step --out validate.json  # keep a partial on a kill
+```
+
+It reports any of `invalidTopology`, `openShell`, `nonPositiveVolume`,
+`noSolid`, `selfIntersecting`, and exits non-zero when any occurrence fails.
+Each `parts` entry is one finding on one shape: `ref`/`name` is the placement
+the checks ran on, and `occurrences` lists every placement the finding applies
+to (`failureCount` counts occurrences, `prototypeCount` unique shapes).
+
+Two subtleties worth knowing. `BRepCheck_Analyzer` returns **true** for a
+reversed solid, so topological validity alone cannot catch an inverted body —
+only the sign of the volume can. And volume is measured per solid, never
+aggregated: a `+1000` and a `-1000` inside one compound sum to zero, so any
+check reading a compound's total volume sees nothing wrong.
+
+Large assemblies: a part placed a hundred times is ONE shape with a hundred
+locations, so topology, closure, solid presence and volume are checked once per
+unique shape, in parallel across a process pool (`CADGEN_VALIDATE_WORKERS`
+sizes it; `1` runs in-process). The self-intersection test is numeric and can
+differ by placement — the same bolt has failed at 15° and 30° of tilt and passed
+upright — so by default it runs once per shape at its first placement and the
+report says so (`"selfIntersectionCheck": "first-placement"`). Pass
+`--every-placement` to run it on every copy (a `selfIntersecting` entry then
+lists exactly the placements that failed), or `--skip-self-intersection` to drop
+the test when it dominates runtime. Progress paints on stderr per shape;
+`--out PATH` also writes the report after every shape with `"partial": true`
+until the run completes, so a run that is killed (out of memory, a lost daemon
+worker) leaves the findings it reached.
+
+`validate` and `interfere` measure the document ON DISK: it is loaded as
+written and runs no Python, even when its script has changed since — a door
+never rebuilds a model. Rerun the script first when you want the new geometry
+measured. A document the store has never seen (one edited or written by another
+tool) is compiled from its bytes on demand, like an import.
+
+### `interfere`: do two parts occupy the same space?
+
+```bash
+cadgen step inspect interfere STEP/arm.step --tolerance 0.01
+cadgen step inspect interfere STEP/arm.step --refs o1.7            # inside one subassembly
+cadgen step inspect interfere STEP/arm.step --refs o1.3,o1.9       # two named parts, as wholes
+```
+
+`interfere` intersects every candidate pair of solids (a world-bbox reject runs
+first) and reports the pairs whose common volume exceeds `--tolerance` in mm^3.
+Touching faces yield hairline slivers, so the default is 1 mm^3; go lower for
+small parts.
+
+The unit of the verdict is the **part**: a direct component of the document
+root, or of the ref you name with `--refs` (the deepest common ancestor when you
+name several). A purchased servo arrives as a sub-assembly whose motor sits
+inside its case by construction, and a weldment is several solids in one
+product — bodies of one part overlap and always will, and a STEP document
+cannot tell a vendor sub-assembly from one you authored. So overlaps between
+bodies of the same part are still computed but reported separately, as
+`intraPartOverlaps` in `--json` and a per-part summary in text; they never
+fail the check. `clashes` — the ones that fail it — are between two different
+parts. To test a part's own bodies against each other, name that part alone:
+`--refs o1.18`.
+
+Fewer than two bodies, or all bodies in one part, is `INCONCLUSIVE` with
+`ok:false`, not a pass: nothing that could fail was tested.
+
+## Reference discovery
+
+Compact facts and planes:
+
+```bash
+cadgen step inspect refs path/to/model.step \
+  --facts --planes --positioning
+```
+
+Detailed selector inspection:
+
+```bash
+cadgen step inspect refs path/to/model.step '#selector' \
+  --detail --positioning
+```
+
+Topology enumeration, only when needed:
+
+```bash
+cadgen step inspect refs path/to/model.step --topology
+```
+
+Plane options:
+
+```bash
+--plane-coordinate-tolerance FLOAT
+--plane-min-area-ratio FLOAT
+--plane-limit INT
+```
+
+Use lower plane limits and compact facts for normal validation. Use topology enumeration only for selector discovery, complex debugging, or when a feature cannot be verified through facts/planes/measurements; it can be expensive on large models.
+
+## Measurement checks
+
+Use `measure` for bounding distances, clearances, offsets, part spacing, plate thickness, hole-to-face distances, and alignment verification.
+
+```bash
+cadgen step inspect measure path/to/model.step \
+  --from '#selector_a' \
+  --to '#selector_b' \
+  --axis x
+```
+
+Axis may be inferred when possible, but specify `x`, `y`, or `z` for deterministic checks.
+
+## Alignment checks
+
+Use `align` when two exported STEP references should be flush or centered. It returns a translation delta between the selected refs; apply any required correction in the build123d source (see `positioning.md`), regenerate, and re-inspect.
+
+```bash
+cadgen step inspect align path/to/assembly.step \
+  --moving '#moving_selector' \
+  --target '#target_selector' \
+  --mode flush \
+  --axis z
+```
+
+## Frame inspection
+
+Use `frame` to validate occurrence transforms and selected-reference world frames:
+
+```bash
+cadgen step inspect frame path/to/model.step '#selector'
+```
+
+Frame output is useful for assemblies, part-local-to-world conversion, and placement debugging.
+
+## Diff checks
+
+For modification tasks, compare before and after artifacts:
+
+```bash
+cadgen step inspect diff path/to/before.step path/to/after.step --planes
+```
+
+Use diff when a repair, feature addition, or source edit could affect unrelated geometry.
+
+## Validation report content
+
+Report only checks that were actually run or directly supported by tool output. If an important selector was inspected, return the local selector ref beside the owning CAD Viewer link.
+
+Use this structure:
+
+```text
+Validation:
+- STEP generation: passed/partial/failed
+- Solids/assembly: <counts and labels>
+- Bounding box: <dimensions and units>
+- Major planes/refs: <summary>
+- Positioning: <frame/measure/align results if relevant>
+- Feature checks: <holes, cutouts, bosses, etc.>
+- Visual review: `$cad-viewer` viewer link returned; CAD `cadgen step snapshot` PNG included or skipped with reason; follow-up geometry checks for any visual findings
+```
+
+Do not claim:
+
+- structural safety
+- process certification
+- tolerance compliance
+- manufacturability beyond geometric plausibility
+unless the relevant analysis or manufacturing data was explicitly performed.

--- a/.qwenpaw-plugin/skills/cad/references/kinematics.md
+++ b/.qwenpaw-plugin/skills/cad/references/kinematics.md
@@ -1,0 +1,224 @@
+# CAD kinematics and animation
+
+Read this file when the user asks to articulate, pose, or animate a STEP
+model, or when designing or reviewing mates, couplings, pose presets, posed
+exports, or animation clips.
+
+There are THREE systems with different lifecycles, deliberately independent:
+
+- **Geometry** is the module's constants and the factory the parameterless
+  model calls with them (`WIDTH = 10.0` … `return _bracket(WIDTH)`). Changing
+  one re-runs Python and rebuilds the outputs. They are not live in the viewer.
+- **Kinematics** is typed mates declared as PURE DATA via `kinematics=` on
+  the export decorators. It drives the viewer's pose sliders — no rebuild, no
+  Python at render time — and never moves the geometry a model writes. It
+  lives in the model's sidecar (`<name>.step.json`, written beside the
+  artifact), the one thing a sidecar is written for.
+- **Animation** is choreography in the RENDER MODULE beside the document:
+  `STEP/<name>.step.js`, next to `<name>.step` and `<name>.step.json`. It is
+  authored and committed, discovered by name, loaded by the viewer and the
+  snapshot door, and read by NO build — no decorator names it, the sidecar
+  carries no copy, the gate has no clause for it. It targets occurrences
+  directly and knows nothing about mates. Editing it is a reload in the
+  viewer, never a rebuild; editing kinematics never changes the tree either,
+  but it does rewrite the sidecar, so a kinematics edit is a (cheap) run.
+
+## Kinematics: typed mates
+
+Kinematics is the ONE thing a model writes a sidecar for, and it never moves
+geometry: the declaration describes how the written tree articulates, the
+viewer poses it at render time. A model that declares none has no sidecar.
+
+One `kinematics=` dict, closed keys `mates` / `couplings` / `poses`, on any of
+`@step`/`@stl`/`@glb`/`@threemf`. Each decorator's declaration stands alone
+(share a module-level dict; there is no cross-decorator inheritance).
+
+```python
+import cadgen
+from cadgen import step
+from cadgen import build123d as bd
+
+KINEMATICS = {
+    "mates": [
+        cadgen.revolute("elbow", parent="#upper_arm", child="#forearm",
+                        axis="#forearm.pivot_bore", limits=(0, 150)),
+        cadgen.slider("extend", parent="#rail", child="#carriage",
+                      axis="#rail.f2", limits=(0, 80)),
+        cadgen.cylindrical("lead", parent="#housing", child="#screw",
+                           axis="#screw.f1",
+                           limits={"turn": (0, 3600), "travel": (0, 40)}),
+        cadgen.fastened("mount", parent="#carriage", child="#bracket"),
+    ],
+    "couplings": [cadgen.couple("curl", {"mcp": 50, "pip": 70, "dip": 40})],
+    "poses": {"open": {"jaw": 40}, "closed": {"jaw": 0}},
+}
+
+@step(out="../STEP/arm.step", kinematics=KINEMATICS)
+def arm(): ...
+
+
+if __name__ == "__main__":
+    arm()
+```
+
+- **Mate kinds**: `revolute` (degrees about an axis), `slider` (model units
+  along it), `cylindrical` (sub-DOFs `<name>.turn` and `<name>.travel` about
+  one axis), `fastened` (0-DOF rigid attachment — needed exactly when
+  occurrences are SIBLINGS in the instance tree, like a pin that must orbit
+  with its carrier; instance-tree children ride for free).
+- **`parent`/`child`** are occurrence refs: `#`-prefixed labels (canonical —
+  label parts with `cadgen.label_shape`) or occurrence ids. They must resolve
+  at build or the build fails; `cadgen step inspect refs` lists the leaves.
+  A label resolves **into linked children**: a part labelled inside a
+  sub-assembly you call (`#shoulder_yaw_servo` living in `base_link()`'s
+  tree) resolves to its occurrence under the link (`o1.1.1`), so an assembly
+  can mate parts of a sub-assembly it links without owning their geometry.
+  A ref may name a SUBASSEMBLY as well as a part — a labelled group `Compound`
+  is an occurrence in the instance tree, and mating it carries every part
+  beneath it. That is how a rocker-bogie chain is three mates instead of three
+  hundred; `inspect refs` does not list group refs, because they are not
+  rendered parts.
+- **`axis`** is a selector ref (`axis="#forearm.pivot_bore"` — a cylindrical
+  face or circular edge yields its axis, a planar face its center+normal) or
+  literals (`origin=(x, y, z), direction=(x, y, z)`). Refs resolve ONCE at
+  build into world numbers; the viewer does arithmetic, never topology.
+- **ZERO IS THE ARTIFACT AS WRITTEN.** Every DOF's rest value is 0 — the
+  placement the author built. There is no `default=`; a presentation pose is a
+  preset. A model that must be WRITTEN at another configuration is authored
+  at that configuration (or is another model): no decorator argument moves
+  geometry.
+- **`couple(name, {dof: ratio})`** declares a virtual DOF gearing real ones
+  linearly and ADDITIVELY (setting `curl=x` adds `50*x` degrees to `mcp`).
+  Exact gear trains are ratio arithmetic, not code.
+  A geared member BACK-DRIVES in the viewer: when exactly one coupling gears a
+  DOF with a nonzero ratio, its Pose slider reads the effective value
+  (own + ratio x coupling), is labelled "driven by <coupling>", and dragging it
+  moves the COUPLING — `coupling = (target - own)/ratio`, clamped to the
+  coupling's limits — so sliding one gear turns the whole train. A member's own
+  value (from a preset or `--kinematics`) is never overwritten, and a DOF geared
+  by two couplings stays independent: that inverse is underdetermined, so the
+  viewer refuses it rather than guessing a split.
+- A declaration needs at least one mate (or coupling): a pose is a set of joint
+  values and a joint is what a mate declares, so `poses` alone declare nothing
+  and are refused. A part with no joints declares no `kinematics=`.
+- **`poses`** are named `{dof: value}` presets — all that remains of "pose"
+  as a concept.
+- The mate graph is a TREE: one parent mate per occurrence, no cycles.
+  Closed-loop linkages (four-bars) are out of scope by design — they need a
+  solver; the viewer evaluates pure forward kinematics from the sidecar's
+  numbers at render time.
+
+## Annotating a STEP you did not generate
+
+A document with no model script gets its kinematics from
+`cadgen step build IN OUT`, whose `--kinematics` takes the whole SPACE — the
+same `{mates, couplings, poses, at}` vocabulary, as inline JSON or a `.json`
+path — and whose `--animation` copies a `.js` module's text into OUT's sidecar.
+The input is read with OCCT and re-emitted by the canonical writer, so OUT's
+bytes are deterministic whichever kernel wrote IN:
+
+```bash
+cadgen step build vendor/hinge.step STEP/hinge.step \
+  --kinematics '{"mates": [{"name": "swing", "kind": "revolute",
+                            "parent": "#body", "child": "#lever",
+                            "axis": "#lever.bore", "limits": [0, 90]}],
+                 "poses": {"open": {"swing": 45}}}'
+```
+
+**Wrapper script or `step build`?** A model that will keep changing belongs in a
+script — a thin `@step` function that imports the foreign STEP and re-exports
+it, so the kinematics live beside the geometry decisions and every edit is one
+`python model.py`. Reach for `step build` when the geometry is fixed and not
+yours: a one-shot annotation or canonicalization of a vendor file. Re-running it
+is a no-op, editing only the kinematics refreshes the sidecar without
+re-emitting a byte, and vendor metadata (PMI, GD&T) does not survive the trip.
+
+## Animation: the render module (`<name>.step.js`)
+
+A STEP document may carry ONE JavaScript module beside it, named after the
+document: `STEP/arm.step` → `STEP/arm.step.js`. It is the place for
+render-only behaviour — today choreography, as the `clips` export below;
+other render-only exports will join it, and an export the renderer does not
+know is a load ERROR, never ignored. It is an ES module with no imports,
+authored by you and COMMITTED even though it lives in a format folder (the
+project's `.gitignore` whitelists `*.step.js`; see `project-layout.md`).
+
+```js
+// STEP/arm.step.js — beside arm.step; the viewer loads it by name.
+export const clips = {
+  demo: {
+    label: "Demo",
+    duration: 8,          // seconds
+    loop: true,           // default
+    update(t, m) {        // called every frame; t in seconds
+      m.get("forearm").rotate([0, 0, 1], 120 * (t / 8), [0, 0, 25]);
+      m.get("#o1.3.1,o1.3.2").translate([0, 0, 40 * Math.min(t / 2, 1)]);
+      m.get("lid").opacity(t < 5 ? 1 : 1 - (t - 5) / 2);
+    },
+  },
+};
+```
+
+- `m.get(target)` takes a LABEL (canonical) or occurrence-id refs
+  (`"#o1.3.1"`, comma lists; each id covers its whole subtree). Unknown
+  targets THROW — a typo never silently animates nothing. Labels here match
+  RENDERED PARTS only: to animate a whole group, name its occurrence id.
+- Handles: `.rotate(axis, degrees, origin=[0,0,0])`, `.translate(vec)`,
+  `.opacity(0..1)`, `.visible(bool)`. Successive transform calls
+  PREMULTIPLY: spin about a part's own center first, then orbit the origin,
+  and the spin rides the orbit.
+- Every frame starts from rest and `update(t)` rebuilds the state — a pure
+  function of t, so scrub/loop/seek are free. No wall-clock, no state.
+- Animation is deliberately Turing-complete and deliberately ignorant of
+  mates: animating a jointed part re-describes the motion (a few lines of
+  ratio math). That independence is what guarantees choreography edits can
+  never invalidate builds.
+- No build reads the file. Nothing declares it: drop it beside the document
+  and the viewer's Animation tab appears on the next load; delete it and the
+  tab goes. A model without one is simply a model without animation.
+- Targets are checked at LOAD, against the compiled tree: every clip's
+  `update(0, m)` runs once when the module loads, and a label or occurrence
+  id no part carries is reported in the viewer's Status tab and in
+  `snapshot --animation`'s error — not at the first frame that reaches it.
+- Mesh-only models (no `.step`) have no document to sit beside, and so no
+  render module; animation is a STEP-document concern.
+
+## Reviewing motion
+
+Snapshot renders stills; motion review is interactive in the viewer. For
+still evidence of a configuration, render at DOF values:
+
+```bash
+cadgen step snapshot STEP/arm.step tmp/open.png --kinematics '{"jaw": 40}'
+```
+
+`--kinematics` is named for the `kinematics=` block it drives, and takes
+either spelling: `{dof: value}` JSON, or the NAME of a pose the model
+declares under `poses`. A name is checked against the declaration, so a typo
+fails with the poses this model actually has:
+
+```bash
+cadgen step snapshot STEP/arm.step tmp/open.png --kinematics open
+```
+
+For still evidence of a CLIP, freeze one frame: `--animation` names a clip
+the document's render module (`STEP/arm.step.js`) declares and `--time` the
+moment in seconds (default 0). One frame, one clip, one time — there is no sequence output. The frame
+is composed exactly as the viewer composes it: `--kinematics` sets the base
+pose, and the clip's `update(t, m)` is evaluated at that time on top of it.
+A clip name the model does not declare fails with the clips it has:
+
+```bash
+cadgen step snapshot STEP/arm.step tmp/demo_t2.png --animation demo --time 2.0
+cadgen step snapshot STEP/arm.step tmp/demo_open.png --kinematics open --animation demo --time 2.0
+```
+
+In a JSON job the request is one field, `"animation": {"clip": "demo",
+"time": 2.0}`, beside `"kinematics"`; the Python door takes the same object
+(`step.snapshot(..., animation={"clip": "demo", "time": 2.0})`) or the clip
+name with `time=`.
+
+Identify fixed pivots, link lengths, gear ratios, and joint limits BEFORE
+declaring mates; pivot every rotation about its hinge bore or mate face —
+never a bounding-box center. Convert visual concerns into `cadgen step
+inspect measure` checks before calling them fixed.

--- a/.qwenpaw-plugin/skills/cad/references/migrations.md
+++ b/.qwenpaw-plugin/skills/cad/references/migrations.md
@@ -1,0 +1,40 @@
+# Migrations
+
+Read this file when the tooling behaves as though it disagrees with a model you
+believe is correct. That is the signature of version skew: a project authored
+against an older cadgen, running under a newer one.
+
+cadgen carries no compatibility layer — no shims, no aliases, no deprecated
+keyword arguments, no codemod. Every entry point teaches one contract, the
+current one, so skew surfaces as ordinary wrongness rather than as a message
+about versions. Recognizing it is the reader's job.
+
+## When to suspect skew
+
+- **A model script runs, exits 0, and writes nothing.** An older source carries
+  no decorated function and no entry point of its own, so Python defines a
+  function and exits. Nothing looks for an entry point by name.
+- **A command or flag you are sure of comes back unknown**, and the help lists
+  an unfamiliar set. Building a model is running its script; there is no
+  generation verb, and retired spellings are simply unrecognized arguments.
+- **A sidecar is refused for its schema version.** Sidecars are never upgraded
+  in place and never partially read, because a wrong-shaped one would cost a
+  model its kinematics silently.
+- **A model that used to articulate renders inert**, presenting as a plain
+  document with no pose and no animation. Nothing is discovered by convention: a
+  companion `.js` file is read only when a decorator names it.
+- **Meshes come out visibly coarser or finer, with no error.** Mesh tolerance
+  kept its name and changed meaning — chord tolerance is a fraction of the
+  component's bounding diagonal, not an absolute length — so a value carried
+  across from an older project is wrong in proportion to the part's own size.
+
+A half-migrated project fails in the wrong place: a correctly converted script
+with a stale sidecar beside it fails at the sidecar. Symptoms are only worth
+reading once the old artifacts are gone.
+
+## Migration guides
+
+- **cadgen 0.4 → 0.5** — generator functions became decorated model scripts, the
+  generation CLI was removed, sidecars and provenance moved, snapshot job JSON
+  was re-keyed, and mesh tolerance became relative.
+  https://github.com/earthtojake/text-to-cad/blob/main/docs/migrations/migrating-0.4-to-0.5.md

--- a/.qwenpaw-plugin/skills/cad/references/positioning.md
+++ b/.qwenpaw-plugin/skills/cad/references/positioning.md
@@ -1,0 +1,286 @@
+# Positioning logic, joints, and mating
+
+Read this file when geometry has mating interfaces, repeated features, assembly children, axes, datums, motion, or user-specified alignment. This is the authoritative reference for assembly positioning, part-local origins, build123d joints, explicit `Location` transforms, CLI `inspect align`, and positioning report content.
+
+## Core rule
+
+Positioning is authored in source and validated after generation. Do not position parts by visually dragging or by editing exported STEP geometry. Use build123d parameters, local coordinate systems, `Location` transforms, `Plane`/`Axis` datums, `cadgen.assembly.AssemblyHelper` relationships, source-level `Joint` objects when useful, and labeled assembly children.
+
+## Terminology
+
+Use these terms carefully:
+
+- **AssemblyHelper** is the preferred generated-script wrapper from `cadgen.assembly`. It records semantic relationships such as `face_to_face`, `coaxial`, `revolute`, and `linear`, then realizes them with native build123d joints.
+- **build123d joints** are source-level objects such as `RigidJoint`, `RevoluteJoint`, `LinearJoint`, `CylindricalJoint`, and `BallJoint`. They are attached to `Solid` or `Compound` objects and can reposition parts with `connect_to()`.
+- **CLI `inspect align`** is a selector-pair validation tool. It computes a read-only translation delta between selected local refs in a STEP/CAD entry. It does not edit source code, patch exported STEP files, or represent an authored mate feature. This is the one place that distinction is defined; the rest of the skill assumes it.
+- **Mating intent** is the design relationship: flush, centered, coaxial, offset, hinge-like, slider-like, or otherwise datum-driven.
+
+Use `AssemblyHelper` and build123d joints to express and compute source assembly placement where appropriate, then use CLI inspection to validate the generated STEP.
+
+## Preferred assembly structure
+
+For assemblies, prefer a mate/joint-driven structure over arbitrary transforms:
+
+```text
+root component
+→ part-local coordinate systems
+→ named datums / joint locations
+→ AssemblyHelper semantic relationships backed by native build123d joints
+→ labeled Compound assembly with verbose native labels
+→ refs/measure/frame/align validation
+```
+
+A numeric `Location(...)` should usually correspond to a stated datum, offset, clearance, screw axis, face contact, or joint relationship.
+
+Place a shape with `Pos(...) * shape`, `Rot(...) * shape`, `Location(...) * shape`, or `shape.moved(loc)` — these move the shape and keep its geometry shared. Avoid `shape.located(loc)`: it deep-copies the geometry, which is slower and, for a child model placed in an assembly, breaks the cache's ability to reference the child instead of copying it.
+
+Group a functional unit — a bearing, a gearbox stage, a fastener set — into a sub-assembly node with `asm.add_module(name, children)` when it is placed, reasoned about, or repeated as a unit; nested occurrence refs such as `#o1.12.1` then stay meaningful.
+
+## Part-local positioning
+
+For each part, define a local coordinate convention before modeling:
+
+```text
+- Origin: center, base datum, mounting interface, or functional axis.
+- XY plane: main sketch/base plane unless another datum is dominant.
+- +Z: extrusion/up direction.
+- Named dimensions: offsets, hole spacing, boss spacing, clearances.
+- Datum features: mating faces, screw axes, centerlines, locating tabs, rails.
+```
+
+Good defaults:
+
+- Symmetric standalone parts: origin at body center.
+- Plates: origin at footprint center; thickness along Z.
+- Enclosures: origin at footprint center; base/lid mating surfaces controlled by Z parameters.
+- Shaft/knob/axisymmetric parts: origin on rotational axis.
+- Mating adapter plates: origin on the primary mounting datum or center of the bolt pattern.
+
+## Feature placement inside a part
+
+Use named parameters and local coordinates:
+
+```python
+hole_offset_x = 30
+hole_offset_y = 17.5
+hole_positions = [
+    (-hole_offset_x, -hole_offset_y),
+    ( hole_offset_x, -hole_offset_y),
+    (-hole_offset_x,  hole_offset_y),
+    ( hole_offset_x,  hole_offset_y),
+]
+
+with Locations(*hole_positions):
+    Hole(radius=hole_diameter / 2)
+```
+
+Avoid untraceable placement constants inside geometry calls. Put all meaningful offsets into parameters.
+
+## AssemblyHelper pattern
+
+Use `AssemblyHelper` for generated assembly scripts. It keeps the LLM-facing code intent-focused while still using native build123d labels, `Joint` objects, and `Compound` assemblies.
+
+```python
+from cadgen import build123d as bd, step
+from cadgen.assembly import AssemblyHelper
+
+base_height = 30.0
+lid_thickness = 3.0
+gasket_gap = 0.5
+
+asm = AssemblyHelper("enclosure")
+base = asm.add(make_base(), "base")
+lid = asm.add(make_lid(), "lid")
+
+base_seat = asm.rigid_frame(
+    base,
+    "lid_seat",
+    bd.Location((0, 0, base_height / 2)),
+)
+lid_underside = asm.rigid_frame(
+    lid,
+    "underside",
+    bd.Location((0, 0, -lid_thickness / 2)),
+)
+
+asm.face_to_face(base_seat, lid_underside, offset=gasket_gap)
+
+
+@step
+def model():
+    return asm.build()
+```
+
+The fixed target is listed first and the moving target second. In the example above, the base stays fixed and the lid moves. The helper is a positioning tool: it calls native build123d `connect_to()` under the hood and its whole output is the placed geometry — nothing about the relationship is recorded or exported. The STEP contains the resolved static placement and native assembly labels, not persistent constraints. Motion that should persist (joints the viewer animates, pose presets) is declared with `kinematics=` on the decorator (`references/kinematics.md`), not with the positioning helper.
+
+Use helper labels intentionally:
+
+```python
+standoff = asm.feature(Cylinder(radius=3.0, height=12.0), "m3_standoff", "front_left")
+hinge_axis = asm.rigid_frame(lid, "hinge_axis", Location((0, -25, 0)))
+```
+
+Assembly labels name the root occurrence. `asm.add()` labels child component occurrences and their exported shape context. For repeated hardware or library parts, use role/location labels such as `front_left` and `rear_right` so STEP topology and viewer selections remain traceable after export.
+
+Feature labels survive best when the labeled geometry remains a child shape in a `Compound`. Labels on boolean-subtracted or fused feature history are not reliable STEP feature history.
+
+Use the frame method that matches native build123d joint inputs: `rigid_frame()` and `ball_frame()` take a `Location`; `revolute_frame()`, `linear_frame()`, and `cylindrical_frame()` take an `Axis` plus optional native range/reference arguments.
+
+## Child dependencies
+
+A child part is wired in one of two modes — a **CHILD** (a model in this
+project: import its function and call it; the default) or an **INPUT** (a
+document read via `cadgen.read_step`: imported parts, or a generated part the
+user explicitly asked to decouple). The modes, what a rebuild tracks, and the
+code live in "Composing on other parts" in `step-generation.md`.
+Positioning-wise the two are identical: a child is a shape; place it with the
+same frames and mates as authored geometry.
+
+**Place a child with `Pos/Rot/Location * child` or `child.moved(loc)` — never
+`child.located(loc)`.** `located()` deep-copies the geometry, so the parent
+owns a duplicate component instead of linking to the child's tree, and it
+also discards any rotation the shape already carried (`build123d-modeling.md`).
+`AssemblyHelper` and build123d joints place through `connect_to()` and keep
+the link. A mirrored placement is not a placement at all — STEP cannot express
+a reflection — so a right-hand part is its own model built from the shared
+factory (`step-generation.md`, "Mirrored parts are their own models").
+
+## Imported components
+
+For purchased or downloaded parts (see `$step-parts`), read the STEP file
+with `cadgen.read_step` (never `build123d.import_step` — the whys are in
+"Composing on other parts" in `step-generation.md`) and add it like any
+authored part.
+
+```python
+from cadgen import read_step
+
+servo = asm.add(read_step("models/parts/sg90_servo.step"), "servo")
+```
+
+Imported geometry was not authored here, so do not assume its origin or orientation. Derive mating frames from inspected geometry: run `refs --facts --planes --positioning` and `measure` against the imported part, then define `asm.rigid_frame(...)` locations from the measured faces, axes, and bolt patterns. Validate the resulting mate exactly like an authored one.
+
+## When to use build123d joints
+
+Use `AssemblyHelper`/build123d joints when assembly intent is clearer as a relationship between part datums than as a raw transform:
+
+- lid-to-base, cover-to-frame, bracket-to-rail, flange-to-pipe, pin-to-hole, shaft-to-bearing
+- hinge, slider, screw-like, cylindrical, ball/gimbal, or other motion-positioned assemblies
+- repeated or library components that already expose joints
+- source assemblies where a change to one dimension should recompute part placement
+
+Direct `Location(...)` transforms are acceptable for simple static layouts when they are parameterized and documented, such as a row of identical spacers or a visual exploded view.
+
+Raw build123d joints are acceptable for advanced cases not covered by `AssemblyHelper`, but preserve the same fixed-first directionality: call `connect_to()` on the fixed/root joint and pass the moving part's joint as `other`. `connect_to()` is a source-generation operation. It repositions the moving part for the generated model; it is not a persistent external constraint in the exported STEP file.
+
+## Joint type selection
+
+Use the simplest joint that expresses the source-level relationship:
+
+- `RigidJoint` / `asm.rigid_frame()`: fixed placement, face-to-face seating, mounting datums, imported components with known interfaces.
+- `RevoluteJoint` / `asm.revolute_frame()`: hinge or rotational pose; define with an `Axis` and drive with an angle parameter for a static STEP pose.
+- `LinearJoint` / `asm.linear_frame()`: slider, latch, telescoping component; define with an `Axis` and drive with a position parameter.
+- `CylindricalJoint` / `asm.cylindrical_frame()`: combined axial translation and rotation, such as screw-like or pin-in-slot relationships.
+- `BallJoint` / `asm.ball_frame()`: gimbal or spherical orientation relationship; define with a `Location` and angular ranges.
+
+When only final static placement matters and no meaningful joint datum exists, use explicit `Location` transforms and validate them.
+
+## Assembly positioning workflow
+
+1. Choose the fixed/root component.
+2. Define part-local frames and datums before modeling child placement.
+3. Identify functional datums such as mating faces, screw axes, hinge axes, sliding axes, locating tabs, gasket offsets, or contact planes.
+4. Name source-level joints or mating datums on each child with `asm.rigid_frame()`, `asm.revolute_frame()`, `asm.linear_frame()`, or another helper frame method.
+5. Use `AssemblyHelper` relationship methods where they improve source clarity, otherwise use parameterized `Location` transforms.
+6. Build a labeled `Compound` assembly with `asm.build()`.
+7. Generate the assembly through the Python source, not by re-importing the generated STEP (see `step-generation.md`):
+
+```bash
+python path/to/assembly.py
+cadgen step inspect refs path/to/assembly.step --facts --planes --positioning
+```
+
+## CLI alignment validation
+
+After generation, select moving and target refs from the local selector refs returned by `refs --positioning` and compute deltas:
+
+```bash
+cadgen step inspect align path/to/assembly.step \
+  --moving '#moving_selector' \
+  --target '#target_selector' \
+  --mode flush \
+  --axis z
+```
+
+Use `--mode flush` for coplanar face alignment. Use `--mode center` for centerline, plane-center, or symmetrical alignment where supported by the selected references. If the returned delta is outside tolerance, apply a source-level correction (see below), regenerate, and rerun inspection.
+
+## Frame validation
+
+Use `frame` to inspect an occurrence or selector's world frame:
+
+```bash
+cadgen step inspect frame path/to/assembly.step '#selector'
+```
+
+Use this when:
+
+- a child appears in the wrong orientation
+- a mating face is offset in world coordinates
+- an axis is expected to align with X/Y/Z
+- repeated parts should share orientation
+- a downstream task needs a stable coordinate frame
+
+## Measurement validation
+
+Use `measure` for scalar checks:
+
+```bash
+cadgen step inspect measure path/to/assembly.step \
+  --from '#selector_a' \
+  --to '#selector_b' \
+  --axis z
+```
+
+Examples:
+
+- lid bottom face to base top face should be 0 mm for flush contact
+- two screw axes should have matching X/Y positions
+- bracket mounting face should sit a specified distance from a datum plane
+- spacer height should equal requested offset
+
+## Source-level positioning corrections
+
+When a positioning check fails, fix one of these in source:
+
+- child `Location` translation
+- child `Location` rotation
+- `AssemblyHelper` relationship fixed/moving order or offset
+- build123d joint location or axis
+- part-local origin convention
+- feature offset parameter
+- sketch plane
+- workplane selection
+- assembly hierarchy
+- symmetric placement signs
+
+Then regenerate. Do not patch the exported STEP directly.
+
+## Reporting positioning
+
+In the final response, report only checks that were run:
+
+```text
+Positioning/joints:
+- source used RigidJoint lid_seat → underside
+- base/lid Z mate flush, delta 0.00 mm
+- screw boss axis alignment: checked in XY by measurement
+- lid occurrence frame: +Z up, origin at assembly centerline
+```
+
+If no positioning-sensitive features exist, say:
+
+```text
+Positioning: not applicable beyond centered part-local origin.
+```
+
+If a mate or alignment was intended but not checked, say `not checked`; do not imply success.

--- a/.qwenpaw-plugin/skills/cad/references/project-layout.md
+++ b/.qwenpaw-plugin/skills/cad/references/project-layout.md
@@ -1,0 +1,357 @@
+# CAD project structure
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+
+This reference is pure convention: cadgen itself is deliberately unopinionated (a
+model script's outputs default to its siblings; `out=` relocates them). Use
+this structure for anything bigger than a couple of loose models; skip it for
+one-off parts, where a flat folder is fine. Authoring the models themselves is
+the `$cad` skill; drawings are `$dxf`.
+
+**Where the project lives**: in a workspace that is more than CAD — a
+monorepo, an app with models on the side — put the project inside the
+directory that holds the workspace's models (`models/`, for example, or
+`cad/`, `hardware/` — whatever the workspace already uses as its home for
+CAD; `models/` is only the conventional name), never loose at the root.
+In an empty or bare workspace, the CAD project IS the workspace: lay out
+`src/` and the format folders at the root.
+
+## The layout: code in `src/`, raw outputs in format folders
+
+Only OUTPUTS are organized by format. Code is not: a model script is not a
+"STEP thing" — it is authored Python that happens to emit a STEP.
+
+```
+<project>/
+  src/                    # AUTHORED code — the only thing you edit
+    README.md             #   the model catalog (see below)
+    plate.py              #   one model per file: a part …
+    plate_drawing.py      #   … a drawing …
+    assembly.py           #   … the root assembly
+    chassis/              #   a SUB-ASSEMBLY folder: its assembly model …
+      frame.py            #     … and the parts only it uses (never a module named `chassis`)
+      strut.py
+    purchased/            #   vendor parts you did not draw: read_step wrapper models
+      servo.py
+    lib/                  #   shared code (plain modules — never models)
+      __init__.py         #     one-line docstring; lib is a regular package
+      holes.py            #     helpers
+      bracket_shape.py    #     a factory two models build from
+  STEP/                   # raw outputs ONLY (+ their sidecars) — and the one authored exception:
+    plate.step
+    assembly.step.js      #   the render module beside a document (choreography); authored, committed
+    chassis/  purchased/  #   outputs mirror src/ folder for folder
+    imported/             #   committed source files brought in from outside (see commit policy)
+  DXF/  STL/  GLB/  3MF/  # other format folders: same shape, outputs + imported/
+  tmp/                    # scratch: snapshots, debug renders (gitignored)
+```
+
+Two mechanical rules:
+
+1. **Format folders hold only raw artifacts.** Never code, never notes. Each
+   model script declares its own destination — cadgen has no layout knowledge:
+
+   ```python
+   from cadgen import build123d as bd
+   from cadgen import step
+
+   WIDTH = 10.0
+
+
+   @step(out="../STEP/plate.step")
+   def plate():
+       return bd.Box(WIDTH, 10, 10)
+
+
+   if __name__ == "__main__":
+       plate()
+   ```
+
+   `out=` resolves relative to the script, so the project relocates as a
+   unit.
+2. **`src/` holds ONLY runnable model scripts.** Every `.py` directly under
+   `src/` is a model — one parameterless decorated function — that ends with
+   `if __name__ == "__main__": <model>()`; run it to build it. Everything
+   shared goes in `src/lib/`: helpers, factories, and constants several models
+   read. So `ls src/*.py` IS the model catalog. `src/lib/` is a regular
+   package, not a namespace one: it always contains an `__init__.py`, and a
+   one-line docstring naming what the package holds is enough.
+
+Because scripts sit directly in `src/`, imports need no setup: a build's
+import path is exactly `python script.py`'s — the script's own directory,
+`src/`, plus whatever `PYTHONPATH` the project sets — so shared code and
+sibling models import directly, from any working directory. A model may share its stem
+with the `lib/` module it wraps (`src/body.py` over `lib/body.py`); the two are
+different modules (`body` and `lib.body`), so alias the import — `from lib
+import body as body_lib` — rather than let the module name shadow the model
+function you are about to define. The same shadowing bites a file that needs
+**both** a sibling's constants or helpers **and** its model function: `import
+base_clamp` binds the module, then `from base_clamp import base_clamp` rebinds
+the same name to the function (or the other way round, depending on order).
+Alias the module — `import base_clamp as base_clamp_mod` beside `from
+base_clamp import base_clamp` — and read constants through the alias. Code in
+`lib/` may call a model function too (`from servo import servo` inside a
+`lib/` helper pins the child exactly as a call from the parent's own body
+does); the child's file must be importable from the caller's `sys.path` (its
+folder, or a root the project declares via `PYTHONPATH`), which in this layout
+means it sits in the same `src/` (or the same group directory):
+
+```python
+from lib import fasteners            # a helper module: any edit to it rebuilds this model
+from plate import WIDTH              # a constant from another model: tracked by value
+from plate import plate              # another model: a child, tracked by its result
+```
+
+Those three imports are the three kinds of dependency a model can have —
+**models by result, constants by value, functions by file** — and `cadgen
+store why src/<model>.py` shows which ones a model has and whether each is
+current. Importing a model never builds it; calling it inside your body does.
+
+Build from anywhere: `python src/plate.py`. Build-if-missing and rebuild are
+the same command — the freshness gate runs first, so an unchanged model is a
+no-op. There is no project-level build command: regenerate a whole project by
+running each script.
+
+```bash
+for f in src/*.py; do python "$f"; done
+```
+
+The CAD Viewer opened at the project root catalogs the format folders'
+artifacts (scripts never appear); before anything is built, discovery is
+`src/`, not the viewer.
+
+## Assemblies pull their children
+
+A parent (`assembly.py`) imports its part and sub-assembly models and calls
+them in its body; each call builds that child if it is stale — in parallel
+with its siblings, on its own worker — or loads it from the store, and the
+parent's output LINKS to the child's result. So **running the root is the
+whole build**: `python src/assembly.py` rebuilds exactly what is stale beneath
+it and nothing else. Dependency is pull, not push: rebuilding a part on its
+own (`python src/plate.py`) does NOT rebuild the assemblies that use it —
+rerun the parent to pick the change up.
+
+**A sub-assembly is a model** with its own file and its own outputs
+(`frame.py` → `STEP/frame.step`), composed into the root exactly like a part.
+A sub-assembly with parts of its own is a folder; see "Folders mirror the
+product tree". A helper that returns a group of placed parts belongs in a model file, not in
+`lib/`: as a model it has a record, builds once, links into every parent and
+gives you a STEP to inspect on its own; as a `lib/` function it re-runs inside
+every caller and any edit rebuilds them all.
+
+**A mirrored part is its own model.** STEP cannot express a reflection, so a
+right-hand part is not a mirrored placement of the left-hand one: put the
+shape in a `lib/` factory (`side_bracket(mirrored=False)`) and give each hand
+a one-line model file. The template shows the pattern.
+
+**A print-only part is a model too.** `@stl` (or `@glb`/`@threemf`) with no
+`@step` declares a model whose outputs are meshes; it composes into
+assemblies like any part and writes no STEP.
+
+**The environment is not an input.** Nothing in `src/` or `lib/` reads a
+parameter from `os.environ` (or the working directory, the current time, a
+random source): the store tracks source by hash, constants by value and children by
+result, and cannot see any of those, so a variant selected through them builds
+once and then reads as current under every other setting. A configuration is a
+factory argument in `lib/`; another configuration is another model file.
+
+## Folders mirror the product tree
+
+`src/` is the import root: every import is spelled from it (`from
+chassis.frame import frame`, `from lib import holes`, `from purchased.servo
+import servo`), whatever folder the importing script sits in — because the
+project declares it with `PYTHONPATH=src` (cadgen never curates paths). One
+naming rule makes that hold everywhere: **a folder never contains a module of
+its own name.** A build runs like `python script.py`, so the script's own
+folder comes first on the import path; from inside `frame/`, the name `frame`
+would resolve to `frame/frame.py` instead of the folder, and every spelled
+import into that folder fails with "'frame' is not a package". Name the folder
+for the subsystem (`chassis/`) and the model for the assembly it builds
+(`chassis/frame.py`). Two kinds of folder follow.
+
+**A sub-assembly is a folder.** A folder that holds an assembly model — one
+that calls the parts beside it — is a sub-assembly; the parts only it uses live
+beside that model, and a part two sub-assemblies share moves up to the level
+that owns both. The tree nests as deep as the product does (`base/clamp/`),
+and the format folders mirror it one to one (`STEP/base/clamp/clamp.step`), so
+the STEP tree reads like the product tree. `purchased/` is the one conventional
+folder: `read_step` wrapper models for vendor parts, importable from every
+level.
+
+**A group is an independent product.** A project that holds several unrelated
+assemblies — a demo corpus, a shop's library — puts each one in its own
+directory under `src/`, so one assembly's part models do not pile up beside
+another's:
+
+```
+<project>/
+  src/
+    README.md                         # catalog: one row per group
+    rover/                            #   a GROUP: one assembly and everything it owns
+      rover.py                        #     the root model (stem = the group's name)
+      wheel.py  suspension.py         #     its part and sub-assembly models
+      lib/                            #     helpers only this group uses
+        __init__.py
+        hub.py
+    gear_stage/
+      gear_stage.py
+  STEP/
+    rover/                            # the group's outputs, one folder per group
+      rover.step  wheel.step  suspension.step
+    gear_stage/
+      gear_stage.step
+```
+
+Three rules keep the tree as simple as a flat project:
+
+1. **Groups do not import each other.** A group's root, parts, sub-assembly
+   folders and drawings live under its one directory. `src/lib/` and
+   `src/purchased/` are the two folders every group may import; code two
+   groups both need lives there or is a sign they are one group. Every
+   import is spelled from `src/` (`from rover.wheel import wheel`, also
+   inside `rover/`), never relative to the importing file — which is why no
+   folder may hold a module of its own name.
+2. **Outputs mirror the folders.** Every model declares an `out=` that mirrors
+   its folder path under the format folder (`src/rover/wheel.py` →
+   `../../STEP/rover/wheel.step`, `src/tom/end_effector/claw_left.py` →
+   `../../../STEP/tom/end_effector/claw_left.step`; meshes likewise under `STL/`),
+   so the format folders stay browsable one assembly at a time and the CAD
+   Viewer opened at the project root shows one folder per assembly.
+3. **Every `.py` under `src/` outside `lib/` is a model.** The flat rule holds
+   at any depth: each script is runnable, and `find src -name '*.py' -not
+   -path '*/lib/*'` is the catalog. Standalone parts that belong to no
+   assembly stay directly under `src/`.
+
+The catalog README lists each group with its root; `python
+src/<group>/<group>.py` builds that assembly and whatever is stale beneath it.
+
+## Naming
+
+- Model script stem = artifact stem = a Python identifier (`plate.py` →
+  `STEP/plate.step`). Industry/exchange names (part numbers, revisions,
+  spaces) go on the ARTIFACT via `out=` ("../STEP/PN-10432_revB.step"),
+  never into the stem — scripts must stay importable modules.
+- A drawing gets its own stem: `plate_drawing.py` → `DXF/plate_drawing.dxf`.
+- Every `.py` under `src/` outside `lib/` is a model file; a file may hold
+  several models (then each writes `<function>.<fmt>` beside it), sharing one closure —
+  keep them to small variant families.
+- A mirrored pair is two stems: `bracket_left.py`, `bracket_right.py`.
+- Never distinguish files by case alone (macOS filesystems are usually
+  case-insensitive).
+- Files brought in from outside — vendor downloads, supplier files, anything
+  used as a SOURCE, whether rendered directly or composed into generated
+  models downstream — keep their upstream names and live in the format
+  folder's `imported/` subfolder (`STEP/imported/`, `DXF/imported/`, ...).
+  Track those folders with Git LFS; `project-template.md` has the
+  `.gitattributes` to copy.
+
+## Renaming or retiring outputs
+
+Changing a model's `out=` (or deleting a model) does not remove what the old
+declaration produced: the previous artifact, its `.step.json` sidecar, and
+any declared mesh exports stay on disk and will look like real project files
+forever. Treat a rename as an edit PLUS a cleanup, done conservatively:
+
+1. BEFORE editing, list exactly what the old declaration names: the `out=`
+   target, its `<name>.step.json` sidecar, and each declared export's
+   `out=` target (`@stl`/`@glb`/`@threemf`).
+2. Make the edit, rebuild, and verify the new artifacts exist.
+3. Delete ONLY the files from step 1, by exact path. Never glob
+   (`rm STEP/A*`), never touch `imported/` (those are sources, not outputs),
+   and when unsure, stop and check `git status` — in a committed project the
+   orphans appear as exactly the deletions you expect, and anything
+   unexpected means step 1 was wrong.
+
+## Building many models
+
+Running the root assembly already builds its children in parallel. Distinct
+roots fan out safely too: builds never wait on or cancel one another, and two
+concurrent runs of one script both complete, with the store keeping the result
+whose sources match the files as they are now (nothing corrupts).
+
+```bash
+ls src/*.py | xargs -n1 -P4 python
+```
+
+Running builds are limited to one per core (`CADGEN_JOBS` overrides); the
+rest queue, so a wide fan-out costs no wall time over the ideal. Two costs
+worth avoiding: parallel snapshot invocations each pay a headless browser —
+batch several views into one `--job` packet instead — and concurrent identical
+mesh exports of one document waste work (the shared ledger makes them safe,
+not free).
+
+Several agents building one assembly at once: give each its own entry — a
+small model that composes only its subsystem — verify there, and build the
+full assembly once when the subsystems land; the root then links the
+subsystems' results and rebuilds only what changed.
+
+## `src/README.md` — the model catalog
+
+Every project ships a short catalog so an agent landing in the project knows
+what builds what without reading every script:
+
+```markdown
+# <project> models
+
+| Script           | Artifact              | Description                          |
+|------------------|-----------------------|--------------------------------------|
+| plate.py         | STEP/plate.step       | Mounting plate, `HOLE_D` corner holes|
+| plate_drawing.py | DXF/plate_drawing.dxf | Plate flat pattern                   |
+| frame.py         | STEP/frame.step       | Plate + two standoffs (sub-assembly) |
+| assembly.py      | STEP/assembly.step    | Frame + left/right brackets (root)   |
+
+Build: `python src/assembly.py` builds the root and whatever is stale beneath
+it; `python src/<script>` per row for the rest; unchanged models are no-ops.
+Imported sources: STEP/imported/servo.step (committed, no script).
+```
+
+Keep it a table plus a few lines; update it whenever a model is added or
+changed.
+
+## Commit policy (a principle, not a layout)
+
+Derived files are regenerable and typically ignored; authored files and
+anything code cannot reproduce are committed:
+
+1. **Authored** (`src/`): always committed.
+2. **Generated** (the format folders): NOT committed by default — a fresh
+   clone regenerates by running the scripts. Snapshots and other review
+   renders are scratch, not artifacts: they go to `tmp/`, always ignored.
+3. **Committed exceptions, made deliberately**: imported source files under
+   any format folder's `imported/` (no code can regenerate them — a
+   code-only checkout must never be missing INPUTS, only derived outputs);
+   render modules (`STEP/<name>.step.js`, the choreography beside a
+   document — authored, read by no build, so nothing regenerates them); and
+   pinned fixtures —
+   anything asserted against byte-for-byte, since regeneration on a newer
+   kernel can legally change bytes for identical geometry. Pin a loose file
+   with its own negation line or `git add -f`.
+
+```gitignore
+/STEP/*
+!/STEP/imported/
+!/STEP/*.step.js
+/DXF/*
+!/DXF/imported/
+/STL/*
+!/STL/imported/
+/GLB/*
+!/GLB/imported/
+/3MF/*
+!/3MF/imported/
+/tmp/
+__pycache__/
+```
+
+Note the `*` forms: ignoring the directory itself (`/STEP/`) would make the
+`imported/` negation dead — git never descends into an ignored directory.
+
+## Scaffolding a new project
+
+Copy `project-template.md` (beside this reference) — the full tree with a working part,
+drawing, mesh-only part, mirrored pair, two-level assembly, lib modules,
+README, and .gitignore to create verbatim. Then verify the loop end to end:
+`python src/assembly.py`, snapshot it, and confirm the format folders gained
+the artifacts. The template ends with the finished tree — what the project
+looks like after that first build, imported source and sidecar included — so
+there is nothing else to go and look at.

--- a/.qwenpaw-plugin/skills/cad/references/project-template.md
+++ b/.qwenpaw-plugin/skills/cad/references/project-template.md
@@ -1,0 +1,449 @@
+# Project scaffold template
+
+Create these files verbatim (rename `demo`/`plate` to the real project/part),
+then run `python src/assembly.py` from the project root to verify the loop.
+The finished tree at the end shows the whole project after that first build.
+
+The project root, `demo/` below, is the workspace root when the workspace is
+bare, and otherwise sits inside the workspace's existing home for models —
+`<workspace>/models/demo/`, or `cad/`, `hardware/`, whatever it already uses;
+`models/` is only the conventional name. Everything under `demo/` is the same
+either way.
+
+The template is one of everything: a part (`plate`), a drawing of it
+(`plate_drawing`), a print-only mesh part (`standoff`), a mirrored pair built
+from one factory (`bracket_left`/`bracket_right`), a sub-assembly that places
+one child twice (`frame`), and the root assembly (`assembly`).
+
+## `src/plate.py`
+
+```python
+"""Demo part: a mounting plate with corner holes."""
+
+from __future__ import annotations
+
+from cadgen import build123d as bd
+from cadgen import step
+
+from lib import holes
+
+WIDTH = 60.0
+DEPTH = 40.0
+THICKNESS = 4.0
+
+
+HOLE_D = 4.5
+
+
+@step(out="../STEP/plate.step")
+def plate():
+    body = bd.Box(WIDTH, DEPTH, THICKNESS)
+    return holes.corner_holes(body, WIDTH, DEPTH, THICKNESS, HOLE_D)
+
+
+if __name__ == "__main__":
+    plate()
+```
+
+## `src/plate_drawing.py`
+
+```python
+"""Demo drawing: the plate's flat pattern (outline + corner holes)."""
+
+from __future__ import annotations
+
+from cadgen import build123d as bd
+from cadgen import dxf
+
+from lib import holes
+from plate import DEPTH, WIDTH  # constants from a model: tracked by value; importing never builds
+
+
+HOLE_D = 4.5
+
+
+@dxf(out="../DXF/plate_drawing.dxf")
+def plate_drawing():
+    with bd.BuildSketch() as cut:
+        bd.Rectangle(WIDTH, DEPTH)
+        with bd.Locations(*holes.corner_hole_centers(WIDTH, DEPTH)):
+            bd.Circle(HOLE_D / 2, mode=bd.Mode.SUBTRACT)
+    return cut.sketch  # a bare shape is the CUT layer
+
+
+if __name__ == "__main__":
+    plate_drawing()
+```
+
+A `@dxf` function returns build123d 2D geometry and the engine writes the DXF —
+the same division of labor `@step` has. Return `{layer: shape}` instead when a
+drawing genuinely has more than one CAM operation. See the `$dxf` skill.
+
+## `src/standoff.py`
+
+```python
+"""Demo print-only part: a standoff that exists as a mesh, never a STEP."""
+
+from __future__ import annotations
+
+from cadgen import build123d as bd
+from cadgen import stl
+
+HEIGHT = 12.0
+OUTER_D = 8.0
+BORE_D = 3.4
+
+
+@stl(out="../STL/standoff.stl")
+def standoff():
+    return bd.Cylinder(OUTER_D / 2, HEIGHT) - bd.Cylinder(BORE_D / 2, HEIGHT)
+
+
+if __name__ == "__main__":
+    standoff()
+```
+
+`@stl` alone declares a model whose outputs are meshes: same store record,
+same no-op, and it composes into `frame` below like any part. Add `@step` above
+it later if a STEP is ever wanted; nothing else changes.
+
+## `src/bracket_left.py`
+
+```python
+"""Demo part: the left-hand side bracket."""
+
+from __future__ import annotations
+
+from cadgen import step
+
+from lib.bracket_shape import side_bracket
+
+
+@step(out="../STEP/bracket_left.step")
+def bracket_left():
+    return side_bracket()
+
+
+if __name__ == "__main__":
+    bracket_left()
+```
+
+## `src/bracket_right.py`
+
+```python
+"""Demo part: the right-hand side bracket — the left one's mirror image."""
+
+from __future__ import annotations
+
+from cadgen import step
+
+from lib.bracket_shape import side_bracket
+
+
+@step(out="../STEP/bracket_right.step")
+def bracket_right():
+    return side_bracket(mirrored=True)
+
+
+if __name__ == "__main__":
+    bracket_right()
+```
+
+STEP cannot express a reflection, so a mirrored part is its own model: the
+shape lives once, in the factory, and each hand is a one-line model with its
+own STEP, its own record and its own place in the assembly.
+
+## `src/frame.py`
+
+```python
+"""Demo sub-assembly: the plate carrying two standoffs."""
+
+from __future__ import annotations
+
+from cadgen import build123d as bd
+from cadgen import step
+
+from plate import THICKNESS, WIDTH, plate   # the model (by result) and two constants (by value)
+from standoff import standoff
+
+PITCH = WIDTH / 2
+
+
+@step(out="../STEP/frame.step")
+def frame():
+    base = plate()                                  # built if stale, else loaded; LINKED
+    base.label = "plate"
+    post = standoff()                               # a mesh-only child links like any other
+    left = bd.Pos(-PITCH / 2, 0.0, THICKNESS / 2) * post    # placed: one link …
+    left.label = "standoff_left"
+    right = bd.Pos(PITCH / 2, 0.0, THICKNESS / 2) * post    # … placed again: a second link, one tree
+    right.label = "standoff_right"
+    return bd.Compound(children=[base, left, right], label="frame")
+
+
+if __name__ == "__main__":
+    frame()
+```
+
+Place children with `Pos/Rot/Location * child` or `child.moved(loc)` — never
+`child.located(loc)`, which copies the geometry and turns the link into a
+duplicate component.
+
+## `src/assembly.py`
+
+```python
+"""Demo root assembly: the frame between its two brackets."""
+
+from __future__ import annotations
+
+from cadgen import build123d as bd
+from cadgen import step
+
+from bracket_left import bracket_left
+from bracket_right import bracket_right
+from frame import frame
+from plate import DEPTH, THICKNESS
+
+SPAN = DEPTH / 2 + 6.0
+
+
+@step(out="../STEP/assembly.step")
+def assembly():
+    core = frame()                                  # a sub-assembly: its tree, linked
+    core.label = "frame"
+    left = bd.Pos(0.0, -SPAN, THICKNESS) * bracket_left()
+    left.label = "bracket_left"
+    right = bd.Pos(0.0, SPAN, THICKNESS) * bracket_right()
+    right.label = "bracket_right"
+    return bd.Compound(children=[core, left, right], label="assembly")
+
+
+if __name__ == "__main__":
+    assembly()
+```
+
+Running `python src/assembly.py` builds every stale model beneath it — the
+brackets, the frame, and through the frame the plate and the standoff — in
+parallel, and links their results. Rebuilding a part alone does not rebuild
+this root; rerun it to pick up the change.
+
+## `src/lib/__init__.py`
+
+```python
+"""Shared helpers for the demo project: hole patterns and the bracket factory."""
+```
+
+`src/lib/` is a regular package, so this file is never omitted — one line naming
+what the package holds is the whole file.
+
+## `src/lib/holes.py`
+
+```python
+"""Shared hole helpers (plain module: no @step here)."""
+
+from __future__ import annotations
+
+from cadgen import build123d as bd
+
+INSET = 6.0
+
+
+def corner_hole_centers(width: float, depth: float):
+    """The four corner-hole centers, shared by the part and its drawing."""
+    return [
+        (sx * (width / 2 - INSET), sy * (depth / 2 - INSET))
+        for sx in (-1, 1)
+        for sy in (-1, 1)
+    ]
+
+
+def corner_holes(body, width: float, depth: float, thickness: float, hole_d: float):
+    for x, y in corner_hole_centers(width, depth):
+        body -= bd.Pos(x, y, 0) * bd.Cylinder(hole_d / 2, thickness * 2)
+    return body
+```
+
+## `src/lib/bracket_shape.py`
+
+```python
+"""The side-bracket factory: one shape, two hands (plain module: no @step here)."""
+
+from __future__ import annotations
+
+from cadgen import build123d as bd
+
+LENGTH = 40.0
+HEIGHT = 10.0
+THICKNESS = 6.0
+HOLE_D = 5.0
+
+
+def side_bracket(mirrored: bool = False) -> bd.Shape:
+    body = bd.Box(LENGTH, THICKNESS, HEIGHT)
+    body -= bd.Pos(LENGTH / 4, 0.0, 0.0) * bd.Rot(90, 0, 0) * bd.Cylinder(HOLE_D / 2, THICKNESS * 2)
+    return bd.mirror(body, about=bd.Plane.YZ) if mirrored else body
+```
+
+A helper in `lib/` is part of the SOURCE of every model that imports it: any
+edit here rebuilds both brackets (and, on their next run, the assemblies that
+use them). That is the right behaviour for a factory — and the reason shared
+code that is really a sub-assembly should be a model file instead.
+
+## `src/README.md`
+
+```markdown
+# demo models
+
+| Script           | Artifact               | Description                           |
+|------------------|------------------------|---------------------------------------|
+| plate.py         | STEP/plate.step        | Mounting plate, `HOLE_D` corner holes |
+| plate_drawing.py | DXF/plate_drawing.dxf  | Plate flat pattern                    |
+| standoff.py      | STL/standoff.stl       | Print-only standoff (mesh only)       |
+| bracket_left.py  | STEP/bracket_left.step | Left side bracket                     |
+| bracket_right.py | STEP/bracket_right.step| Right side bracket (mirror image)     |
+| frame.py         | STEP/frame.step        | Plate + two standoffs (sub-assembly)  |
+| assembly.py      | STEP/assembly.step     | Frame + both brackets (root)          |
+
+Build: `python src/assembly.py` builds the root and whatever is stale beneath
+it; `python src/plate_drawing.py` for the drawing; unchanged models are no-ops.
+Imported sources: STEP/imported/servo.step (committed, no script).
+```
+
+`STEP/imported/servo.step` stands for any source file brought in from outside
+(a vendor download, a supplier's model) under its upstream name: no script
+produces it, so it is committed, and a model script that composes it reads it
+with `cadgen.read_step` anchored on the script's own location — scripts build
+from any working directory, so the path is
+`Path(__file__).parent / "../STEP/imported/servo.step"`, never a bare relative
+string (the `$cad` skill covers `read_step`, and how to wrap an import in a
+model of its own so assemblies can link to it).
+
+## `.gitignore`
+
+```gitignore
+/STEP/*
+!/STEP/imported/
+!/STEP/*.step.js
+/DXF/*
+!/DXF/imported/
+/STL/*
+!/STL/imported/
+/GLB/*
+!/GLB/imported/
+/3MF/*
+!/3MF/imported/
+/tmp/
+__pycache__/
+```
+
+The `*` forms matter: ignoring the directory itself (`/STEP/`) would make the
+`imported/` negation dead — git never descends into an ignored directory. The
+`!/STEP/*.step.js` line keeps render modules (the authored choreography beside
+a document, `arm.step.js` beside `arm.step`) committed while everything
+generated around them stays ignored. A project whose folders mirror the
+product tree (groups, sub-assembly folders, `purchased/`) needs the negations
+at every depth, because git never descends into an ignored directory:
+
+```gitignore
+/STEP/*
+!/STEP/imported/
+!/STEP/*.step.js
+!/STEP/*/
+/STEP/*/*
+!/STEP/*/*.step.js
+!/STEP/*/*/
+/STEP/*/*/*
+!/STEP/*/*/*.step.js
+```
+
+One `!/STEP/*/`, `/STEP/*/*`, `!/STEP/*/*.step.js` triple per nesting level
+(the same for `DXF/`, `STL/`, `GLB/`, `3MF/`). Pin any other file deliberately
+with its own negation line or `git add -f`.
+
+## `.gitattributes`
+
+```gitattributes
+# Imported sources are binaries you did not write: keep them out of plain git history.
+STEP/imported/** filter=lfs diff=lfs merge=lfs -text
+DXF/imported/**  filter=lfs diff=lfs merge=lfs -text
+STL/imported/**  filter=lfs diff=lfs merge=lfs -text
+GLB/imported/**  filter=lfs diff=lfs merge=lfs -text
+3MF/imported/**  filter=lfs diff=lfs merge=lfs -text
+
+# Authored text beside the documents stays plain git.
+*.step.js text
+*.step.json text
+```
+
+A per-project file at the project root, next to `.gitignore`. The `imported/`
+folders hold vendor STEPs, supplier DXFs and other files you did not author;
+tracking them with Git LFS keeps those binaries out of plain git history while
+the render modules and sidecars beside the documents stay diffable text. Run
+`git lfs install` once per machine. If a file under `imported/` is a few lines
+of text beginning `version https://git-lfs...`, it is an LFS pointer whose
+object was not fetched: `read_step` fails on it, and
+`git lfs checkout STEP/imported` (or the folder in question) is the fix.
+
+## Verify
+
+```bash
+python src/assembly.py                   # builds the root and, beneath it, frame, plate, standoff, both brackets
+python src/assembly.py                   # "current" — the no-op gate works
+python src/plate_drawing.py              # builds DXF/plate_drawing.dxf (the drawing is not under the root)
+cadgen store why src/frame.py            # the frame's record: its two children, pinned and current
+cadgen step snapshot STEP/assembly.step tmp/assembly.png
+```
+
+## The finished tree
+
+After the verify loop, the project is complete and looks like this — the one
+exemplar this structure needs:
+
+```
+demo/
+  .gitignore
+  .gitattributes
+  src/                          # committed — the only thing anyone edits
+    README.md
+    plate.py
+    plate_drawing.py
+    standoff.py
+    bracket_left.py
+    bracket_right.py
+    frame.py
+    assembly.py
+    lib/
+      __init__.py
+      holes.py
+      bracket_shape.py
+  STEP/
+    plate.step                  # generated by src/plate.py — ignored
+    bracket_left.step
+    bracket_right.step
+    frame.step
+    assembly.step
+    assembly.step.js            # the render module beside assembly.step — authored, committed
+    imported/
+      servo.step                # brought in from outside — committed
+  STL/
+    standoff.stl                # generated by src/standoff.py — ignored
+  DXF/
+    plate_drawing.dxf           # generated by src/plate_drawing.py — ignored
+  tmp/
+    assembly.png                # the snapshot: scratch — ignored
+```
+
+No model here declares kinematics or a mesh export beside its STEP, so no
+`.step.json` sidecar is written; a model that does gets one beside its
+document, generated with it and ignored with it. `assembly.step.js` is the
+other file beside a document: the render module (choreography — see the cad
+skill's kinematics reference). Nothing generates it and no build reads it; the
+viewer loads it by name, so it is authored like `src/` and committed like
+`imported/`.
+
+`git status` in this tree shows exactly `.gitignore`, `.gitattributes`, `src/`,
+`STEP/assembly.step.js` and `STEP/imported/servo.step`: authored code, the
+authored choreography, and the one input code cannot regenerate. Everything
+else is rebuilt by running the scripts, so a fresh clone that runs
+`python src/assembly.py && python src/plate_drawing.py` arrives at this same
+tree.

--- a/.qwenpaw-plugin/skills/cad/references/repair-loop.md
+++ b/.qwenpaw-plugin/skills/cad/references/repair-loop.md
@@ -1,0 +1,210 @@
+# Repair loop
+
+Read this file when generation, export, inspection, positioning, snapshot review, CAD Viewer setup, or documentation validation fails.
+
+## Loop
+
+1. Read the failing command output.
+2. Classify the failure.
+3. Make the smallest responsible source or command change.
+4. Rerun the failed command.
+5. Rerun any dependent validation checks.
+6. Report remaining risk or deliberate deviations.
+
+## Failure classes and fixes
+
+### Multi-section loft: "Failed to create valid loft" / "Recovery failed"
+
+The message names neither the station nor the cause. Two checks, in this order:
+
+1. **Loft increasing PREFIXES** (`faces[:5]`, `[:10]`, `[:20]`, …) to bracket
+   where it breaks, and watch the reported volume as well as the exception — a
+   loft that "succeeds" with an absurd volume is already failing.
+2. **Loft every ADJACENT PAIR.** If every pair succeeds but the full set fails,
+   the sections are individually fine and the problem is global — almost always
+   that sections disagree on POINT COUNT. Guarantee a fixed sample count per
+   section.
+
+Two silent causes worth ruling out before either:
+
+- **A section that is genuinely disconnected** (two closed regions — e.g. a
+  station cutting two separate nacelles, or crossing an open slot) produces a
+  `Face` that raises nothing and reports a plausible area; only `Face.is_valid`
+  is False. The loft then fails dozens of stations away. End the loft at the last
+  connected station, or bridge the gap in the section and cut it back afterwards.
+  (`Face.is_valid` is a PROPERTY — calling `f.is_valid()` raises
+  `TypeError: 'bool' object is not callable`, which reads like a corrupt object.)
+- **Samples dropped where a component does not exist** make counts vary station
+  to station. Carry a value rather than dropping the sample.
+
+### Boolean against a large lofted surface never returns
+
+A subtract against a single large B-spline surface costs a full-surface
+classification PER TOOL and grows superlinearly in tool count — measured on one
+~4,900-control-point skin: 1 tool 24 s, 4 tools 70 s, 41 tools did not finish in
+15 minutes, and a 44-tool build ran over seven hours without completing. Batching
+into one list operand does NOT help; the cost is per tool, not per accumulation.
+
+Confirm rather than guess: the process stays at ~100 % CPU with the progress file
+frozen on its first phase, and a stack sample shows `Extrema_ExtPS::Perform` with
+`BSplSLib_Cache::BuildCache` rebuilding on nearly every evaluation.
+
+Fix by not cutting: shallow cosmetic recesses do not need to be booleans at all.
+At 19 m rendered to 1920 px, 1 px is ~10 mm, so a 4 mm groove is sub-pixel and
+reads only because the edge overlay draws feature edges. Keep booleans for
+openings that change the silhouette, and build the rest additively.
+
+### Source import or syntax failure
+
+Likely causes:
+
+- invalid Python syntax
+- missing import
+- wrong build123d symbol
+- function not named the `@step` model function
+- executable code outside the intended function has side effects
+
+Fix:
+
+- correct imports and syntax
+- ensure the `@step` model function returns the STEP-ready shape or compound
+- keep output paths in CLI commands, not inside the `@step` model function
+
+### Invalid or missing geometry
+
+Likely causes:
+
+- open sketch
+- subtractive profile outside target
+- zero thickness
+- boolean operation failed
+- construction geometry used as exported geometry
+
+Fix:
+
+- close profiles intended to become faces
+- verify dimensions are positive
+- make subtractive tools pass through when through-cuts are intended
+- simplify the failing feature and rebuild incrementally
+
+### Fillet or chamfer failure
+
+Likely causes:
+
+- radius/length exceeds local geometry
+- selected edges include tiny or unintended edges
+- boolean operation created complex edge topology
+
+Fix:
+
+- reduce radius/length
+- filter selected edges more narrowly
+- apply fillets later in the model
+- split edge groups by feature intent
+
+### Wrong scale or bounding box
+
+Likely causes:
+
+- units mismatch
+- mistaken diameter/radius
+- extrusion direction or amount wrong
+- part not centered as assumed
+- direct imported STEP uses unexpected units
+
+Fix:
+
+- check parameter values
+- inspect facts and planes
+- measure critical extents
+- correct source dimensions or import handling
+
+### Missing feature
+
+Likely causes:
+
+- wrong `Mode.ADD`/`Mode.SUBTRACT`
+- feature profile not inside target
+- blind cut too shallow
+- selector changed after prior operation
+
+Fix:
+
+- confirm feature mode
+- increase cut length for through-cuts
+- inspect topology or planes
+- regenerate and measure/check feature-specific refs
+
+### Selector fragility
+
+Likely causes:
+
+- arbitrary index selection
+- topology changed after fillet or boolean
+- similar faces/edges are indistinguishable
+
+Fix:
+
+- select by axis, plane, position, normal, or inspected reference
+- use `refs --facts --planes --positioning` to rediscover stable references
+- add construction datums or simplify operations if needed
+
+### Positioning or joint mismatch
+
+Likely causes: wrong part-local origin or datum, reversed `AssemblyHelper` fixed/moving order, `.connect_to()` moving the wrong part, inverted joint axis, sign errors in symmetric placement, an explicit `Location` not recomputed after a parameter change, or a joint defined in world coordinates when a part-local datum was intended.
+
+Fix:
+
+- inspect `refs --positioning`, then `frame` and `align` on the relevant selectors
+- verify the source-level `AssemblyHelper` target order, joint labels, and `joint_location` definitions
+- apply the smallest source correction from the list in `positioning.md` (Source-level positioning corrections)
+- regenerate the assembly from the Python source and rerun the failed check
+
+### CAD Viewer startup or link failure
+
+Likely causes:
+
+- Node/npm unavailable
+- CAD Viewer app not built or cannot start
+- Viewer URL path is not the project's absolute model directory
+- returned link is missing `?file=`, or its `file=` is not relative to that directory
+
+Fix:
+
+- rebuild each link as `<viewer-origin><absolute-model-directory>?file=<path relative to it>`
+- return one documented Viewer link per requested file
+- if unresolved, report the startup failure and rely on CLI facts/measurements plus snapshots for validation
+
+### CAD `cadgen step snapshot` failure
+
+Likely causes:
+
+- target input path is wrong, missing, or not a STEP/STP file or same-stem Python generator
+- adjacent CAD Viewer GLB/topology artifact missing
+- invalid render flags
+
+Fix:
+
+- generate STEP first, then snapshot the primary `.step`/`.stp` artifact
+- retry only with simpler supported snapshot jobs, starting with a single `view` output before wireframe display or `section`
+- choose modes and packet size per `snapshot-review.md`
+
+## Diff after repair
+
+Use `diff` when the fix might have affected unrelated geometry:
+
+```bash
+cadgen step inspect diff path/to/before.step path/to/after.step --planes
+```
+
+## Reporting failed repairs
+
+If a check cannot be repaired in the current environment, report:
+
+```text
+- what failed
+- what was tried
+- which artifact is still usable
+- which validation claims cannot be made
+- what the next source-level correction should be
+```

--- a/.qwenpaw-plugin/skills/cad/references/snapshot-review.md
+++ b/.qwenpaw-plugin/skills/cad/references/snapshot-review.md
@@ -1,0 +1,99 @@
+# Snapshot review
+
+Read this file when choosing saved CAD `cadgen step snapshot` outputs for primary STEP/STP artifacts.
+
+## Policy
+
+Snapshot validation is mandatory. Every created or visibly updated primary STEP/STP part or assembly gets at least one reviewed PNG snapshot; deterministic checks passing is not a reason to skip. Use CAD `cadgen step snapshot` rather than opening the viewer manually or using Playwright; snapshots are faster, lighter, more precise, and more agent-friendly. Snapshots are PNG stills; review motion interactively in the viewer. For still evidence of a pose or of one moment in a clip, pass `--kinematics` and/or `--animation CLIP --time SECONDS` (see `kinematics.md`, "Reviewing motion") — one frame, never a sequence.
+
+Skip saved snapshots only when no visible geometry was created or updated, or no valid artifact exists:
+
+- pure format/export requests where geometry is unchanged
+- source changes that do not alter visible geometry
+- inspection-only tasks (for example direct measurement questions) that create or update nothing
+- failed Python or STEP generation before a valid artifact exists
+
+When skipping, report the reason and the deterministic evidence that still ran.
+
+Do not loop on snapshots. Rerender only when a source repair changed visible geometry or when a specific visual finding needs confirmation.
+
+## Packet sizing
+
+One PNG is enough for a simple static part. Use the small multi-view packet when semantic errors are plausible from shape complexity or prompt intent:
+
+- assemblies or more than one body/part
+- holes on multiple faces or multiple axes
+- shells, internal cavities, bores, passages, open enclosures, or section-critical features
+- ribs, gussets, bosses, standoffs, slots, cutouts, lightening holes, fins, blades, or repeated patterns
+- source repairs after a geometry, boolean, selector, or feature failure
+- prompts where "looks like the requested object" is part of the task
+- deterministic checks pass but visible semantics are still uncertain
+
+## Small packet
+
+Prefer a single `view` JSON job with these outputs:
+
+```json
+{
+  "input": "models/part.step",
+  "mode": "view",
+  "outputs": [
+    { "path": "/tmp/render/iso.png", "camera": "iso" },
+    { "path": "/tmp/render/iso_opposite.png", "camera": { "direction": [-1, 1, -0.8] } },
+    { "path": "/tmp/render/top_ortho.png", "camera": "top" },
+    { "path": "/tmp/render/front_ortho.png", "camera": "front" }
+  ],
+  "render": { "viewLabels": true, "padding": 0.12, "sizeProfile": "diagnostic" }
+}
+```
+
+The two opposed isometric views guarantee every face appears in at least one image — rear, left, and bottom features are covered by default, not by suspicion. The top ortho is the primary pattern/symmetry check and the front ortho the profile check.
+
+Set `input` to the primary STEP/STP artifact using a relative or absolute path (documents only — a `.py` model script is refused: run it first, then snapshot the STEP it wrote). The snapshot CLI derives its internal render root from that input path. It defaults to `theme: "snapshot"` and `display.mode: "solid"`. `snapshot` is a render-only theme — Workbench Light with the ground grid, origin axis and shadows removed, because in a still image those read as geometry rather than as orientation. It is not offered in the CAD Viewer's theme picker; pass `theme: "workbench-light"` to match the viewport exactly; labeled/section views default to 1600x1200 when dimensions are omitted. Use `render.sizeProfile: "assembly"` or `"assembly-large"` for complex assemblies that need 1800x1200 or 1920x1440. For CAD review packets, use still-image render modes `view` and `section`; set `display.mode` to `solid`, `transparent`, `hidden_edges`, `hidden_lines_removed`, or `wireframe` when the visual check benefits from explicit CAD linework.
+
+Use `--focus '#o1.2' ...` to emphasize specific part or subassembly occurrence refs — in `view` renders the focused refs keep full opacity while the rest of the assembly is ghosted in place (framing and context are preserved); in `section` mode focus isolates the refs entirely. Use `--hide '#o1.2' ...` to omit parts from the render in every mode. Do not combine focus and hide in the same snapshot command or job. These filters accept occurrence refs only, not face, edge, vertex, or shape selectors.
+
+## Output paths
+
+Name the file and you get that file:
+
+```bash
+cadgen step snapshot STEP/bracket.step tmp/review.png
+# then Read tmp/review.png
+```
+
+OUT (and an output's `path` in a JSON packet) is written exactly as given, with a relative path resolved against the current working directory. The target is deleted before the render starts and the finished image is written atomically, so the file at that path is always the render you just ran.
+
+1. **Tight iteration: reuse one name.** Render, Read, edit the source, render again to the same `tmp/review.png`. Every read is provably the latest render, because a failed one leaves nothing to read.
+2. **Comparisons: name the iterations.** Use `tmp/before.png` and `tmp/after.png` when both images are genuinely needed.
+3. **A missing file IS the failure signal.** A nonzero exit or a file-not-found means the render failed; there is never an older image at the path to mistake for output.
+
+Pass a directory (`tmp/` as OUT, or an output `path` that is one) only when the name does not matter: a timestamped name is generated inside it, and that is the one case where you read the path from the `saved snapshot:` line.
+
+## Targeted additions
+
+Add views only when the brief or a failure mode calls for them:
+
+- reference-image reproduction: one snapshot from the reference image's viewpoint for side-by-side comparison
+- `section`: shell, bore, internal cavity, passage, blind hole, enclosure, or wall/floor relationship
+- `display.mode: "solid"`: shaded CAD view with explicit edge linework
+- `display.mode: "rendered"`: shaded material view without edge overlay
+- `display.mode: "transparent"`: overlap, collision, enclosure readability, or hidden contact checks when transparency adds information and wireframe is too noisy
+- `display.mode: "hidden_edges"`: opaque shaded context with hidden/occluded CAD edges visible through solids
+- `display.mode: "hidden_lines_removed"`: line-focused review where hidden/occluded edges should be suppressed
+- `display.mode: "wireframe"`: internal overlap, hidden interference, or assembly collision suspicion when full triangle wire is useful
+- labeled or annotated review: use supported CAD Viewer refs, selections, screenshots, or GUI review links
+
+Exploded or labeled review is an intent, not a render mode. Satisfy it through supported CAD Viewer mechanisms, supported JSON job settings, or the GUI link.
+
+## Diagnostic review
+
+Visual review is diagnostic, not authoritative. Convert every visual concern into a follow-up geometry check before using it as a validation claim:
+
+- hole pattern appears asymmetric -> measure hole centers and compare offsets
+- lid, child part, or occurrence appears offset -> inspect frames and mating deltas
+- gusset, boss, standoff, rib, or plate may be floating -> inspect solid count, labels, connectivity, contact, or relevant distances
+- cavity, bore, or blind hole looks wrong -> run section review, then measure wall thickness, depth, or through-condition
+- repeated pattern looks uneven -> measure pattern centers, angular spacing, or occurrence frames
+
+Final reports should include the generated snapshot PNGs or the documented skip reason, and state which deterministic checks support any visual finding.

--- a/.qwenpaw-plugin/skills/cad/references/step-generation.md
+++ b/.qwenpaw-plugin/skills/cad/references/step-generation.md
@@ -1,0 +1,543 @@
+# The model contract and STEP generation
+
+Read this file when authoring or rebuilding a model script, composing models
+into assemblies, deciding what a rebuild tracks, or working with imported
+STEP/STP files.
+
+## The model script is the tool
+
+Generation has no CLI. A model is a plain Python script whose `__main__` calls
+the decorated function; that call builds it:
+
+```python
+from cadgen import build123d as bd
+from cadgen import step
+
+WIDTH = 10.0
+
+
+@step
+def bracket():
+    return bd.Box(WIDTH, 10, 10)
+
+
+if __name__ == "__main__":
+    bracket()
+```
+
+```bash
+python bracket.py                 # builds bracket.step (and the result tree in the store)
+python bracket.py --force --json  # per-run flags ride the script's argv
+```
+
+Every run keeps the model's result in the store current — a **tree** of exact
+`.brep` + `.surf` components plus links to its children's trees — and writes
+every output the model declares from that result. Unchanged sources are a
+fast no-op. The default `.step` is the sibling `<stem>.step`; relocate it
+durably with `@step(out="path/to/out.step")` (relative to the script). There
+is no per-run output override: a model has one set of outputs, declared in its
+decorators, and the store's record of it is keyed by the script.
+
+Rules the decorator enforces:
+
+- **The decorator only declares.** Nothing runs at decoration or import time.
+  A model file without `if __name__ == "__main__": <model>()` never builds.
+- **A top-level call builds.** Calling the decorated name when no build is in
+  progress (`__main__`, a REPL) runs the pipeline and returns `None`; a failed
+  build exits with the pipeline's code. It takes no arguments.
+- **A call inside a build composes.** From another model's body the same name
+  returns the shape: the child is built if it is stale (writing ITS outputs
+  and record), otherwise loaded from the store, and either way its result is
+  linked into the parent's. Composition is ordinary Python; there is nothing
+  to cache by hand and no composition API.
+- **One model per file is the recommendation, not a rule.** A model's identity
+  is `script.py::function`; a file holding one model is named by its path alone
+  (`python plate.py`, `store why plate.py`). Several decorated functions in one
+  file are allowed — a small variant family — and each is its own record,
+  output (a sole model writes `<file>.<fmt>`; models sharing a file write
+  `<function>.<fmt>`) and job, built by its
+  own call under `__main__`; name one as `plate.py::plate_wide` in `store why`
+  and `store forget`. They share the file's closure: editing any of them makes
+  all of them stale, so a family that changes independently belongs in
+  separate files.
+- **Calling a model from plain Python returns its geometry.** Outside a build,
+  `plate()` builds (or finds current) and returns the model's tree as a
+  `Compound` — what a parent composing it would get — so a script, a notebook
+  or a REPL can read bounds, faces or volumes straight off a model. A drawing
+  returns `None`.
+- **A model takes no parameters.** It is one configuration of one set of
+  outputs, so there is nothing for an argument to select; the decorator
+  refuses a parameter list. Parametric geometry is a plain factory the model
+  calls:
+
+  ```python
+  from cadgen import build123d as bd
+  from cadgen import step
+
+
+  def _bracket(width: float, thickness: float) -> bd.Shape:
+      return bd.Box(width, 10, thickness)
+
+
+  @step
+  def bracket():
+      return _bracket(width=40.0, thickness=6.0)
+
+
+  if __name__ == "__main__":
+      bracket()
+  ```
+
+  A second configuration is a second model (`bracket_wide.py`), with its own
+  outputs — the way two part numbers are two parts. Values a model shares with
+  its drawing or its assembly live in module constants (`WIDTH = 40.0`) that
+  the siblings import.
+- **The return is a bare build123d `Shape` and nothing else** — a dict return
+  is refused. The return IS the geometry: a `Compound` placing children is
+  packaged as occurrences (linked where a child is another model's result), a
+  single solid as one component. Nothing is declared or inferred about it —
+  `inspect` and the run both report `part`/`assembly` off the tree.
+- **Outputs are what the decorators declare.** `@step` writes the `.step`.
+  Mesh outputs are `@stl`/`@threemf`/`@glb` stacked on the model, tolerances
+  on the decorators (`supported-exports.md`). **A model may declare no STEP at
+  all**: `@stl`/`@threemf`/`@glb` with no `@step` is a full model — same tree,
+  record, build, no-op and composition — that writes its meshes and no
+  `.step`, no sidecar. STEP is one output kind, not a requirement.
+- Options on `@step`: `out=`, `mesh_tolerance=`, `mesh_angular_tolerance=`,
+  `kinematics=` (`kinematics.md`). **No decorator argument changes the
+  geometry a model produces**: they decide where the files land, how they are
+  written, and what the sidecar declares. No decorator names JavaScript:
+  choreography is the render module beside the document
+  (`STEP/<name>.step.js`), which the viewer loads by name and no build reads.
+  Everything a model declares about itself lives in its decorators, and a
+  child's declarations never ride up into a parent.
+
+**Imports:** `from cadgen import build123d as bd` is the canonical import — a
+lazy, transparent re-export (same names, same objects on first touch), so a
+current model's re-run never pays the ~2.5s kernel import: the freshness gate
+and the warm-worker handoff fire before any `bd.` attribute resolves. Raw
+`import build123d` still works, just slower on re-runs (the build prints a
+one-line hint). Keep `bd.<anything>` out of module-level constants and default
+arguments for the same reason.
+
+**A model runs like `python script.py`.** Its folder is on `sys.path` for the
+whole build, plus your `PYTHONPATH` — cadgen adds nothing else and infers no
+project root — so an import inside the body, or inside a helper the body calls,
+resolves exactly like one at module top — and the file it loads is hashed when
+it executes, so it is in the closure either way. Prefer module-top imports for
+readability and so the static scan sees the graph up front; a lazy import is
+not an error.
+
+## Generated vs imported STEP
+
+These two terms classify a STEP file by what its source is:
+
+- A **generated STEP file** has a model script as its source. The STEP is a
+  *derived output*; the script is what you edit and re-run.
+- An **imported STEP file** is its own source: authored or downloaded
+  elsewhere. There is nothing upstream to regenerate.
+
+A model that DECLARES something beyond geometry — kinematics, animation, or
+mesh exports — gets a sidecar BESIDE THE OUTPUT (`<name>.step.json`) carrying
+those sections. A plain model writes NO sidecar: its record in the store is
+what makes reruns no-op. Imports write none of it. The written STEP file
+itself carries NO cadgen metadata and no link back to source code, ever — a
+bare artifact copied anywhere is a plain importable file, and every door
+resolves it by its bytes, so a moved or copied document renders identically to
+its twin.
+
+## Composing on other parts: children and inputs
+
+A model that builds on another part wires it in one of two modes. Choose
+deliberately:
+
+- **A CHILD (the default)** — the other part is a model in this project:
+  import its function and call it. A child edit flows into the parent on the
+  parent's next rebuild; there are no exported bytes to keep in sync. Never
+  route a generated child through its exported `.step`.
+- **An INPUT** — the other part is a document, not source: a purchased or
+  downloaded part, or a generated part the user has EXPLICITLY asked to
+  decouple (export it once, then treat the export like any other document).
+  Read it with `cadgen.read_step`, below.
+
+### Children
+
+A child is just an import: model scripts are real modules, and
+`from widget import widget` binds the model with no build side effects.
+Calling `widget()` inside the parent's body builds the child when it is stale
+(writing the child's own outputs) or loads its result from the store, and
+returns the shape. What comes back is GEOMETRY only — tree, labels, colors,
+placements. A child's sidecar content (its mates, kinematics, animation) never
+rides up into the parent: declare what the assembly needs on the assembly.
+
+```python
+from cadgen import build123d as bd
+from cadgen import step
+
+from link_pin import link_pin   # importing binds; never builds
+
+
+@step(out="../STEP/link_arm.step")
+def link_arm():
+    bar = bd.Box(40.0, 8.0, 4.0)
+    bar.label = "bar"
+    pin = link_pin()                                   # built if stale, else loaded
+    left = pin.moved(bd.Location((-15.0, 0.0, 2.0)))   # placed: the parent LINKS to the pin
+    left.label = "pin_left"
+    right = pin.moved(bd.Location((15.0, 0.0, 2.0)))   # placed again: a second link, one tree
+    right.label = "pin_right"
+    return bd.Compound(children=[bar, left, right], label="link_arm")
+
+
+if __name__ == "__main__":
+    link_arm()
+```
+
+**Link or component.** Place a child's shape as it came back — `moved()`,
+`Pos/Rot/Location * child`, relabelled, recolored — and the parent's result
+LINKS to the child's tree (stored once, shared by every parent; two placements
+are two links to one tree). Modify it (a boolean, a mirror, extracting a
+sub-shape) and the parent owns that geometry as its own components; the
+dependency is tracked either way. **Never `located()`** for placement: it
+deep-copies the geometry, which makes it the parent's own component instead
+of a link (`positioning.md`). Put geometry changes that belong to the child in
+the child's file or its factory.
+
+**Every build is parallel.** A child call returns at once with a lazy shape
+and submits the child's build to the pool; the body keeps calling siblings,
+each landing on its own worker; the parent waits when it first reads geometry
+— normally the closing `bd.Compound(children=[...])`, after every sibling has
+been submitted. Placement (`moved`, `Pos/Rot/Location *`), `.label` and
+`.color` are deferred; anything that reads geometry (`.faces()`,
+`.bounding_box()`, a boolean, `copy.copy`) forces that child there, so
+parallelism follows the dependencies the body actually expresses. Nothing is
+annotated and nothing is scheduled ahead of time.
+
+**Dependency is pull.** A parent depends on each child by RESULT: its record
+pins the child's tree hash, so a child edit that yields identical geometry
+leaves the parent current, and an edit that does not reach a child skips that
+child's Python and kernel work entirely. **Rebuilding a child does not rebuild
+the assemblies that use it** — run the parent to pick up the change
+(`python src/robot.py` builds whatever is stale beneath it and links the
+rest). A parent finished against a child that changed during its build says so
+(`already stale: … rerun`).
+
+**Builds never wait on or cancel one another.** Two runs of one model both
+run to completion; each publishes what it built and the store keeps the one
+whose sources match the files as they are now. Editing a child while its
+parent builds leaves the parent finished against the child it pinned — its
+next gate says stale (`store why` shows the pinned vs current tree). There is
+no lock anywhere.
+
+### What a rebuild tracks — models by result, constants by value, functions by file
+
+What an importer TAKES from a model file decides how that file counts:
+
+- **`from widget import widget`** (the model function) → tracked by RESULT:
+  the parent pins the child's tree; `widget.py` is not in the parent's source.
+- **`from widget import WIDTH`** (a module-level literal: a number, string,
+  bool, `None`, or tuples/lists/dicts of those) → tracked by VALUE: a
+  comment or body edit in `widget.py` leaves the importer current; only a
+  changed value rebuilds it.
+- **Anything else** from a model file (a helper function, a `bd.` object, an
+  expression) → tracked by FILE: the whole file joins the importer's source
+  closure, and any edit to it rebuilds the importer. Shared helpers therefore
+  belong in `lib/` (a plain module, in the closure of every model that
+  reaches it), and shared constants may live in a model file or in `lib/`.
+
+Inputs join the closure too: a `read_step` document is hashed as a build
+input. The render module beside the document (`<name>.step.js`) is NOT one —
+it is the viewer's, and editing it never makes a model stale.
+
+Every decorator argument is ordinary Python, evaluated when the module is
+imported: `out=f"{FOLDER}/{NAME}.step"`, `mesh_tolerance=TOL` with `TOL` from
+`lib/`, a path built from a constant — all fine, and nothing is read off the
+source text. The values feeding them are tracked like any other input (a
+`lib/` module by file, a model-file constant by value), so changing the
+constant behind an `out=` makes the model stale. The module top must still stay
+kernel-free: what a door pays to learn a model's declarations is one import of
+the file.
+
+### Models inside a package
+
+A model file may live inside a Python package (folders with `__init__.py`).
+cadgen runs it under its dotted name, so relative imports (`from .parts.washer
+import washer`) resolve whenever cadgen loads the model: as a child of another
+model, or when you run it as a module (`python -m pkg.stack`). Running the file
+by path (`python pkg/stack.py`) is Python's own limit, not cadgen's: Python
+executes it as `__main__` with no package, so a relative import fails before
+cadgen is involved; use `-m` or absolute imports for a file you run directly.
+`PYTHONPATH` still declares any import root beyond the script's own folder;
+cadgen adds nothing of its own.
+
+### Mirrored parts are their own models
+
+STEP cannot express a reflection, so a right-hand part is not a mirrored
+placement of the left-hand one: give it its own model file that calls the same
+factory, and let the assembly place two ordinary children.
+
+```python
+# src/lib/bracket_shape.py — the factory (plain module, no decorator)
+from cadgen import build123d as bd
+
+
+def side_bracket(mirrored: bool = False) -> bd.Shape:
+    body = bd.Box(40.0, 10.0, 6.0) - bd.Pos(12.0, 0.0, 0.0) * bd.Cylinder(2.5, 6.0)
+    return bd.mirror(body, about=bd.Plane.YZ) if mirrored else body
+```
+
+```python
+# src/bracket_left.py
+from cadgen import step
+
+from lib.bracket_shape import side_bracket
+
+
+@step(out="../STEP/bracket_left.step")
+def bracket_left():
+    return side_bracket()
+
+
+if __name__ == "__main__":
+    bracket_left()
+```
+
+```python
+# src/bracket_right.py
+from cadgen import step
+
+from lib.bracket_shape import side_bracket
+
+
+@step(out="../STEP/bracket_right.step")
+def bracket_right():
+    return side_bracket(mirrored=True)
+
+
+if __name__ == "__main__":
+    bracket_right()
+```
+
+Mirroring a child inside the parent (`bd.mirror(bracket_left(), ...)`) is
+legal — the parent then owns the mirrored geometry as its own components — but
+the right-hand part has no STEP of its own and no place to declare exports or
+mates. Prefer the model.
+
+### Inputs: reading a STEP file the model does not generate
+
+Use `cadgen.read_step`, not `build123d.import_step`. It returns the same
+shape, served from the op memo on a warm run, and — the part that matters — it
+RECORDS the file's content hash as a build input. Replacing the vendor STEP
+then makes the model stale on its own, with no `--force`; read through
+build123d and the model stays "current" against a file that changed
+underneath it.
+
+```python
+from pathlib import Path
+
+from cadgen import read_step, step
+
+_HERE = Path(__file__).resolve().parent
+
+
+@step
+def rig():
+    motor = read_step(_HERE / "imported" / "vendor_motor.step")   # recorded input
+    ...
+```
+
+An imported part is an INPUT, not a model: nothing links to it and it has no
+record. To make it first-class — so assemblies link to it, so it has its own
+outputs and declarations — wrap it in a model of its own:
+
+```python
+from pathlib import Path
+
+from cadgen import read_step, step
+
+_HERE = Path(__file__).resolve().parent
+
+
+@step(out="../STEP/servo.step")
+def servo():
+    return read_step(_HERE / ".." / "STEP" / "imported" / "sg90_servo.step")
+
+
+if __name__ == "__main__":
+    servo()
+```
+
+**Never `read_step` your own output.** A model that reads the `.step` it is
+about to write is not a loop — it is a model whose input changes every time it
+runs, so the gate can never say "current", every build is a full rebuild, and
+the geometry depends on what the last run happened to leave on disk. Keep
+source documents where the model cannot write them — placement policy belongs
+to `project-layout.md` (`imported/`). Input path and output path being different
+files is the whole rule. If the geometry you want is something the project
+already builds, call that model instead of reading the artifact.
+
+For structuring multi-part projects (folder layout, shared `src/lib/` code,
+commit policy), read `project-layout.md` and `project-template.md`.
+
+## Freshness: `cadgen store why`
+
+`cadgen store why <model>.py` (or a generated `.step`; the store remembers
+which script wrote it) is the one freshness door. It prints the gate's verdict
+clause by clause and why:
+
+```text
+model   /abs/src/frame.py
+verdict STALE  (child result moved: standoff.py)
+  [ok] 1 record present
+  [ok] 2 closure 1 files unchanged
+  [x] 3 children (2)
+        [ok] /abs/src/plate.py  pinned 51b0eafbbc5f  current 51b0eafbbc5f
+        [x] /abs/src/standoff.py  pinned 33df4f5cf2ee  current 91667e73758b  child result moved
+  [ok] 4 tree 7dc0cee81f77 complete
+  [ok] 5 outputs (1)
+        [ok] /abs/STEP/frame.step
+closure b99f36c995b8  files: frame.py
+tree    components 0  occurrences 0  links 3
+        link plate -> 51b0eafbbc5f
+        link standoff_left -> 33df4f5cf2ee
+        link standoff_right -> 33df4f5cf2ee
+```
+
+Here `standoff.py` was edited and rebuilt on its own; the frame still pins
+the old tree, so it is stale until `python src/frame.py` runs — the pull
+semantics above, made visible. The exit code is 1 for stale, 0 for current;
+`--json` gives the same verdict as data. The five clauses: (1) a record
+exists; (2) the closure files — and any constant imported by value — hash as
+recorded; (3) every child is current and its tree is the one pinned; (4) the
+tree and its components exist in the store; (5) every declared output matches
+its recorded sha. Mesh tolerances and argv flags are not inputs. Reach for
+`store why` whenever a model did or did not rebuild when you expected it to,
+before reaching for `--force`.
+
+## Generated assemblies
+
+An assembly is a model whose return places children (a `Compound` of parts
+or of other models' results); the tree records that structure and `inspect`
+reports it as `assembly`. Passing a generated assembly's exported `.step` to a tool treats it as a document and
+loses source-level composition; work with the `.py` source. Prefer
+`cadgen.assembly.AssemblyHelper` so native labels, named mate frames, and
+source-level relationships are preserved before STEP export (see
+`positioning.md`).
+
+## Imported STEP/STP files
+
+An imported STEP/STP file needs no model script and no preparation step. Hand
+it straight to `cadgen step inspect`, `cadgen step snapshot`, or a mesh door:
+each compiles a tree from the file's bytes on first use (a job in the pool,
+shared with the CAD Viewer), and its part/assembly kind is inferred from the
+STEP product hierarchy.
+
+```bash
+cadgen step inspect refs path/to/imported.step --facts
+cadgen stl build path/to/imported.step meshes/imported.stl
+```
+
+To produce STL/3MF/native GLB files from an imported STEP, pass it to the
+matching format door with an explicit OUT (an imported file declares nothing, so
+a bare door has no variants to produce); read `supported-exports.md`.
+
+### Re-emitting a foreign STEP as your own
+
+A STEP written by another kernel round-trips through cadgen with
+`cadgen step build IN OUT`: OCCT reads it, the tree is built, and the
+canonical writer emits it, so OUT's bytes are deterministic and identical on
+every run. The same command ANNOTATES a document that has no model script —
+`--kinematics` takes the whole space (`{mates, couplings, poses, at}`, the same
+vocabulary the decorator takes, as inline JSON or a `.json` path) and
+`--animation` copies a `.js` module's text into OUT's sidecar.
+
+```bash
+cadgen step build vendor/hinge.step STEP/hinge.step \
+  --kinematics '{"mates": [{"name": "swing", "kind": "revolute",
+                            "parent": "#body", "child": "#lever",
+                            "axis": "#lever.bore", "limits": [0, 90]}],
+                 "poses": {"open": {"swing": 45}}}'
+```
+
+Re-running is a no-op; editing only the kinematics refreshes the sidecar without
+re-emitting a byte. Vendor metadata (PMI, GD&T) does not survive the round trip.
+**Choose the door by how the model will evolve**: a shape you will keep changing
+belongs in a model script (a thin wrapper that reads the foreign STEP), while
+a one-shot canonicalization or annotation of a file you do not own is exactly
+what `step build` is for.
+
+## Optional-module assemblies
+
+A model that imports several part modules and SKIPS the ones that do not exist
+yet is a useful pattern for parallel work — the assembly stays renderable while
+individual parts are still being written. It has one sharp edge.
+
+The model's closure is computed from the modules it ACTUALLY IMPORTED at build
+time. A module that did not exist during the build was never in the closure,
+so its later appearance cannot make the model stale, and every door keeps
+reading the old document's tree — no error, no warning. Run the model script
+explicitly after adding a part module rather than relying on the gate.
+
+## After generation
+
+- Confirm the process succeeded and each declared output exists and is
+  non-empty (the stdout line names the document; `--json` adds the `tree`
+  hash).
+- Run the baseline inspection and any spec-driven checks per
+  `inspection-and-validation.md`:
+
+```bash
+cadgen step inspect refs path/to/model.step --facts --planes --positioning
+```
+
+## Workers and the daemon
+
+Every build is a job on a worker; every worker has build123d imported. A warm
+daemon runs them **by default** — the decorator hands a directly-run script to
+it before any kernel import — and `CADGEN_DAEMON=0` uses transient workers
+instead:
+
+```bash
+python path/to/part.py              # warm: persistent workers
+CADGEN_DAEMON=0 python part.py      # transient workers, spawned for this run
+```
+
+- **One worker per model.** A request lands on the worker bound to its model
+  script; a busy worker means a second one (an *extra*) runs the job now; a
+  model with no worker takes a warm spare (`CADGEN_DAEMON_SPARES`, default 2,
+  refilled in the background). Nothing waits on another build and no worker
+  count is capped.
+- **Children build in parallel.** Inside a body, each child call submits that
+  child to the pool and returns at once; siblings build on their own workers
+  while the body continues, and the parent waits only when it first reads the
+  geometry.
+- **One running build per core.** `N = os.cpu_count()` jobs run at once
+  (`CADGEN_JOBS` overrides); the rest queue in order. A parent waiting on its
+  children holds no slot, so a deep tree builds on a single slot. Hitting the
+  limit during a fan-out is normal and costs no wall time.
+- **Idle workers unbind after 10 minutes** (`CADGEN_DAEMON_IDLE_UNBIND`,
+  seconds) and return to the spare set; the daemon exits after an hour with no
+  request (`CADGEN_DAEMON_IDLE_TIMEOUT`). Both are about RAM; neither ever
+  blocks a build.
+- **No memory ceiling and no worker cap.** Unlimited memory is the operating
+  assumption. A worker the OS kills mid-job is reported as a dead worker with
+  its exit status, the job it held, and the exact `CADGEN_DAEMON=0 ...` rerun;
+  nothing is retried silently.
+- **`CADGEN_DAEMON=0` is still parallel.** Transient workers are spawned for
+  the run (each paying one kernel import, concurrently), inherit the
+  environment — so a test's `CADGEN_CACHE_DIR` isolates its store — and exit
+  with the run. There is no daemon job ledger in this mode, so the CAD Viewer
+  does not see such builds in progress.
+- **`cadgen daemon status`** reports each worker's model, whether it is busy,
+  its job count and whether it is an extra; the spare count; and `jobs running
+  n/N, queued m` — the first place to look when a build seems slow.
+- Doors (`inspect`, `snapshot`, the mesh doors) never run a body and take no
+  slot; a compile of a document with no tree is the one door operation that
+  is a job.
+- The daemon runs on Windows too (a named pipe instead of a Unix socket). It
+  is per cadgen install; `CADGEN_DAEMON_SOCKET` overrides the address, and a
+  `.log` beside it holds lifecycle and C-level OCP noise. When cadgen itself
+  changes, the daemon notices the version token mismatch, drains its jobs and
+  exits; the next client starts a fresh one.
+
+Cold and warm builds write identical bytes for every format.

--- a/.qwenpaw-plugin/skills/cad/references/supported-exports.md
+++ b/.qwenpaw-plugin/skills/cad/references/supported-exports.md
@@ -1,0 +1,148 @@
+# Supported exports
+
+Read this file when the user requests STL, 3MF, or native GLB output files from CAD geometry. For a `.step` file, run the model script (see `step-generation.md`) — a mesh door writes mesh formats only. For 2D DXF output, use the `$dxf` skill: a drawing is its own `<name>.py` declaring one `@dxf` function — one model per file, so a drawing never shares a script with a `@step` model.
+
+## Policy
+
+STL, 3MF, and native GLB are mesh exports, not substitutes for STEP. Validate the primary CAD geometry first, then export the requested formats. Do not treat exported mesh renders as CAD validation; inspect and snapshot the primary model per the standard workflow.
+
+Native GLB exports are ordinary glTF 2.0 binary files for external tools: Y-up, with one material per distinct part/face color. Do not confuse them with what the CAD Viewer renders from — the model's result tree in the store (`~/.cache/cadgen`: content-addressed exact-geometry components plus links to child trees), which every build writes and a mesh door never does.
+
+## Declare the exports the model always has
+
+A mesh output that belongs to the model belongs in the model. Stack `@stl`, `@glb` or `@threemf` on the `@step` function and every build produces them:
+
+```python
+from cadgen import build123d as bd
+from cadgen import glb, step, stl
+
+
+@step(out="STEP/bracket.step")
+@stl(out="STL/bracket.stl")
+@glb
+def bracket():
+    return bd.Box(40, 20, 6)
+
+
+if __name__ == "__main__":
+    bracket()
+```
+
+`python models/bracket.py` then writes the STEP **and** the declared meshes, and rewrites any of them that were deleted or edited — no separate export step (a declared output is part of the model's freshness gate). The declarations are recorded in the document's sidecar, which is where the mesh doors read them from.
+
+## A model with no STEP
+
+A model's outputs are whatever its decorators declare, and STEP is one output kind, not the primary. A function decorated with `@stl`, `@glb` or `@threemf` alone — no `@step` — is a full model: the same tree and record in the store, the same build, the same parallel children, the same no-op when nothing changed, the same composition (`spacer()` inside another model's body links its tree like any child). It writes its declared meshes and no `.step` (and no sidecar). Use it for a print-only part or a render asset; there is no requirement to write a STEP. Review it with its format's snapshot door (`cadgen stl snapshot STL/spacer.stl tmp/spacer.png`); `cadgen store why spacer.py` explains its freshness exactly as for a STEP model.
+
+```python
+from cadgen import build123d as bd
+from cadgen import stl
+
+
+@stl(out="STL/spacer.stl", mesh_tolerance=4e-4)
+def spacer():
+    return bd.Cylinder(6, 3) - bd.Cylinder(2.5, 3)
+
+
+if __name__ == "__main__":
+    spacer()
+```
+
+Stacking order stays neutral: add `@step` above or below later and the same declarations ride along; the `.step` then joins the outputs.
+
+A decorator `out=` is the one intentional exception to native path semantics: on `@stl`, `@glb` and `@threemf` — exactly as on `@step` — a relative `out=` resolves relative to the SCRIPT, not the working directory. That is what makes a project relocatable: the declaration travels with the model and produces the same layout whatever directory the script is run from. Ad-hoc OUT arguments on the doors are cwd-relative instead, because they are one-shot and never persisted.
+
+Declare the same format more than once at distinct targets for draft/print variants:
+
+```python
+@stl(out="STL/bracket_draft.stl", mesh_tolerance=8e-3)
+@stl(out="STL/bracket_print.stl", mesh_tolerance=4e-4)
+```
+
+## Tool
+
+One door per format — `cadgen stl build`, `cadgen 3mf build`, `cadgen glb build` — each taking a STEP/STP **document** and an optional output path:
+
+```bash
+cadgen stl build STEP/model.step                     # every declared @stl variant
+cadgen stl build STEP/model.step meshes/model.stl    # one ad-hoc export
+```
+
+Doors take documents, never scripts: `python model.py` is the one source door, and a door handed a `.py` says so. Omitting the output is the normal form: it produces exactly what the model declared, read from the document's sidecar. A document that declares no variants of that format has nothing to produce — declare `@stl` on the model and rerun the script, or name an explicit OUT. An explicit OUT takes the same native path semantics as every other door: a relative path resolves against the current working directory, an absolute path is used as given, and `~` expands. Ask for several formats by running several doors — each writes only its own format:
+
+```bash
+cadgen stl build STEP/model.step
+cadgen 3mf build STEP/model.step
+cadgen glb build STEP/model.step
+```
+
+An output the model already has at the requested tolerances is reported `current` and not rewritten. `--force` re-exports it anyway; it never rebuilds the model itself — rerun `python <script>` for that. The door reads the document's tree by the file's content hash and compiles one from the bytes if the store has none; whether the document is behind its script is not the door's question (`cadgen store why`), so no document is ever refused.
+
+An imported STEP/STP file declares nothing, so give it an explicit OUT; its part/assembly kind is inferred automatically:
+
+```bash
+cadgen stl build path/to/imported.step meshes/imported.stl
+```
+
+A mesh door never writes a `.step` file. A generated model's STEP is the OUTPUT of `python <model>.py`; an imported model's STEP is already the file on disk.
+
+## Rendering a mesh file
+
+Each mesh format also has a `snapshot` verb, with the same `TARGET [OUT]` grammar `cadgen step snapshot` uses:
+
+```bash
+cadgen stl snapshot STL/bracket.stl tmp/bracket_mesh.png
+cadgen 3mf snapshot 3MF/bracket.3mf tmp/bracket_3mf.png
+cadgen glb snapshot meshes/bracket.glb tmp/bracket_glb.png
+```
+
+A mesh carries no CAD topology, so these render shaded solid and do not HAVE `--focus`/`--hide`, `--display`, `--kinematics`, `--animation`/`--time`, or `--mode section` — a mesh has no occurrences, CAD edges, kinematics, or clips for those to act on, so they are absent from the command rather than refused by it. `cadgen step snapshot` refuses a mesh input and names the door that takes it.
+
+This is a review of the EXPORT, not of the model. Snapshot validation of the primary STEP is still what the required workflow means; render the mesh when the question is about the mesh (tessellation density, a tolerance change, what an external tool will receive).
+
+## Mesh tolerance
+
+Mesh exports tessellate each component's exact surfaces with the same watertight tessellator the CAD Viewer renders with, at the same default tolerances — an export matches what renders, boundary vertices lie on the exact STEP edge curves, and repeated exports are byte-identical.
+
+Use these flags when the default mesh density is wrong for the part:
+
+```bash
+--mesh-tolerance FLOAT           # chord tolerance RELATIVE to each component's
+                                 # bounding diagonal (default 1.5e-3)
+--mesh-angular-tolerance FLOAT   # max normal spread across a triangle edge,
+                                 # radians (default 0.35)
+```
+
+Either flag overrides what the declaration and the model set, for that run only. Use tighter tolerances for visual fidelity on curved parts; use looser tolerances for large simple geometry when file size matters. The linear tolerance is relative (scale-free), not an absolute deflection in millimetres.
+
+## Workflow
+
+1. Validate the model per the standard workflow (build, inspect, snapshot).
+2. Declare the exports the model should always have; run the model script.
+3. For anything ad hoc, run the format door for each requested format.
+4. Report the exported files.
+
+Example — the model declares its STL, and a one-off coarse GLB is requested beside it:
+
+```bash
+python models/bracket.py
+
+cadgen glb build models/bracket.step meshes/bracket_preview.glb \
+  --mesh-tolerance 5e-3 \
+  --mesh-angular-tolerance 0.5
+
+cadgen step inspect refs models/bracket.step --facts --planes --positioning
+```
+
+## Reporting
+
+```text
+Files:
+- STEP: /absolute/project/models/bracket.step
+- STL: /absolute/project/models/STL/bracket.stl
+- GLB: /absolute/project/models/meshes/bracket_preview.glb
+
+Validation:
+- CAD geometry validated; STL/3MF/native GLB written as requested exports.
+- Primary STEP/STP snapshot packet run/skipped and why.
+```

--- a/.qwenpaw-plugin/skills/cad/requirements.txt
+++ b/.qwenpaw-plugin/skills/cad/requirements.txt
@@ -1,0 +1,1 @@
+cadgen[snapshot]==0.5.1

--- a/.qwenpaw-plugin/skills/dfam-check/LICENSE
+++ b/.qwenpaw-plugin/skills/dfam-check/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thompson Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.qwenpaw-plugin/skills/dfam-check/SKILL.md
+++ b/.qwenpaw-plugin/skills/dfam-check/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: dfam-check
+description: Measure mesh files against Design for Additive Manufacturing (DfAM) rules and report printability findings per process (FDM, SLS, SLA/DLP, metal PBF, MJF). Use when the user asks whether a part is printable, wants overhang/wall-thickness/support analysis of an `.stl`, `.obj`, `.ply`, or `.3mf` mesh, wants a build-orientation recommendation, or wants DfAM redesign guidance before slicing with `$gcode` or regenerating geometry with `$cad`.
+---
+
+# DfAM Check
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review.
+
+Use this skill to produce conservative, evidence-backed DfAM reports for mesh
+files before slicing or printing. It measures geometry facts locally and
+compares them against per-process design limits; it never slices, uploads, or
+starts print jobs.
+
+## Geometry Inspection
+
+Use `scripts/dfam_tool.py` in the active project Python environment for all
+geometry facts (install `requirements.txt` first — every run needs it). The tool is fact-only:
+it reports measurements and never emits pass/fail or readiness statuses.
+Comparisons and verdicts belong to this workflow. Do not estimate wall
+thickness, overhang angles, or support volume by eye or from renders when the
+tool can measure them.
+
+```bash
+python scripts/dfam_tool.py measure part.stl --angle-limit 45
+python scripts/dfam_tool.py orientations part.stl --angle-limit 45
+```
+
+Set `--angle-limit` to the target process's self-supporting angle from
+`references/process-limits.md` before measuring, and re-run when the target
+process changes: the aggregate support-area facts are binned against it.
+
+STEP/STP input is boundary-representation CAD, not a mesh. When the `$cad`
+skill is installed, export an STL sidecar with it first, then measure the STL
+here. Report that remediation instead of attempting raw STEP parsing.
+
+## Workflow
+
+1. Collect print intent: target process, material, layer height, and any
+   machine or material datasheet the user can provide. If the process is
+   unknown, measure once with the default 45° limit, then present findings
+   per candidate process rather than guessing a single verdict.
+2. Read `references/process-limits.md` and select the limit column for the
+   target process. A user-provided machine/material datasheet overrides the
+   defaults; cite whichever source is used for every comparison.
+3. Run `measure` on the exact upload file. Do not inspect only a generator
+   script, source CAD model, or console summary of the file.
+4. Run `orientations` when the process requires supports and the measured
+   support area is nonzero. Report any candidate that materially reduces
+   support area, with its build-height tradeoff.
+5. Compare each measured fact to the cited limit and report findings with
+   restrained status labels:
+   - `✅ pass`: the measured fact satisfies the cited limit.
+   - `❌ fail`: a measured fact directly violates the cited limit.
+   - `❓ need more info`: missing process context, unmeasured geometry,
+     sampling too sparse to trust, or tool limitations.
+6. Order findings by severity: watertightness first (blocks slicing for
+   every process), then wall thickness, then overhangs/supports, then
+   orientation and cost signals.
+
+## Comparison
+
+Compare only trustworthy pairs of evidence.
+
+- Cite the limit source (process-limits table row, or the user's datasheet
+  field) and the measured fact (JSON field path) for every finding.
+- Treat `p05_mm` below the wall-thickness limit as a violation even when
+  `min_mm` alone could be a sampling outlier; report both values.
+- On an assembly, `wall_thickness` reports `body_count` and a `per_body`
+  breakdown. Attribute a violation to the body it belongs to; a thin figure
+  pooled across bodies is not a finding against the part as a whole.
+- Do not apply support-angle findings to powder processes (SLS, MJF); the
+  relevant powder-process check is trapped-volume powder escape, which this
+  tool does not yet measure — report that as `❓ need more info` when
+  enclosed cavities are likely.
+- Do not silently rescale geometry. `scale.units_suspect` is measured from
+  the bounding-box diagonal: when it is `true`, the source is probably in
+  meters or inches, every down-facing face reads as resting on the plate, and
+  overhang and support figures of 0.0 mean nothing. Report a unit/scale
+  finding and ask the user to confirm units before comparing anything against
+  a material limit.
+- Support-volume ratios are coarse upper bounds; report them as cost
+  signals, not hard failures, unless the user has set an explicit budget.
+
+## Redesign Handoff
+
+For every `❌ fail`, include a concrete, plain-language redesign instruction
+with target numbers (for example "thicken the wall at [12.4, 3.0, 8.1] from
+0.6 mm to ≥1.2 mm" or "chamfer the overhang at [23.3, 10.0, 52.0] to ≥45°").
+When the `$cad` skill is installed, offer to apply the redesign instructions
+with it and re-measure the regenerated geometry here, repeating until no
+`❌ fail` findings remain. When `$cad-viewer` is installed, hand the measured
+file path(s) to it so the user can inspect the findings visually.

--- a/.qwenpaw-plugin/skills/dfam-check/agents/openai.yaml
+++ b/.qwenpaw-plugin/skills/dfam-check/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DfAM Check"
+  short_description: "Measure meshes against DfAM printability rules"
+  default_prompt: "Use $dfam-check to measure this mesh against DfAM rules for my target process."

--- a/.qwenpaw-plugin/skills/dfam-check/references/process-limits.md
+++ b/.qwenpaw-plugin/skills/dfam-check/references/process-limits.md
@@ -1,0 +1,58 @@
+# DfAM Process Limits
+
+Design-rule limits per additive process, for comparison against measured
+facts from `scripts/dfam_tool.py`. Values are conservative defaults from
+published process design guides and consistent with ISO/ASTM 52910
+(general DfAM guidance) and ISO/ASTM 52911-1 (laser powder bed fusion of
+metals). Machine-, material-, and parameter-specific datasheets override
+these defaults when the user provides them — cite whichever source is used.
+
+| Limit | FDM/FFF | SLS (PA12) | SLA/DLP | PBF-LB metal (SLM/DMLS) | MJF |
+| --- | --- | --- | --- | --- | --- |
+| Min supported wall (mm) | 1.2 | 0.7 | 0.5 | 0.4 | 0.5 |
+| Min unsupported wall (mm) | 1.6 | 0.7 | 1.0 | 0.5 | 0.5 |
+| Self-supporting angle (deg from horizontal) | 45 | n/a (powder supports) | 30 | 45 | n/a (powder supports) |
+| Min hole diameter (mm) | 2.0 | 1.5 | 0.5 | 1.5 | 1.0 |
+| Min positive feature (mm) | 0.8 | 0.8 | 0.2 | 0.4 | 0.5 |
+| Max unsupported bridge (mm) | 10 | n/a | 5 | 2 | n/a |
+
+Sources: Hubs FDM/SLS/SLA/metal design guides, Formlabs design guides,
+HP MJF design guidelines, EOS design rules; ISO/ASTM 52910 §6 for the
+category structure (feature limits §6.5, support structures §6.7).
+
+## Interpretation notes
+
+- **Wall thickness facts** come from ray-cast sampling, so `min_mm` is a
+  sampled minimum, not an exhaustive one. Treat `p05_mm` below the limit as
+  a strong violation signal even when `min_mm` alone might be an outlier.
+- **Overhang facts** exclude faces resting on the build plate. For powder
+  processes (SLS, MJF) the surrounding powder supports all geometry:
+  support-area findings do not apply, but trapped-powder escape holes
+  become the relevant check instead.
+- **Support volume** is a prism upper-bound estimate for cost and
+  post-processing effort, not a slicer-accurate figure. Ratios above
+  ~30% of part volume usually justify reorientation or redesign for
+  support-requiring processes.
+- **Watertightness** (`mesh.watertight: false`) blocks slicing for every
+  process and should be reported before any other finding.
+- **Orientation candidates** are the six axis-aligned rotations only.
+  A candidate reaching materially lower support area than the current
+  orientation is a finding worth reporting with its build-height tradeoff.
+
+
+## What the tool measures today
+
+`dfam_tool.py` returns measured values for **min supported wall**, **min
+unsupported wall** (both from the thickness field) and **self-supporting
+angle** (from the overhang map). Those rows can be compared directly against
+the limits above.
+
+**Min hole diameter**, **min positive feature** and **max unsupported bridge**
+have no measured counterpart yet. Treat them the way the trapped-powder gap is
+treated: report them as not checked, rather than inferring them from a render,
+the bounding box, or the triangle count. A limit with no measurement behind it
+is not a finding.
+
+Wall thickness is measured per connected body. An assembly reports a
+`per_body` breakdown alongside the pooled figures, because a ray crossing a
+mating clearance would otherwise record the fit gap as a wall.

--- a/.qwenpaw-plugin/skills/dfam-check/requirements.txt
+++ b/.qwenpaw-plugin/skills/dfam-check/requirements.txt
@@ -1,0 +1,11 @@
+trimesh
+numpy
+rtree
+# trimesh treats these as optional extras, but this tool needs them on every
+# run: scipy backs the connected-components call behind mesh.body_count and
+# mesh.split, and networkx + lxml are required to load the .3mf that SKILL.md
+# advertises. Without them the first measure of any mesh dies with a raw
+# ModuleNotFoundError.
+scipy
+networkx
+lxml

--- a/.qwenpaw-plugin/skills/dfam-check/scripts/dfam_tool.py
+++ b/.qwenpaw-plugin/skills/dfam-check/scripts/dfam_tool.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Fact-only DfAM geometry measurements for mesh files.
+
+Reports measurements as JSON. It never emits pass/fail, verdicts, or
+readiness statuses; comparisons against process limits belong to the
+skill workflow using `references/process-limits.md`.
+
+Requires: trimesh, numpy, rtree (pip install trimesh numpy rtree)
+
+Usage:
+    python dfam_tool.py measure <mesh> [--samples 2000] [--angle-limit 45]
+    python dfam_tool.py orientations <mesh> [--angle-limit 45]
+
+`--angle-limit` only parameterises which faces are *counted* in the
+support-area aggregates; per-face angles are always reported so the
+agent can re-bin against any process limit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import numpy as np
+import trimesh
+
+
+def _load(path: str) -> trimesh.Trimesh:
+    mesh = trimesh.load(path, force="mesh")
+    if isinstance(mesh, trimesh.Scene):
+        mesh = mesh.dump(concatenate=True)
+    return mesh
+
+
+def _mesh_facts(mesh: trimesh.Trimesh) -> dict:
+    return {
+        "bbox_mm": [round(float(v), 2) for v in mesh.extents],
+        "volume_mm3": round(float(abs(mesh.volume)), 1) if mesh.is_volume else None,
+        "surface_area_mm2": round(float(mesh.area), 1),
+        "triangle_count": int(len(mesh.faces)),
+        "watertight": bool(mesh.is_watertight),
+        "euler_number": int(mesh.euler_number),
+        "body_count": int(mesh.body_count),
+    }
+
+
+def _overhang_facts(mesh: trimesh.Trimesh, angle_limit: float) -> dict:
+    """Face angles measured from horizontal: 0 = flat ceiling, 90 = vertical."""
+    normals = mesh.face_normals
+    areas = mesh.area_faces
+    centers = mesh.triangles_center
+
+    down = normals[:, 2] < -1e-6
+    surface_angle = 90.0 - np.degrees(np.arcsin(np.clip(-normals[:, 2], 0, 1)))
+
+    z_min = mesh.bounds[0][2]
+    on_plate = centers[:, 2] < (z_min + 0.1)
+
+    counted = down & ~on_plate & (surface_angle < angle_limit)
+    total_area = float(areas.sum())
+
+    # angle histogram of down-facing, off-plate faces (10° bins)
+    off_plate_down = down & ~on_plate
+    hist = {}
+    if off_plate_down.any():
+        bins = np.arange(0, 100, 10)
+        idx = np.digitize(surface_angle[off_plate_down], bins) - 1
+        for b in range(len(bins) - 1):
+            area = float(areas[off_plate_down][idx == b].sum())
+            if area > 0:
+                hist[f"{bins[b]}-{bins[b+1]}deg"] = round(area, 2)
+
+    worst = []
+    if counted.any():
+        w_idx = np.where(counted)[0]
+        order = w_idx[np.argsort(-areas[w_idx])][:8]
+        worst = [
+            {
+                "location_xyz": [round(float(v), 2) for v in centers[i]],
+                "surface_angle_deg": round(float(surface_angle[i]), 1),
+                "area_mm2": round(float(areas[i]), 2),
+            }
+            for i in order
+        ]
+
+    return {
+        "angle_limit_used_deg": angle_limit,
+        "down_facing_area_below_limit_mm2": round(float(areas[counted].sum()), 2),
+        "down_facing_area_below_limit_pct": round(
+            100 * float(areas[counted].sum()) / total_area, 1) if total_area else 0.0,
+        "face_count_below_limit": int(counted.sum()),
+        "down_facing_angle_histogram_mm2": hist,
+        "largest_faces_below_limit": worst,
+    }
+
+
+def _wall_facts(mesh: trimesh.Trimesh, samples: int, seed: int = 42) -> dict:
+    """Ray-cast thickness field, measured one connected body at a time.
+
+    Cast against a whole assembly, a ray leaving one body can cross a mating
+    clearance and land on its neighbour, which records the fit gap as a wall.
+    A tight-clearance assembly then reports a wall-thickness violation that no
+    single part actually has. Splitting first makes that impossible, because
+    each body is only ever measured against itself.
+    """
+    bodies = mesh.split(only_watertight=False)
+    if len(bodies) <= 1:
+        facts = _wall_facts_single(mesh, samples, seed)
+        facts.pop("_thickness", None)
+        facts.pop("_origins", None)
+        return facts
+
+    areas = np.array([float(b.area) for b in bodies])
+    if not np.isfinite(areas).all() or areas.sum() <= 0.0:
+        return {
+            "samples": 0,
+            "note": "no positive face area; mesh is degenerate, thickness not measured",
+        }
+
+    # Split the sample budget by surface area so a large body is not measured
+    # at the same resolution as a small one, with a floor so small bodies are
+    # still sampled at all.
+    share = areas / areas.sum()
+    pooled: list = []
+    pooled_origins: list = []
+    per_body: list = []
+    for i, (body, frac) in enumerate(zip(bodies, share)):
+        budget = max(int(round(samples * frac)), 64)
+        facts = _wall_facts_single(body, budget, seed + i)
+        per_body.append({
+            "body": i,
+            "min_mm": facts.get("min_mm"),
+            "p05_mm": facts.get("p05_mm"),
+            "median_mm": facts.get("median_mm"),
+            "samples_valid": facts.get("samples_valid", 0),
+        })
+        if "_thickness" in facts:
+            pooled.append(facts["_thickness"])
+            pooled_origins.append(facts["_origins"])
+
+    if not pooled:
+        return {
+            "error": "no valid thickness samples",
+            "body_count": len(bodies),
+            "per_body": per_body,
+        }
+
+    thickness = np.concatenate(pooled)
+    origins = np.concatenate(pooled_origins)
+    thin_idx = np.argsort(thickness)[:8]
+
+    return {
+        "body_count": len(bodies),
+        "measured_per_body": True,
+        "samples_valid": int(len(thickness)),
+        "min_mm": round(float(thickness.min()), 3),
+        "p05_mm": round(float(np.percentile(thickness, 5)), 3),
+        "p25_mm": round(float(np.percentile(thickness, 25)), 3),
+        "median_mm": round(float(np.median(thickness)), 3),
+        "max_mm": round(float(thickness.max()), 3),
+        "per_body": per_body,
+        "thinnest_samples": [
+            {
+                "location_xyz": [round(float(v), 2) for v in origins[i]],
+                "thickness_mm": round(float(thickness[i]), 3),
+            }
+            for i in thin_idx
+        ],
+    }
+
+
+def _wall_facts_single(mesh: trimesh.Trimesh, samples: int, seed: int = 42) -> dict:
+    """Ray-cast thickness field for ONE connected body."""
+    rng = np.random.default_rng(seed)
+    n = min(samples, max(len(mesh.faces), 1))
+
+    # Area weighting needs a positive total. A mesh of only degenerate faces
+    # has none, and is not something a thickness field can describe - say so
+    # rather than dividing by zero inside rng.choice.
+    total_area = float(mesh.area_faces.sum())
+    if not np.isfinite(total_area) or total_area <= 0.0:
+        return {
+            "samples": 0,
+            "note": "no positive face area; mesh is degenerate, thickness not measured",
+        }
+
+    face_idx = rng.choice(len(mesh.faces), size=n,
+                          p=mesh.area_faces / total_area)
+
+    origins = mesh.triangles_center[face_idx]
+    directions = -mesh.face_normals[face_idx]
+    origins = origins + directions * 1e-4
+
+    locations, ray_ids, _ = mesh.ray.intersects_location(
+        ray_origins=origins, ray_directions=directions, multiple_hits=False)
+
+    if len(ray_ids) == 0:
+        return {"error": "ray casting produced no hits", "samples_requested": n}
+
+    thickness = np.linalg.norm(locations - origins[ray_ids], axis=1)
+    diag = float(np.linalg.norm(mesh.extents))
+    valid = (thickness > 1e-3) & (thickness < diag)
+    thickness = thickness[valid]
+
+    if len(thickness) == 0:
+        return {"error": "no valid thickness samples", "samples_requested": n}
+
+    hit_origins = origins[ray_ids][valid]
+    thin_idx = np.argsort(thickness)[:8]
+
+    return {
+        "samples_valid": int(len(thickness)),
+        "min_mm": round(float(thickness.min()), 3),
+        "p05_mm": round(float(np.percentile(thickness, 5)), 3),
+        "p25_mm": round(float(np.percentile(thickness, 25)), 3),
+        "median_mm": round(float(np.median(thickness)), 3),
+        "max_mm": round(float(thickness.max()), 3),
+        "thinnest_samples": [
+            {
+                "location_xyz": [round(float(v), 2) for v in hit_origins[i]],
+                "thickness_mm": round(float(thickness[i]), 3),
+            }
+            for i in thin_idx
+        ],
+        # Underscore keys are internal: _wall_facts pools them across bodies
+        # and strips them before anything is printed. They are numpy arrays
+        # and would not survive json.dumps.
+        "_thickness": thickness,
+        "_origins": hit_origins,
+    }
+
+
+def _support_volume_facts(mesh: trimesh.Trimesh, angle_limit: float) -> dict:
+    """Prism estimate of volume under faces below the given angle."""
+    m = mesh.copy()
+    m.apply_translation([0, 0, -m.bounds[0][2]])
+
+    normals = m.face_normals
+    areas = m.area_faces
+    centers = m.triangles_center
+
+    down = normals[:, 2] < -1e-6
+    surface_angle = 90.0 - np.degrees(np.arcsin(np.clip(-normals[:, 2], 0, 1)))
+    on_plate = centers[:, 2] < 0.1
+    needs = down & ~on_plate & (surface_angle < angle_limit)
+
+    proj_area = areas[needs] * np.abs(normals[needs, 2])
+    support_vol = float((proj_area * centers[needs, 2]).sum())
+    part_vol = float(abs(m.volume)) if m.is_volume else float(m.convex_hull.volume)
+
+    return {
+        "angle_limit_used_deg": angle_limit,
+        "estimated_support_volume_mm3": round(support_vol, 1),
+        "part_volume_mm3": round(part_vol, 1),
+        "support_to_part_ratio_pct": round(
+            100 * support_vol / part_vol, 1) if part_vol else 0.0,
+        "method": "prism from face centroid to build plate; coarse upper-bound estimate",
+    }
+
+
+def _orientation_facts(mesh: trimesh.Trimesh, angle_limit: float) -> dict:
+    """Support area + build height for 6 axis-aligned candidate orientations."""
+    rotations = {
+        "current_plus_z": np.eye(4),
+        "flip_180_x": trimesh.transformations.rotation_matrix(np.pi, [1, 0, 0]),
+        "rot_plus_90_x": trimesh.transformations.rotation_matrix(np.pi / 2, [1, 0, 0]),
+        "rot_minus_90_x": trimesh.transformations.rotation_matrix(-np.pi / 2, [1, 0, 0]),
+        "rot_plus_90_y": trimesh.transformations.rotation_matrix(np.pi / 2, [0, 1, 0]),
+        "rot_minus_90_y": trimesh.transformations.rotation_matrix(-np.pi / 2, [0, 1, 0]),
+    }
+    out = []
+    for name, T in rotations.items():
+        m = mesh.copy()
+        m.apply_transform(T)
+        ov = _overhang_facts(m, angle_limit)
+        out.append({
+            "orientation": name,
+            "support_area_mm2": ov["down_facing_area_below_limit_mm2"],
+            "support_area_pct": ov["down_facing_area_below_limit_pct"],
+            "build_height_mm": round(float(m.extents[2]), 2),
+        })
+    return {
+        "angle_limit_used_deg": angle_limit,
+        # Percentages are of total surface area, which is rotation-invariant.
+        # That makes them comparable between candidates but not a measure of
+        # plate coverage - rank on support_area_mm2, read pct as a signal.
+        "pct_denominator": "total surface area",
+        "candidates": out,
+    }
+
+
+def _safe(fn, *args) -> dict:
+    """Run one fact family, degrading to an error field instead of a traceback.
+
+    measure assembles every family before printing, so one throwing family
+    used to cost the user the facts that did compute: a planar mesh dies in
+    convex_hull and took the whole report with it. Each family now fails on
+    its own and the rest still reach the caller as JSON.
+    """
+    try:
+        return fn(*args)
+    except Exception as exc:  # noqa: BLE001 - report it, never propagate
+        detail = f"{type(exc).__name__}: {exc}".splitlines()[0]
+        return {"error": detail[:300]}
+
+
+def _scale_hint(mesh: trimesh.Trimesh) -> dict:
+    """Flag meshes whose units are probably not millimetres.
+
+    A meters-scale export measures a bbox like 0.05 x 0.02 x 0.04, which sits
+    under the 0.1 mm on-plate tolerance: every down-facing face reads as
+    resting on the plate, so overhangs and support both come back 0.0 and the
+    part looks like a flawless print. Give the workflow something measured to
+    branch on rather than asking the agent to eyeball the bounding box.
+    """
+    diag = float(np.linalg.norm(mesh.extents))
+    suspect = bool(np.isfinite(diag) and diag < 1.0)
+    return {
+        "bbox_diagonal_mm": round(diag, 4),
+        "units_suspect": suspect,
+        "note": (
+            "bbox diagonal under 1 mm; source is probably in meters or inches. "
+            "Rescale to millimetres before trusting overhang, support or "
+            "thickness numbers."
+        ) if suspect else "bbox consistent with millimetre units",
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    m = sub.add_parser("measure", help="full measurement set for one mesh")
+    m.add_argument("mesh")
+    m.add_argument("--samples", type=int, default=2000)
+    m.add_argument("--angle-limit", type=float, default=45.0)
+
+    o = sub.add_parser("orientations", help="candidate orientation measurements")
+    o.add_argument("mesh")
+    o.add_argument("--angle-limit", type=float, default=45.0)
+
+    args = ap.parse_args()
+
+    try:
+        mesh = _load(args.mesh)
+    except Exception as e:
+        print(json.dumps({"error": f"failed to load mesh: {e}"}))
+        return 1
+
+    if args.command == "measure":
+        report = {
+            "file": args.mesh,
+            "mesh": _safe(_mesh_facts, mesh),
+            "scale": _safe(_scale_hint, mesh),
+            "overhangs": _safe(_overhang_facts, mesh, args.angle_limit),
+            "wall_thickness": _safe(_wall_facts, mesh, args.samples),
+            "support_volume": _safe(_support_volume_facts, mesh, args.angle_limit),
+        }
+    else:
+        report = {
+            "file": args.mesh,
+            "scale": _safe(_scale_hint, mesh),
+            "orientations": _safe(_orientation_facts, mesh, args.angle_limit),
+        }
+
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.qwenpaw-plugin/skills/dxf/LICENSE
+++ b/.qwenpaw-plugin/skills/dxf/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thompson Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.qwenpaw-plugin/skills/dxf/SKILL.md
+++ b/.qwenpaw-plugin/skills/dxf/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: dxf
+description: Generate, regenerate, and validate 2D DXF drawings from Python build123d sources. Use for DXF files, `.py` drawing scripts, @dxf models, 2D profiles, outlines, templates, gaskets, panels, flat patterns, laser/plasma/waterjet cut layouts, and 2D drawing exports of CAD geometry.
+---
+
+# DXF generation and validation
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review.
+
+## Setup
+
+This skill's commands are thin entrypoints over the `cadgen` distribution, which
+carries the Python build runtime and the JavaScript it executes. Install it once:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+Drawings are build123d geometry, so a drawing build loads the CAD kernel like a
+STEP build does (~2.5s cold; the warm daemon absorbs it on re-runs). Only
+`cadgen dxf snapshot` additionally needs **Node 20 or newer on `PATH`** — it
+meshes the flat pattern on demand through a bundled Node one-shot; a missing
+`node` is reported at render time.
+
+## Purpose
+
+Create or modify 2D DXF drawings from natural-language requirements or from CAD
+geometry, generate validated drawing artifacts, and return checked outputs. A
+DXF drawing's source of truth is a Python file named `<name>.py` defining one
+parameterless `@dxf` model function.
+
+**A drawing is a model.** It has the same wrapper, record, freshness gate and
+build job a `@step` part has; its one output is the `.dxf` file; it has no
+geometry tree (nothing links to a drawing). Every run writes the sibling
+`<name>.dxf` (or the `out=` the decorator names); an unchanged source is a
+no-op; a drawing that calls a part model — `bracket()` inside its body — is
+stale whenever that part's GEOMETRY changes and current when it does not;
+`cadgen store why <drawing>.py` explains the verdict; `--force` rebuilds it
+anyway. The CAD Viewer and `dxf snapshot` read the `.dxf` file itself, so the
+file you hand a cutting service and the file the viewer renders are one and
+the same.
+
+## The contract
+
+**A `@dxf` function takes no parameters and returns build123d 2D geometry. The
+engine writes the DXF.** You never construct a document, name a file, or place
+an entity — the same division of labor `@step` has.
+
+```python
+from cadgen import build123d as bd
+from cadgen import dxf
+
+
+HOLE_D = 4.5
+
+
+@dxf
+def gasket():
+    with bd.BuildSketch() as cut:
+        bd.Rectangle(60, 40)
+        bd.Circle(HOLE_D / 2, mode=bd.Mode.SUBTRACT)
+    return cut.sketch          # bare shape -> the CUT layer
+
+
+if __name__ == "__main__":
+    gasket()
+```
+
+- **Bare shape** → one `CUT` layer. That is the whole contract for most drawings.
+- **`{layer: shape}`** → named layers, when the drawing genuinely has more than
+  one CAM operation (`CUT` / `ENGRAVE` / `SCORE`). A `Compound` whose children
+  are all labelled means the same thing.
+- **No parameters.** Dimensions are module constants (`HOLE_D = 4.5`) or
+  constants imported from the part the drawing derives from; a different
+  drawing is a different file.
+- **Text** is `bd.Text(...)` engraved OUTLINES on a marking layer, never a DXF
+  `TEXT` entity: cut and marking toolchains consume geometry, and font rendering
+  inside CAM is unreliable.
+- **Geometry must lie in the XY plane.** A face taken from a solid sits at that
+  solid's height; relocate it (`flatten.flatten_face(face)`, or
+  `bd.Location((0, 0, -z)) * face`). The engine REFUSES off-plane geometry rather
+  than silently writing its XY shadow.
+- **Output bytes are a function of the geometry.** Layers are sorted by name and
+  entities by geometric content, so an unchanged drawing rebuilds to an identical
+  file, cold or warm, on any machine.
+
+## The three DXF workflows
+
+Copy the full template for the applicable workflow from
+`references/generator-templates.md` when creating a new drawing.
+
+1. **Drafted from scratch** (gaskets, panels, templates, cut layouts with no 3D
+   model behind them): a `<name>.py` that builds sketches and returns them.
+
+2. **Flat pattern of a generated STEP part**: a drawing script beside the model
+   it derives from, with its OWN stem (one model per file — `bracket_drawing.py`
+   beside `bracket.py`). Import the model and call it, exactly as an assembly
+   composes a child: importing never builds, and inside the drawing's build the
+   call returns the part's geometry (building the part first if it is stale).
+
+   ```python
+   from cadgen import dxf, flatten
+   from bracket import bracket        # a child: tracked by its RESULT
+
+   KERF = 0.15
+
+
+   @dxf
+   def bracket_drawing():
+       return flatten.flat_pattern(bracket(), coordinate=3.0, kerf=KERF)
+
+
+   if __name__ == "__main__":
+       bracket_drawing()
+   ```
+
+   The drawing's record pins the part's tree, so a part edit that changes its
+   geometry makes the drawing stale, and one that does not (a comment, a
+   refactor, a colour) leaves it current. Constants imported from the part
+   (`from bracket import THICKNESS`) are tracked by value the same way.
+
+3. **Flat pattern of an imported STEP** (a `.step`/`.stp` with no Python source):
+   read it with `cadgen.read_step`, not `build123d.import_step`. It records the
+   file's content hash as a build INPUT, so replacing the vendor STEP makes the
+   drawing stale on its own, with no `--force`; read it through build123d and the
+   drawing stays "current" against a file that changed underneath it.
+
+   ```python
+   from pathlib import Path
+
+   from cadgen import dxf, flatten, read_step
+
+   _HERE = Path(__file__).resolve().parent
+
+   KERF = 0.15
+
+
+   @dxf
+   def panel_flat():
+       panel = read_step(_HERE / "imported" / "vendor_panel.step")   # recorded input
+       return flatten.flat_pattern(panel, coordinate=3.0, kerf=KERF)
+
+
+   if __name__ == "__main__":
+       panel_flat()
+   ```
+
+   **Never read a STEP this project generates.** Reading the `.step` a `@step`
+   model writes is not a loop, it is a drawing whose input changes on every run of
+   the model: the freshness gate can never say "current", every build is a full
+   rebuild, and the flat pattern depends on what the last run left on disk. Keep
+   source STEPs in an `imported/` directory beside the drawing, committed like any
+   other input — input path and output path being different files is the whole
+   rule. For a STEP this project DOES generate, use workflow 2 instead: import the
+   model script and call it, which is tracked by result and never touches an
+   artifact.
+
+One model per file: a source declaring both a `@step` and a `@dxf` model is
+rejected — a drawing gets its own script. A drawing composes models, never the
+reverse: calling a `@dxf` function from a `@step` body is just its 2D geometry
+and links nothing. The viewer catalog is artifacts-only: scripts never list;
+the `.dxf` the run writes is the entry the viewer renders.
+
+## Use this skill when
+
+Use this skill when the user asks for DXF files, 2D drawings, profiles, outlines,
+templates, gaskets, panels, flat patterns, or cut layouts for laser, plasma,
+waterjet, or CNC routing.
+
+Use `$cad` for the 3D part or assembly a DXF derives from. Use `$sendcutsend` for
+SendCutSend-specific upload preflight.
+
+## Defaults
+
+Use these defaults unless the user specifies otherwise:
+
+- Units: millimeters. The engine sets them; a drawing never declares units.
+- Geometry lives at 1:1 scale in the XY plane.
+- Cut profiles close. Open contours belong on bend/engrave/reference layers —
+  generation validation enforces this (see Validation).
+- For CAD-backed parts, derive contours from the real topology with
+  `cadgen.flatten` rather than redrawing them: `planar_faces` selects,
+  `flatten_face` lays a face into XY exactly, `union_faces` fuses, and
+  `flat_pattern` does all of it in one call. Hand-drawn parametric outlines only
+  when there is no reliable 3D topology.
+- Kerf / tool-radius compensation is `flatten.offset_profile(shape, amount)` or
+  `flat_pattern(..., kerf=...)`; never hand-offset coordinates.
+- **Curves stay curves.** The union and the offset are exact OCC operations, so a
+  filleted corner exports as an `ARC` and a hole as a `CIRCLE`, kerf included. A
+  profile that comes out as hundreds of short `LINE`s means something fell back
+  to the sampled path — investigate rather than accept it.
+- Layers carry intent: keep cut geometry and bend/fold lines on separate layers,
+  and include "bend" in bend-layer names so downstream tools classify them as
+  bends rather than cuts.
+- DXF layers are drawing structure, not STEP part/assembly structure.
+
+## Tool
+
+```bash
+python <drawing>.py [flags]                    # its __main__ calls the @dxf model, which writes the .dxf
+cadgen dxf snapshot <drawing.dxf> <file.png>   # render it
+cadgen store why <drawing>.py                  # why the drawing is stale or current
+```
+
+**Running the script (its `__main__` call) is the only door.** There is no
+`cadgen dxf build`: a `.dxf` has no derived state a command must materialize —
+the file IS the product, the CAD Viewer parses it directly, and `dxf snapshot`
+meshes it on demand. The drawing's gate makes a rebuild cheap: an unchanged
+source whose `.dxf` still verifies and whose part children are unchanged is a
+no-op, and `--force` rebuilds anyway. The bytes are a function of the
+drawing's GEOMETRY, so a cold run and a warm daemon worker write the same
+file. Builds never wait on or cancel one another; a drawing that calls parts
+builds them in parallel like any parent.
+
+An imported `.dxf` needs nothing at all — hand it straight to snapshot or the
+Viewer.
+
+Use the active project Python interpreter; treat `python` as an interpreter
+placeholder, and use `--help` for the full interface. Target paths resolve from
+the command's current working directory; run from the workspace that owns the
+artifacts with cwd-relative target paths. Keep a drawing script in the same
+directory as the geometry it derives from, named `<name>.py`.
+
+Flags (a model script runs itself; there is no generation CLI):
+
+- `--force` — regenerate even when the recorded output is current.
+- `--verbose`, `--json`.
+
+A run answers on stdout exactly as a STEP model's does — `built DXF/plate_drawing.dxf`
+or `current DXF/plate_drawing.dxf` — with progress on stderr; `--json` makes the
+result one JSON line (`outcome`, `document`, and `tree`, which is null for a
+drawing) and the progress one JSON line per transition.
+
+One script, one drawing: run each script you want built. Do not put output paths
+in the `@dxf` function's return value; `out=` on the decorator is the only
+place a drawing names its destination (relative to the script).
+
+`cadgen dxf snapshot` renders a drawing's 3D flat pattern to a PNG still:
+
+```bash
+cadgen dxf snapshot path/to/imported.dxf review.png
+cadgen dxf snapshot path/to/drawing.dxf review.png --camera top
+```
+
+It takes the `.dxf` document only — a model script is refused by name (run
+`python <drawing>.py`, then snapshot the drawing it wrote). The command meshes
+the flat pattern on demand through the bundled Node one-shot and
+renders it through the shared snapshot CLI (`cadgen.snapshot_cli`) and the same
+headless browser runtime every rendering skill uses — so geometry and materials
+render identically to the CAD Viewer; the default `snapshot` theme differs from the
+viewport only by dropping the grid, origin axis and shadows.
+
+OUT — the second positional — is written exactly as given, with a relative path resolved against the
+current working directory. The target is deleted before the render starts and the
+finished image is written atomically, so: reuse one name while iterating (every read
+is provably the render you just ran), name the iterations when you genuinely need to
+compare two, and treat a missing file as the failure signal — there is never an older
+image at the path to mistake for output. A directory (`tmp/` as OUT) is the
+don't-care case and gets a generated timestamped name inside it, printed on the
+`saved snapshot:` line.
+
+Grammar: `cadgen dxf snapshot TARGET [OUT] [flags]`. Flags: `--mode view|list`,
+`--camera`, `--theme`, `--size-profile`, `--width`/`--height`, `--job`,
+`--view-labels`, `--debug`, `--json`. Theme settings live under one `--theme`,
+mirroring the viewer's Theme tab; the default theme is `snapshot`, Workbench Light
+without the ground grid, origin axis or shadows. The command has no `--display`,
+and no selector, kinematics, section or exploded options at all — they are absent
+from `--help` rather than refused at runtime, because a drawing carries no CAD
+topology and display settings are CAD topology settings.
+
+No CLI inspects an existing `.dxf`. For entity/layer checks read it with `ezdxf`
+directly (it arrives with build123d), and `validate_dxf_file` for the drawing checks;
+review geometry visually with `$cad-viewer`.
+
+## Workflow
+
+1. Convert the request into a short brief: outline dimensions, holes and slots, layers, units, output path, and validation targets.
+2. Pick the workflow: drafted from scratch, flat pattern of a generated model (create and validate the 3D geometry with `$cad` first), or flat pattern of an imported STEP.
+3. Write or edit the `<name>.py` source with meaningful dimensions as named constants, reusing the model's geometry helpers instead of duplicating formulas.
+4. Run each drawing script directly (`python <drawing>.py`); do not sweep directories.
+
+```bash
+python path/to/source.py
+python path/to/source.py --force
+```
+
+5. Validate the generated DXF deterministically, then hand off and report.
+
+## Viewer integration
+
+The CAD Viewer catalogs `.dxf` files only (artifacts, never scripts) and is a static
+visualization tool: it renders the `.dxf` that exists on disk (parsing and meshing it
+itself — 2D line work for dimensioned drawings, a fold-able 3D flat pattern for cut
+layouts) and never runs a script. A drawing with no `.dxf` yet simply does not appear
+until its script has been run; regenerating after edits is likewise the script's job.
+There is no in-viewer export. An imported `.dxf` renders directly with no artifact
+management.
+
+## Validation
+
+Validation happens IN generation, not after: every `@dxf` build runs the drawing
+checks on the document the engine just serialized, before anything is written, and
+a build with error findings fails. The checks: cut-layer profiles must close
+(polylines, circles, or chained line/arc loops), zero-length/degenerate entities are
+rejected, exact duplicate geometry (double-cut risk) is rejected, explicitly unitless
+documents are rejected, and an empty modelspace is rejected. Open geometry is allowed
+only on bend/engrave/reference-intent layers (matched by name).
+
+The same checks run post-hoc on any existing `.dxf` file — including one that
+never came from a generator — through `cadgen.drawing_checks`:
+
+```python
+from cadgen.drawing_checks import validate_dxf_file
+
+for finding in validate_dxf_file("path/to/file.dxf"):
+    print(finding.render())
+```
+
+Beyond the built-in checks, verify requested dimensions with targeted `ezdxf` reads
+(entity counts by layer, drawing extents, every dimension the user specified) against
+the generated sibling `.dxf` (or the `out=` path when one is declared), and
+review geometry visually in the CAD Viewer:
+
+```python
+import ezdxf
+
+doc = ezdxf.readfile("path/to/source.dxf")
+msp = doc.modelspace()
+cut = msp.query('*[layer=="CUT"]')
+holes = msp.query('CIRCLE[layer=="CUT"]')
+```
+
+Report only checks that actually ran.
+
+## Handoff
+
+After creating or modifying DXF drawings, you must ALWAYS hand the explicit `.dxf`
+file path(s) to `$cad-viewer` when that skill is installed and include its live
+viewer link(s) in the final response. If `$cad-viewer` is unavailable or startup fails, report
+that and rely on `ezdxf` checks instead of silently omitting the handoff.
+
+Final responses should include generated files, returned viewer links, validation
+actually run, and assumptions.

--- a/.qwenpaw-plugin/skills/dxf/agents/openai.yaml
+++ b/.qwenpaw-plugin/skills/dxf/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DXF"
+  short_description: "Generate and validate 2D DXF drawings."
+  default_prompt: "Use $dxf to create, regenerate, and validate explicit DXF drawing files from gen_dxf() Python sources, handing outputs to $cad-viewer when available."

--- a/.qwenpaw-plugin/skills/dxf/references/generator-templates.md
+++ b/.qwenpaw-plugin/skills/dxf/references/generator-templates.md
@@ -1,0 +1,193 @@
+# DXF drawing templates
+
+Read this file when creating a new `<name>.py` drawing script. Copy the
+template for the workflow that applies and replace the TODO markers.
+
+Every template follows one contract: **the parameterless `@dxf` function
+returns build123d 2D geometry and the engine writes the DXF.** You never
+construct a document, name a file, or think about entities.
+
+- Return a **bare shape** for a single-operation drawing — it lands on the `CUT`
+  layer.
+- Return **`{layer: shape}`** when the drawing genuinely has more than one CAM
+  operation (`CUT` / `ENGRAVE` / `SCORE`).
+- Geometry must lie in the **XY plane**. A face derived from a solid is at that
+  solid's height, so relocate it (`flatten.flatten_face`, or
+  `bd.Location((0, 0, -z)) * face`). The engine refuses off-plane geometry
+  rather than silently writing its XY shadow.
+- Validation runs during generation: cut layers must hold closed profiles, and
+  open geometry belongs on a bend/engrave/reference-named layer.
+- Every script ends with `if __name__ == "__main__": <drawing>()` — the call
+  is what builds it.
+
+## 1. Standalone drafting (DXF from scratch)
+
+For pure 2D outputs — gaskets, panels, templates, cut layouts — with no 3D model
+behind them. Keep meaningful dimensions as named constants.
+
+```python
+"""Standalone 2D drawing: <description>."""
+
+from __future__ import annotations
+
+from cadgen import build123d as bd
+from cadgen import dxf
+
+# TODO: named dimension constants
+WIDTH_MM = 40.0
+HEIGHT_MM = 20.0
+HOLE_D_MM = 4.5
+
+
+@dxf
+def drawing():
+    with bd.BuildSketch() as cut:
+        bd.Rectangle(WIDTH_MM, HEIGHT_MM)
+        bd.Circle(HOLE_D_MM / 2, mode=bd.Mode.SUBTRACT)
+    return cut.sketch
+
+
+if __name__ == "__main__":
+    drawing()
+```
+
+Two layers, when the part is both cut and marked:
+
+```python
+"""Standalone 2D drawing with a marking layer."""
+
+from __future__ import annotations
+
+from cadgen import build123d as bd
+from cadgen import dxf
+
+WIDTH_MM = 40.0
+HEIGHT_MM = 20.0
+
+
+@dxf
+def drawing():
+    with bd.BuildSketch() as cut:
+        bd.Rectangle(WIDTH_MM, HEIGHT_MM)
+    with bd.BuildSketch() as mark:
+        bd.Text("REV B", font_size=6)
+    return {"CUT": cut.sketch, "ENGRAVE": mark.sketch}
+
+
+if __name__ == "__main__":
+    drawing()
+```
+
+Text is engraved **outlines**, not DXF `TEXT` entities: cut and marking
+toolchains consume geometry, and font rendering inside CAM is unreliable.
+
+## 2. Flat pattern of a generated STEP part
+
+For a profile of a `$cad` model. The drawing imports the model and calls it,
+exactly as an assembly composes a child: importing a model never builds it,
+and the call inside the drawing's build returns the part's geometry (building
+the part first if it is stale). The drawing's record pins the part's RESULT,
+so a geometry change in the part makes the drawing stale and a comment or
+refactor does not; a constant imported from the part is tracked by value.
+
+```python
+"""Flat-pattern DXF drawing for <name>; geometry reused from <name>.py."""
+
+from __future__ import annotations
+
+from cadgen import dxf, flatten
+
+from <name> import <name>          # a child: tracked by its result; importing never builds
+
+THICKNESS_MM = 6.0                 # TODO: the profile face's height
+
+
+KERF = 0.0
+
+
+@dxf
+def drawing():
+    return flatten.flat_pattern(
+        <name>(),
+        coordinate=THICKNESS_MM,   # TODO: which face plane defines the profile
+        kerf=KERF,
+    )
+
+
+if __name__ == "__main__":
+    drawing()
+```
+
+`flat_pattern` is selection + flatten + union + optional kerf offset in one
+call. Do the steps yourself when a part needs them apart — a bracket with
+flanges on several planes selects each one, flattens each with its own
+transform, and unions the result:
+
+```python
+@dxf
+def drawing():
+    part = bracket()
+    faces = [
+        *flatten.planar_faces(part, normal_axis="z", normal_sign=1.0,
+                              coordinate_axis="z", coordinate=3.0),
+        *flatten.planar_faces(part, normal_axis="y", normal_sign=-1.0,
+                              coordinate_axis="y", coordinate=0.0),
+    ]
+    return flatten.union_faces(flatten.flatten_faces(faces))
+```
+
+## 3. Flat pattern of an imported STEP
+
+For a vendor `.step` with no Python source. Read it with `cadgen.read_step`,
+which records the file's content hash as a build input — replacing the STEP
+makes the drawing stale on its own, with no `--force`.
+
+The face selection is a part-specific judgment call: pick the planar face(s)
+that define the cut profile.
+
+Never point `read_step` at a STEP this project GENERATES — that is a model
+whose input changes every time its sibling builds. Keep vendor files in an
+`imported/` directory beside the drawing (see the CAD skill's
+`step-generation.md`), and give the drawing its own stem:
+
+```python
+"""DXF profile of vendor_panel.step."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cadgen import dxf, flatten, read_step
+
+_STEP_PATH = Path(__file__).parent / "imported" / "vendor_panel.step"
+
+
+KERF = 0.15
+
+
+@dxf
+def drawing():
+    part = read_step(_STEP_PATH)
+    top_z = part.bounding_box().max.Z
+    return flatten.flat_pattern(part, coordinate=top_z, kerf=KERF)
+
+
+if __name__ == "__main__":
+    drawing()
+```
+
+## Common additions
+
+- **Bend / fold lines**: put them on a layer whose name contains `bend`
+  (`{"CUT": profile, "BEND": fold_lines}`). Open geometry is allowed there, and
+  downstream tools classify it as bends rather than cuts.
+- **Kerf / tool-radius compensation**: `flatten.offset_profile(shape, amount)`,
+  or the `kerf=` argument of `flat_pattern`. Positive grows the profile (cut
+  outside the line), negative shrinks it. Never hand-offset coordinates.
+- **Curves stay curves.** The union and the offset are OCC operations on the real
+  faces, so a filleted corner exports as an `ARC` and a hole as a `CIRCLE`, kerf
+  included. If a drawing comes out as hundreds of short `LINE`s, something fell
+  back to the sampled path — check the union inputs rather than accepting it.
+- **Why did it (not) rebuild?** `cadgen store why <drawing>.py` prints the
+  drawing's gate: its closure files, each part it called with the pinned and
+  current tree, and whether the `.dxf` on disk is the one it wrote.

--- a/.qwenpaw-plugin/skills/dxf/requirements.txt
+++ b/.qwenpaw-plugin/skills/dxf/requirements.txt
@@ -1,0 +1,1 @@
+cadgen[snapshot]==0.5.1

--- a/.qwenpaw-plugin/skills/gcode/LICENSE
+++ b/.qwenpaw-plugin/skills/gcode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thompson Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.qwenpaw-plugin/skills/gcode/SKILL.md
+++ b/.qwenpaw-plugin/skills/gcode/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: gcode
+description: Generate, inspect, dry-run, and statically validate plain FDM `.gcode` from 3D mesh files by orchestrating real slicer CLIs. Use when Codex needs to slice `.stl`, `.obj`, unsliced `.3mf`, `.ply`, `.glb`, or `.gltf` into printer-profiled G-code, discover local slicer backends, inspect whether a mesh is slice-ready, or validate generated G-code before any printer-specific handoff.
+---
+
+# G-code
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review.
+
+Use this skill for plain `.gcode` generation from mesh files. It is printer-agnostic and never uploads, starts, or packages print jobs.
+
+## Workflow
+
+1. Confirm the input is a supported mesh: `.stl`, `.obj`, unsliced `.3mf`, `.ply`, `.glb`, or `.gltf`.
+2. Require an explicit printer/profile wrapper JSON. Do not invent real-printer profiles.
+3. Discover slicer backends when the backend is unknown:
+
+```bash
+python scripts/gcode_tool.py discover
+```
+
+4. Inspect the input:
+
+```bash
+python scripts/gcode_tool.py inspect --input path/to/model.stl --json
+```
+
+5. Dry-run the slicer command before executing:
+
+```bash
+python scripts/gcode_tool.py slice \
+  --input path/to/model.stl \
+  --output /tmp/model.gcode \
+  --profile path/to/profile.json \
+  --backend auto \
+  --dry-run
+```
+
+6. Execute only after the dry-run command and profile are appropriate:
+
+```bash
+python scripts/gcode_tool.py slice \
+  --input path/to/model.stl \
+  --output /tmp/model.gcode \
+  --profile path/to/profile.json \
+  --backend auto \
+  --execute
+```
+
+7. Validate the generated G-code:
+
+```bash
+python scripts/gcode_tool.py validate \
+  --gcode /tmp/model.gcode \
+  --profile path/to/profile.json \
+  --json
+```
+
+## Profile Contract
+
+Every slice requires a wrapper profile JSON with an absolute native slicer profile path:
+
+```json
+{
+  "backend": "orcaslicer",
+  "native_config": "/absolute/path/to/native-slicer-profile",
+  "machine": {
+    "name": "Example Printer",
+    "bed_size_mm": [180, 180],
+    "z_height_mm": 180,
+    "motion_bounds_mm": {
+      "x": [0, 180],
+      "y": [0, 180],
+      "z": [0, 180]
+    }
+  },
+  "filament": {
+    "type": "PLA",
+    "nozzle_temp_c": 220,
+    "bed_temp_c": 65
+  }
+}
+```
+
+The wrapper supplies validation bounds and backend selection. `machine.motion_bounds_mm` is optional; omit it for the default `0..bed_size` and `0..z_height` bounds, or set it from a native printer profile when start/end G-code intentionally uses safe wipe/purge positions outside the printable area. The native slicer profile remains the source of detailed process, printer, and filament behavior.
+
+For OrcaSlicer, use `native_settings` and `native_filaments` when the real profile is split across machine, process, and filament JSON files. Keep `native_config` as an absolute path to the primary native profile for compatibility:
+
+```json
+{
+  "backend": "orcaslicer",
+  "native_config": "/absolute/path/to/machine-or-process.json",
+  "native_settings": [
+    "/absolute/path/to/machine.json",
+    "/absolute/path/to/process.json"
+  ],
+  "native_filaments": [
+    "/absolute/path/to/filament.json"
+  ],
+  "machine": {
+    "name": "Example Printer",
+    "bed_size_mm": [180, 180],
+    "z_height_mm": 180
+  },
+  "filament": {
+    "type": "PLA",
+    "nozzle_temp_c": 220,
+    "bed_temp_c": 65
+  }
+}
+```
+
+## Backends And Inputs
+
+Preferred slicer backend order is `orcaslicer`, `prusa-slicer`, then `curaengine`. Prefer installing OrcaSlicer when no preferred backend is available; on macOS use `brew install --cask orcaslicer` and then rerun `discover`. The helper checks both `PATH` and the usual `/Applications/OrcaSlicer.app` cask location. Bambu Studio may be reported by discovery as available but is not preferred because its CLI export path has shown macOS instability.
+
+Pass `.stl`, `.obj`, and unsliced `.3mf` directly to the slicer. Convert `.ply`, `.glb`, and `.gltf` to temporary STL at execution time with optional `trimesh`; if `trimesh` is unavailable, ask the user to install it or provide `.stl`, `.obj`, or unsliced `.3mf`.
+
+Reject `.step`, `.stp`, `.dxf`, `.svg`, `.urdf`, and `.sdf` in v1. `inspect` and `slice` fail with a structured `remediation` object naming the skill and command that produce a sliceable mesh; use it instead of inferring a conversion workflow:
+
+- `.step`, `.stp`: boundary-representation CAD, not a mesh. Export an STL sidecar with `$cad` (`cadgen stl build <input.step> <output>.stl` — the door takes the STEP document; a model script is refused, run `python <model>.py` first), then slice the exported `.stl` here.
+- `.dxf`, `.svg`: 2D drawings with no 2D-to-mesh conversion in this toolchain. Model the 3D solid in `$cad` as a `@step` model script and export an STL sidecar, then slice that. If the part is a flat cut rather than a print, use `$sendcutsend` instead of this skill.
+- `.urdf`, `.sdf`: robot descriptions that reference per-link mesh files. Slice the referenced `.stl`/`.obj` meshes one at a time; regenerate stale or missing ones from the owning CAD source with `$cad` first. Use `$urdf` or `$sdf` for the robot description itself.
+
+Read `references/slicer-backends.md` when backend behavior, profile expectations, or source links matter.
+
+## Validation
+
+Always validate generated G-code before handing it to printer-specific workflows. The validator checks for non-empty content, temperature commands, movement commands, extrusion moves, XYZ bounds, and unknown command warnings.
+
+Read `references/gcode-validation.md` when interpreting validation output or deciding whether a warning is acceptable.
+
+## Bambu Boundary
+
+This skill generates plain `.gcode` only. It does not create Bambu `.gcode.3mf` archives and does not contact printers. For Bambu upload/start workflows, hand off the validated plain `.gcode` to `$bambu-labs`. Let `$bambu-labs` choose the printer-specific LAN handoff, such as an A1 Mini template project or an explicitly enabled bambox project package.

--- a/.qwenpaw-plugin/skills/gcode/agents/openai.yaml
+++ b/.qwenpaw-plugin/skills/gcode/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "G-code"
+  short_description: "Generate G-code from 3D mesh files"
+  default_prompt: "Use $gcode to generate printer-profiled G-code from a mesh file."

--- a/.qwenpaw-plugin/skills/gcode/references/gcode-validation.md
+++ b/.qwenpaw-plugin/skills/gcode/references/gcode-validation.md
@@ -1,0 +1,48 @@
+# G-code Validation
+
+`scripts/gcode_tool.py validate` performs static checks only. It does not simulate extrusion physics, firmware state, acceleration limits, or slicer-specific semantics.
+
+## Required Checks
+
+Validation fails when:
+
+- The file is empty.
+- No `G0`, `G1`, `G2`, or `G3` movement commands are present.
+- No extrusion moves are present.
+- No nozzle or bed temperature commands are present.
+- Parsed absolute `X`, `Y`, or `Z` moves exceed the wrapper profile motion bounds.
+
+An extrusion move is a `G0`, `G1`, `G2`, or `G3` motion whose interpreted `E`
+position advances. The validator tracks exact `G90`/`G91` commands and
+`M82`/`M83` extruder overrides; a later `G90`/`G91` clears the override. It also
+tracks `G92 E` position resets. Retractions and zero-distance `E` moves do not
+satisfy the extrusion check.
+
+Validation warns when:
+
+- Unknown or unsupported G-code commands are encountered.
+- Relative positioning is used; bounds checking is skipped while relative mode is active.
+
+Warnings do not rewrite or delete commands. Treat them as review prompts, especially before sending G-code to unfamiliar firmware.
+
+## Bounds Policy
+
+The validator assumes absolute positioning until `G91` appears, and resumes absolute bounds checks after `G90`. This avoids false hard failures for relative motion blocks while still catching obvious out-of-bed absolute moves.
+
+The wrapper profile provides printable bounds:
+
+- `machine.bed_size_mm[0]`: maximum `X`
+- `machine.bed_size_mm[1]`: maximum `Y`
+- `machine.z_height_mm`: maximum `Z`
+
+By default, motion bounds are `X=0..bed_size_mm[0]`, `Y=0..bed_size_mm[1]`, and `Z=0..z_height_mm`. If a native printer profile intentionally uses safe off-bed wipe, purge, or maintenance positions, set `machine.motion_bounds_mm` with explicit `x`, `y`, and/or `z` `[min, max]` ranges. Do this only from a real printer/profile source, not as a way to silence unknown G-code.
+
+## Interpreting Results
+
+`ok: true` means the file passed these static checks. It does not mean the G-code is safe to print on real hardware. Still review:
+
+- Printer/profile match.
+- Filament and temperature settings.
+- Start and end G-code.
+- Bed origin and coordinate system.
+- Any unknown command warnings.

--- a/.qwenpaw-plugin/skills/gcode/references/slicer-backends.md
+++ b/.qwenpaw-plugin/skills/gcode/references/slicer-backends.md
@@ -1,0 +1,84 @@
+# Slicer Backends
+
+Use real slicer CLIs for mesh-to-G-code work. Do not rely on Bambu Studio as the default backend for this skill.
+
+## Backend Order
+
+1. `orcaslicer`
+2. `prusa-slicer`
+3. `curaengine`
+
+If no preferred backend is installed, install OrcaSlicer first instead of treating the missing slicer as a user-facing blocker. On macOS:
+
+```bash
+brew install --cask orcaslicer
+```
+
+After installation, rerun `scripts/gcode_tool.py discover`. The helper checks `PATH`, backend-specific environment variables, and common macOS app bundle locations such as `/Applications/OrcaSlicer.app/Contents/MacOS/OrcaSlicer`.
+
+`scripts/gcode_tool.py discover` checks PATH and backend-specific environment variables:
+
+- `ORCASLICER_BIN`
+- `PRUSASLICER_BIN`
+- `CURAENGINE_BIN`
+
+Bambu Studio may also be reported as available but not preferred. It is intentionally excluded from default backend selection because the local Bambu CLI export path has previously crashed during `.gcode.3mf` generation.
+
+## Profile Expectations
+
+Every slice needs a wrapper profile JSON. The wrapper must include:
+
+- `backend`: one of `orcaslicer`, `prusa-slicer`, or `curaengine`.
+- `native_config`: absolute path to the primary native slicer config/profile file.
+- `machine.bed_size_mm`: `[width, depth]` in millimeters.
+- `machine.z_height_mm`: maximum Z travel in millimeters.
+- `machine.motion_bounds_mm`: optional per-axis motion limits for native start/end G-code that intentionally moves outside the printable area.
+- `filament.type`, `filament.nozzle_temp_c`, and `filament.bed_temp_c`.
+
+The wrapper is not a complete slicer profile. The native config is authoritative for detailed printer, process, and filament settings.
+
+For OrcaSlicer profiles split across native machine, process, and filament JSON files, add:
+
+- `native_settings`: string or list of absolute paths passed to `--load-settings`.
+- `native_filaments`: string or list of absolute paths passed to `--load-filaments`.
+
+If `native_settings` is omitted, `native_config` is passed as the only setting file.
+
+## Command Shapes
+
+For OrcaSlicer:
+
+```bash
+OrcaSlicer --load-settings machine.json\;process.json --load-filaments filament.json --outputdir /tmp/out --slice 0 input.stl
+```
+
+For PrusaSlicer:
+
+```bash
+prusa-slicer --load profile.ini --export-gcode --output output.gcode input.stl
+```
+
+For CuraEngine:
+
+```bash
+CuraEngine slice -j profile.json -l input.stl -o output.gcode
+```
+
+Always run a dry-run first and inspect the emitted command before `--execute`.
+
+## Input Handling
+
+- `.stl`, `.obj`, and unsliced `.3mf` are passed directly to the selected slicer.
+- `.ply`, `.glb`, and `.gltf` are converted to temporary STL with `trimesh` during `--execute`.
+- Sliced Bambu 3MF files containing `Metadata/plate_N.gcode` are already print jobs; do not re-slice them.
+- `.step`, `.stp`, `.dxf`, `.svg`, `.urdf`, and `.sdf` are out of scope for this skill. `inspect_input` rejects them with a `remediation` object (`skill`, `reason`, `next_step`) that names the owning skill and the exact conversion command; both `inspect` and `slice` surface it in their JSON error payload.
+  - `.step`, `.stp`: export an STL sidecar with `$cad` (`cadgen stl build <input> <output>.stl`).
+  - `.dxf`, `.svg`: no 2D-to-mesh path exists; model the solid in `$cad`, or use `$sendcutsend` when the part is a flat cut rather than a print.
+  - `.urdf`, `.sdf`: slice the per-link meshes the description references, regenerating them from CAD with `$cad` when stale.
+
+## Source Links
+
+- FullControl procedural G-code context: https://github.com/FullControlXYZ/fullcontrol
+- bambox Bambu packaging reference only: https://pypi.org/project/bambox/
+- trimesh mesh format support: https://trimesh.org/formats.html
+- CuraEngine slicing background: https://github.com/Ultimaker/CuraEngine/wiki/Slicing

--- a/.qwenpaw-plugin/skills/gcode/scripts/gcode_tool.py
+++ b/.qwenpaw-plugin/skills/gcode/scripts/gcode_tool.py
@@ -1,0 +1,803 @@
+#!/usr/bin/env python3
+"""Dry-run-first helpers for generating and validating plain FDM G-code."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+DIRECT_MESH_EXTENSIONS = {".stl", ".obj", ".3mf"}
+CONVERT_TO_STL_EXTENSIONS = {".ply", ".glb", ".gltf"}
+
+_STEP_REMEDIATION = {
+    "skill": "cad",
+    "reason": "STEP/STP is boundary-representation CAD, not a mesh.",
+    "next_step": (
+        "Export an STL sidecar with $cad: `cadgen stl build <input> <output>.stl`. "
+        "When a model script exists, run it instead (`python <model>.py`) so its declared exports build. "
+        "Then slice the exported .stl with this skill."
+    ),
+}
+_FLAT_2D_REMEDIATION = {
+    "skill": "cad",
+    "reason": "This is a 2D drawing, not a printable solid, and this toolchain has no 2D-to-mesh conversion.",
+    "next_step": (
+        "For an FDM print, model the 3D solid in $cad with an `@step` model script and export an STL sidecar "
+        "(run `python <model>.py`), then slice that .stl here. "
+        "If the part is a flat cut rather than a print, use $sendcutsend instead of this skill."
+    ),
+}
+
+
+def _robot_description_remediation(skill: str, label: str) -> dict[str, str]:
+    return {
+        "skill": skill,
+        "reason": f"{label} is a robot description that references per-link mesh files; it is not itself a mesh.",
+        "next_step": (
+            f"Slice the per-link .stl/.obj meshes the {label} references, one mesh at a time. "
+            f"If those meshes are missing or stale, regenerate them from the owning CAD source "
+            "($cad: run `python <model>.py`, or `cadgen stl build <input.step> <output>.stl`), then slice the exported mesh here. "
+            f"Use ${skill} for the robot description itself."
+        ),
+    }
+
+
+UNSUPPORTED_INPUT_REMEDIATION = {
+    ".step": _STEP_REMEDIATION,
+    ".stp": _STEP_REMEDIATION,
+    ".dxf": _FLAT_2D_REMEDIATION,
+    ".svg": _FLAT_2D_REMEDIATION,
+    ".urdf": _robot_description_remediation("urdf", "URDF"),
+    ".sdf": _robot_description_remediation("sdf", "SDF"),
+}
+UNSUPPORTED_EXTENSIONS = set(UNSUPPORTED_INPUT_REMEDIATION)
+SLICED_BAMBU_PLATE_RE = re.compile(r"^Metadata/plate_(\d+)\.gcode$")
+
+PREFERRED_BACKEND_ORDER = ["orcaslicer", "prusa-slicer", "curaengine"]
+BACKEND_EXECUTABLES = {
+    "orcaslicer": ["OrcaSlicer", "orca-slicer", "orcaslicer"],
+    "prusa-slicer": ["prusa-slicer", "PrusaSlicer", "prusa-slicer-console"],
+    "curaengine": ["CuraEngine", "curaengine"],
+}
+BACKEND_APP_GLOBS = {
+    "orcaslicer": ["OrcaSlicer*.app/Contents/MacOS/OrcaSlicer"],
+    "prusa-slicer": ["PrusaSlicer*.app/Contents/MacOS/PrusaSlicer"],
+}
+BACKEND_ENV_VARS = {
+    "orcaslicer": "ORCASLICER_BIN",
+    "prusa-slicer": "PRUSASLICER_BIN",
+    "curaengine": "CURAENGINE_BIN",
+}
+BAMBU_EXECUTABLES = ["bambu-studio", "BambuStudio"]
+SUPPORTED_GCODE_COMMANDS = {
+    "G0",
+    "G1",
+    "G2",
+    "G3",
+    "G4",
+    "G21",
+    "G28",
+    "G29",
+    "G90",
+    "G91",
+    "G92",
+    "M18",
+    "M73",
+    "M82",
+    "M83",
+    "M84",
+    "M104",
+    "M106",
+    "M107",
+    "M109",
+    "M117",
+    "M118",
+    "M140",
+    "M190",
+    "M201",
+    "M203",
+    "M204",
+    "M205",
+    "M220",
+    "M221",
+    "M400",
+    "M500",
+    "M501",
+    "M900",
+}
+
+
+class GCodeToolError(RuntimeError):
+    """Raised for expected user-facing workflow errors."""
+
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details = details or {}
+
+
+@dataclass(frozen=True)
+class BackendDiscovery:
+    id: str
+    available: bool
+    path: str | None
+    preferred: bool
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class GCodeProfile:
+    backend: str
+    native_config: str
+    native_settings: tuple[str, ...]
+    native_filaments: tuple[str, ...]
+    machine_name: str
+    bed_size_mm: tuple[float, float]
+    z_height_mm: float
+    motion_bounds_mm: dict[str, tuple[float, float]]
+    filament_type: str
+    nozzle_temp_c: float
+    bed_temp_c: float
+
+
+@dataclass(frozen=True)
+class InputInspection:
+    path: str
+    extension: str
+    size_bytes: int
+    supported: bool
+    direct_to_slicer: bool
+    needs_stl_conversion: bool
+    already_sliced_bambu: bool
+    status: str
+
+
+def tail_text(value: str, *, max_lines: int = 80) -> str:
+    lines = value.splitlines()
+    if len(lines) <= max_lines:
+        return value
+    return "\n".join(lines[-max_lines:])
+
+
+def find_executable(names: list[str], *, search_path: str | None = None) -> str | None:
+    for name in names:
+        found = shutil.which(name, path=search_path)
+        if found:
+            return found
+    return None
+
+
+def find_app_executable(backend: str) -> str | None:
+    applications = Path("/Applications")
+    if not applications.exists():
+        return None
+    for pattern in BACKEND_APP_GLOBS.get(backend, []):
+        for path in sorted(applications.glob(pattern)):
+            if path.is_file():
+                return str(path)
+    return None
+
+
+def find_backend_executable(backend: str, *, search_path: str | None = None) -> str | None:
+    env_value = os.environ.get(BACKEND_ENV_VARS[backend], "").strip()
+    if env_value:
+        return env_value
+    return find_executable(BACKEND_EXECUTABLES[backend], search_path=search_path) or find_app_executable(backend)
+
+
+def discover_backends(*, search_path: str | None = None) -> list[BackendDiscovery]:
+    discoveries: list[BackendDiscovery] = []
+    for backend_id in PREFERRED_BACKEND_ORDER:
+        path = find_backend_executable(backend_id, search_path=search_path)
+        discoveries.append(
+            BackendDiscovery(
+                id=backend_id,
+                available=bool(path),
+                path=path or None,
+                preferred=True,
+            )
+        )
+    return discoveries
+
+
+def discover_bambu_studio(*, search_path: str | None = None) -> list[BackendDiscovery]:
+    paths: list[str] = []
+    env_value = os.environ.get("BAMBU_STUDIO_BIN", "").strip()
+    if env_value:
+        paths.append(env_value)
+    which_value = find_executable(BAMBU_EXECUTABLES, search_path=search_path)
+    if which_value:
+        paths.append(which_value)
+    applications = Path("/Applications")
+    if applications.exists():
+        for pattern in ("BambuStudio*.app/Contents/MacOS/BambuStudio", "Bambu Studio*.app/Contents/MacOS/BambuStudio"):
+            paths.extend(str(path) for path in applications.glob(pattern))
+
+    unique_paths = sorted(dict.fromkeys(paths))
+    if not unique_paths:
+        return [
+            BackendDiscovery(
+                id="bambu-studio",
+                available=False,
+                path=None,
+                preferred=False,
+                reason="not preferred because Bambu Studio CLI has shown macOS export instability",
+            )
+        ]
+    return [
+        BackendDiscovery(
+            id="bambu-studio",
+            available=True,
+            path=path,
+            preferred=False,
+            reason="available but not preferred because Bambu Studio CLI has shown macOS export instability",
+        )
+        for path in unique_paths
+    ]
+
+
+def discovery_report(*, search_path: str | None = None) -> dict[str, Any]:
+    backends = discover_backends(search_path=search_path)
+    not_preferred = discover_bambu_studio(search_path=search_path)
+    return {
+        "preferred_order": PREFERRED_BACKEND_ORDER,
+        "backends": [asdict(item) for item in backends],
+        "not_preferred": [asdict(item) for item in not_preferred],
+    }
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError as exc:
+        raise GCodeToolError(f"Profile does not exist: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise GCodeToolError(f"Profile is not valid JSON: {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise GCodeToolError("Profile JSON must be an object.")
+    return data
+
+
+def require_number(value: Any, label: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise GCodeToolError(f"Profile field {label} must be a number.")
+    number = float(value)
+    if number <= 0:
+        raise GCodeToolError(f"Profile field {label} must be greater than zero.")
+    return number
+
+
+def require_absolute_file(path_value: str, label: str) -> str:
+    profile_path = Path(path_value).expanduser()
+    if not profile_path.is_absolute():
+        raise GCodeToolError(f"Profile field {label} must be an absolute path.")
+    if not profile_path.is_file():
+        raise GCodeToolError(f"Profile {label} does not exist: {profile_path}")
+    return str(profile_path)
+
+
+def optional_path_list(data: dict[str, Any], field: str) -> tuple[str, ...]:
+    value = data.get(field)
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, list) and all(isinstance(item, str) for item in value):
+        values = value
+    else:
+        raise GCodeToolError(f"Profile field {field} must be a string path or list of string paths.")
+    paths = [item.strip() for item in values if item.strip()]
+    if not paths:
+        raise GCodeToolError(f"Profile field {field} cannot be empty when provided.")
+    return tuple(require_absolute_file(path, field) for path in paths)
+
+
+def parse_axis_bounds(value: Any, label: str) -> tuple[float, float]:
+    if (
+        not isinstance(value, list)
+        or len(value) != 2
+        or any(isinstance(item, bool) or not isinstance(item, (int, float)) for item in value)
+    ):
+        raise GCodeToolError(f"Profile field {label} must be [min, max].")
+    lower = float(value[0])
+    upper = float(value[1])
+    if lower >= upper:
+        raise GCodeToolError(f"Profile field {label} must have min less than max.")
+    return lower, upper
+
+
+def load_profile(path: Path) -> GCodeProfile:
+    data = load_json(path)
+    backend = str(data.get("backend") or "").strip().lower()
+    if backend not in PREFERRED_BACKEND_ORDER:
+        raise GCodeToolError(f"Profile backend must be one of: {', '.join(PREFERRED_BACKEND_ORDER)}.")
+
+    native_config = str(data.get("native_config") or "").strip()
+    if not native_config:
+        raise GCodeToolError("Profile field native_config is required.")
+    native_config = require_absolute_file(native_config, "native_config")
+    native_settings = optional_path_list(data, "native_settings") or (native_config,)
+    native_filaments = optional_path_list(data, "native_filaments")
+
+    machine = data.get("machine")
+    if not isinstance(machine, dict):
+        raise GCodeToolError("Profile field machine must be an object.")
+    machine_name = str(machine.get("name") or "").strip()
+    if not machine_name:
+        raise GCodeToolError("Profile field machine.name is required.")
+    bed_size = machine.get("bed_size_mm")
+    if (
+        not isinstance(bed_size, list)
+        or len(bed_size) != 2
+        or any(isinstance(item, bool) or not isinstance(item, (int, float)) for item in bed_size)
+    ):
+        raise GCodeToolError("Profile field machine.bed_size_mm must be [width, depth].")
+    bed_x = require_number(bed_size[0], "machine.bed_size_mm[0]")
+    bed_y = require_number(bed_size[1], "machine.bed_size_mm[1]")
+    z_height = require_number(machine.get("z_height_mm"), "machine.z_height_mm")
+    motion_bounds = {
+        "x": (0.0, bed_x),
+        "y": (0.0, bed_y),
+        "z": (0.0, z_height),
+    }
+    if "motion_bounds_mm" in machine:
+        raw_bounds = machine.get("motion_bounds_mm")
+        if not isinstance(raw_bounds, dict):
+            raise GCodeToolError("Profile field machine.motion_bounds_mm must be an object.")
+        for axis in ("x", "y", "z"):
+            if axis in raw_bounds:
+                motion_bounds[axis] = parse_axis_bounds(raw_bounds[axis], f"machine.motion_bounds_mm.{axis}")
+
+    filament = data.get("filament")
+    if not isinstance(filament, dict):
+        raise GCodeToolError("Profile field filament must be an object.")
+    filament_type = str(filament.get("type") or "").strip()
+    if not filament_type:
+        raise GCodeToolError("Profile field filament.type is required.")
+    nozzle_temp = require_number(filament.get("nozzle_temp_c"), "filament.nozzle_temp_c")
+    bed_temp = require_number(filament.get("bed_temp_c"), "filament.bed_temp_c")
+
+    return GCodeProfile(
+        backend=backend,
+        native_config=native_config,
+        native_settings=native_settings,
+        native_filaments=native_filaments,
+        machine_name=machine_name,
+        bed_size_mm=(bed_x, bed_y),
+        z_height_mm=z_height,
+        motion_bounds_mm=motion_bounds,
+        filament_type=filament_type,
+        nozzle_temp_c=nozzle_temp,
+        bed_temp_c=bed_temp,
+    )
+
+
+def is_sliced_bambu_3mf(path: Path) -> bool:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            return any(SLICED_BAMBU_PLATE_RE.match(info.filename) for info in archive.infolist())
+    except zipfile.BadZipFile:
+        return False
+
+
+def inspect_input(path: Path) -> InputInspection:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise GCodeToolError(f"Input file does not exist: {resolved}")
+
+    extension = resolved.suffix.lower()
+    remediation = UNSUPPORTED_INPUT_REMEDIATION.get(extension)
+    if remediation is not None:
+        supported = ", ".join(sorted(DIRECT_MESH_EXTENSIONS | CONVERT_TO_STL_EXTENSIONS))
+        raise GCodeToolError(
+            f"{extension} is out of scope for this skill. Supported v1 mesh inputs: {supported}. "
+            f"{remediation['reason']} {remediation['next_step']}",
+            details={"remediation": {"extension": extension, **remediation}},
+        )
+    if extension not in DIRECT_MESH_EXTENSIONS | CONVERT_TO_STL_EXTENSIONS:
+        supported = ", ".join(sorted(DIRECT_MESH_EXTENSIONS | CONVERT_TO_STL_EXTENSIONS))
+        raise GCodeToolError(f"Unsupported input extension {extension or '<none>'}. Supported v1 mesh inputs: {supported}.")
+
+    already_sliced = extension == ".3mf" and is_sliced_bambu_3mf(resolved)
+    if already_sliced:
+        status = "already_sliced_bambu_3mf"
+    elif extension in DIRECT_MESH_EXTENSIONS:
+        status = "direct_to_slicer"
+    else:
+        status = "requires_stl_conversion"
+
+    return InputInspection(
+        path=str(resolved),
+        extension=extension,
+        size_bytes=resolved.stat().st_size,
+        supported=True,
+        direct_to_slicer=extension in DIRECT_MESH_EXTENSIONS and not already_sliced,
+        needs_stl_conversion=extension in CONVERT_TO_STL_EXTENSIONS,
+        already_sliced_bambu=already_sliced,
+        status=status,
+    )
+
+
+def backend_path(backend: str, *, search_path: str | None = None) -> str:
+    path = find_backend_executable(backend, search_path=search_path)
+    if not path:
+        names = ", ".join(BACKEND_EXECUTABLES[backend])
+        raise GCodeToolError(f"Backend {backend} is not installed or not on PATH. Checked: {names}.")
+    return path
+
+
+def build_backend_command(
+    *,
+    backend: str,
+    executable: str,
+    slicer_input: Path,
+    output: Path,
+    profile: GCodeProfile,
+) -> list[str]:
+    if backend == "orcaslicer":
+        command = [
+            executable,
+            "--load-settings",
+            ";".join(profile.native_settings),
+        ]
+        if profile.native_filaments:
+            command.extend(["--load-filaments", ";".join(profile.native_filaments)])
+        command.extend(
+            [
+                "--outputdir",
+                str(output.parent),
+                "--slice",
+                "0",
+                str(slicer_input),
+            ]
+        )
+        return command
+    if backend == "prusa-slicer":
+        return [
+            executable,
+            "--load",
+            profile.native_config,
+            "--export-gcode",
+            "--output",
+            str(output),
+            str(slicer_input),
+        ]
+    if backend == "curaengine":
+        return [
+            executable,
+            "slice",
+            "-j",
+            profile.native_config,
+            "-l",
+            str(slicer_input),
+            "-o",
+            str(output),
+        ]
+    raise GCodeToolError(f"Unsupported backend: {backend}")
+
+
+def generated_gcode_candidate(output: Path, slicer_input: Path, existing_gcodes: set[Path]) -> Path | None:
+    expected_by_input = output.parent / f"{slicer_input.stem}.gcode"
+    if expected_by_input.is_file() and expected_by_input.resolve() != output.resolve():
+        return expected_by_input
+    generated = [
+        path
+        for path in output.parent.glob("*.gcode")
+        if path.resolve() not in existing_gcodes and path.resolve() != output.resolve()
+    ]
+    if len(generated) == 1:
+        return generated[0]
+    return None
+
+
+def build_slice_plan(args: argparse.Namespace, *, search_path: str | None = None, converted_input: Path | None = None) -> dict[str, Any]:
+    profile = load_profile(Path(args.profile).expanduser())
+    inspection = inspect_input(Path(args.input))
+    if inspection.already_sliced_bambu:
+        raise GCodeToolError("Input is already a sliced Bambu .gcode.3mf. Refusing to re-slice it.")
+
+    backend = profile.backend if args.backend == "auto" else args.backend
+    if backend not in PREFERRED_BACKEND_ORDER:
+        raise GCodeToolError(f"Backend must be auto or one of: {', '.join(PREFERRED_BACKEND_ORDER)}.")
+    executable = backend_path(backend, search_path=search_path)
+
+    input_path = Path(inspection.path)
+    slicer_input = converted_input or input_path
+    if inspection.needs_stl_conversion and converted_input is None:
+        slicer_input = Path(tempfile.gettempdir()) / f"{input_path.stem}.converted.stl"
+    output = Path(args.output).expanduser().resolve()
+    command = build_backend_command(
+        backend=backend,
+        executable=executable,
+        slicer_input=slicer_input,
+        output=output,
+        profile=profile,
+    )
+
+    return {
+        "dry_run": not args.execute,
+        "backend": backend,
+        "executable": executable,
+        "command": command,
+        "input": asdict(inspection),
+        "output": str(output),
+        "profile": asdict(profile),
+        "conversion": {
+            "required": inspection.needs_stl_conversion,
+            "slicer_input": str(slicer_input),
+            "note": "Requires trimesh at execution time." if inspection.needs_stl_conversion else "",
+        },
+    }
+
+
+def convert_mesh_to_stl(input_path: Path, output_path: Path) -> None:
+    try:
+        import trimesh  # type: ignore
+    except ImportError as exc:
+        raise GCodeToolError(
+            "trimesh is required to convert .ply/.glb/.gltf inputs to temporary STL. "
+            "Install it in the active Python environment or provide .stl/.obj/.3mf directly."
+        ) from exc
+
+    loaded = trimesh.load(str(input_path))
+    if getattr(loaded, "is_empty", False):
+        raise GCodeToolError(f"Input mesh appears empty: {input_path}")
+    if hasattr(loaded, "dump"):
+        mesh = loaded.dump(concatenate=True)
+    else:
+        mesh = loaded
+    if getattr(mesh, "is_empty", False):
+        raise GCodeToolError(f"Input mesh appears empty after scene conversion: {input_path}")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    mesh.export(str(output_path), file_type="stl")
+
+
+def execute_slice(args: argparse.Namespace, *, search_path: str | None = None) -> tuple[int, dict[str, Any]]:
+    input_inspection = inspect_input(Path(args.input))
+    output = Path(args.output).expanduser().resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="gcode-slice-") as tmp:
+        converted_input = None
+        if input_inspection.needs_stl_conversion:
+            converted_input = Path(tmp) / f"{Path(input_inspection.path).stem}.stl"
+            convert_mesh_to_stl(Path(input_inspection.path), converted_input)
+        plan = build_slice_plan(args, search_path=search_path, converted_input=converted_input)
+        slicer_input = Path(plan["conversion"]["slicer_input"])
+        existing_gcodes = {path.resolve() for path in output.parent.glob("*.gcode")}
+        result = subprocess.run(plan["command"], check=False, capture_output=True, text=True)
+
+    plan["returncode"] = result.returncode
+    if result.stdout:
+        plan["stdout_tail"] = tail_text(result.stdout)
+    if result.stderr:
+        plan["stderr_tail"] = tail_text(result.stderr)
+    if result.returncode != 0:
+        return result.returncode, plan
+    if not output.is_file():
+        candidate = generated_gcode_candidate(output, slicer_input, existing_gcodes)
+        if candidate is None:
+            plan["error"] = "Slicer exited successfully but did not create the requested output file."
+            return 1, plan
+        candidate.replace(output)
+        plan["renamed_output_from"] = str(candidate)
+    plan["generated"] = {"path": str(output), "size_bytes": output.stat().st_size}
+    return 0, plan
+
+
+def strip_gcode_comment(line: str) -> str:
+    return line.split(";", 1)[0].strip()
+
+
+def parse_command(line: str) -> str:
+    stripped = strip_gcode_comment(line)
+    if not stripped:
+        return ""
+    first = stripped.split(None, 1)[0].upper()
+    return first
+
+
+def parse_numeric_tokens(line: str) -> dict[str, float]:
+    stripped = strip_gcode_comment(line).upper()
+    tokens: dict[str, float] = {}
+    for key, value in re.findall(r"([A-Z])([-+]?(?:\d+(?:\.\d*)?|\.\d+))", stripped):
+        try:
+            tokens[key] = float(value)
+        except ValueError:
+            continue
+    return tokens
+
+
+def validate_gcode_file(path: Path, profile: GCodeProfile) -> dict[str, Any]:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise GCodeToolError(f"G-code file does not exist: {resolved}")
+    text = resolved.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    errors: list[str] = []
+    warnings: list[str] = []
+    unknown_commands: dict[str, int] = {}
+    stats = {
+        "lines": len(lines),
+        "non_comment_lines": 0,
+        "movement_commands": 0,
+        "extrusion_moves": 0,
+        "temperature_commands": 0,
+    }
+
+    if not text.strip():
+        errors.append("G-code file is empty.")
+
+    absolute_positioning = True
+    extruder_absolute_positioning = True
+    extruder_position = 0.0
+    x_min, x_max = profile.motion_bounds_mm["x"]
+    y_min, y_max = profile.motion_bounds_mm["y"]
+    z_min, z_max = profile.motion_bounds_mm["z"]
+    for line_number, line in enumerate(lines, start=1):
+        command = parse_command(line)
+        if not command:
+            continue
+        stats["non_comment_lines"] += 1
+        tokens = parse_numeric_tokens(line)
+
+        if command not in SUPPORTED_GCODE_COMMANDS and not re.fullmatch(r"T\d+", command):
+            unknown_commands.setdefault(command, line_number)
+
+        if command == "G90":
+            absolute_positioning = True
+            extruder_absolute_positioning = True
+        elif command == "G91":
+            absolute_positioning = False
+            extruder_absolute_positioning = False
+            if "Relative positioning found; XYZ bounds validation is skipped while relative mode is active." not in warnings:
+                warnings.append("Relative positioning found; XYZ bounds validation is skipped while relative mode is active.")
+        elif command == "M82":
+            extruder_absolute_positioning = True
+        elif command == "M83":
+            extruder_absolute_positioning = False
+        elif command == "G92" and "E" in tokens:
+            extruder_position = tokens["E"]
+
+        if command in {"G0", "G1", "G2", "G3"}:
+            stats["movement_commands"] += 1
+            if "E" in tokens:
+                next_extruder_position = tokens["E"] if extruder_absolute_positioning else extruder_position + tokens["E"]
+                if next_extruder_position > extruder_position:
+                    stats["extrusion_moves"] += 1
+                extruder_position = next_extruder_position
+            if absolute_positioning:
+                if "X" in tokens and not x_min <= tokens["X"] <= x_max:
+                    errors.append(f"Line {line_number}: X={tokens['X']} is outside X motion range {x_min}..{x_max} mm.")
+                if "Y" in tokens and not y_min <= tokens["Y"] <= y_max:
+                    errors.append(f"Line {line_number}: Y={tokens['Y']} is outside Y motion range {y_min}..{y_max} mm.")
+                if "Z" in tokens and not z_min <= tokens["Z"] <= z_max:
+                    errors.append(f"Line {line_number}: Z={tokens['Z']} is outside Z motion range {z_min}..{z_max} mm.")
+        if command in {"M104", "M109", "M140", "M190"}:
+            stats["temperature_commands"] += 1
+
+    if stats["movement_commands"] == 0:
+        errors.append("No G0/G1/G2/G3 movement commands found.")
+    if stats["extrusion_moves"] == 0:
+        errors.append("No extrusion moves found.")
+    if stats["temperature_commands"] == 0:
+        errors.append("No nozzle or bed temperature commands found.")
+    if unknown_commands:
+        sample = ", ".join(f"{cmd} line {line}" for cmd, line in sorted(unknown_commands.items())[:12])
+        warnings.append(f"Unknown or unsupported commands were left unchanged: {sample}.")
+
+    return {
+        "ok": not errors,
+        "path": str(resolved),
+        "profile": asdict(profile),
+        "errors": errors,
+        "warnings": warnings,
+        "stats": stats,
+    }
+
+
+def print_json(payload: Any) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def discover_main(args: argparse.Namespace) -> int:
+    print_json(discovery_report(search_path=args.search_path))
+    return 0
+
+
+def inspect_main(args: argparse.Namespace) -> int:
+    inspection = inspect_input(Path(args.input))
+    payload = asdict(inspection)
+    if args.json:
+        print_json(payload)
+    else:
+        print(f"{payload['status']}: {payload['path']}")
+    return 0
+
+
+def slice_main(args: argparse.Namespace) -> int:
+    if args.execute and args.dry_run:
+        raise GCodeToolError("--execute and --dry-run cannot be used together.")
+    if not args.execute:
+        plan = build_slice_plan(args, search_path=args.search_path)
+        plan["dry_run"] = True
+        print_json(plan)
+        return 0
+
+    code, result = execute_slice(args, search_path=args.search_path)
+    result["dry_run"] = False
+    print_json(result)
+    return code
+
+
+def validate_main(args: argparse.Namespace) -> int:
+    profile = load_profile(Path(args.profile).expanduser())
+    result = validate_gcode_file(Path(args.gcode), profile)
+    if args.json:
+        print_json(result)
+    else:
+        status = "ok" if result["ok"] else "failed"
+        print(f"Validation {status}: {result['path']}")
+        for error in result["errors"]:
+            print(f"error: {error}")
+        for warning in result["warnings"]:
+            print(f"warning: {warning}")
+    return 0 if result["ok"] else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    discover = subparsers.add_parser("discover", help="Report installed slicer backends.")
+    discover.add_argument("--search-path", help=argparse.SUPPRESS)
+    discover.set_defaults(func=discover_main)
+
+    inspect = subparsers.add_parser("inspect", help="Classify a mesh input before slicing.")
+    inspect.add_argument("--input", required=True)
+    inspect.add_argument("--json", action="store_true")
+    inspect.set_defaults(func=inspect_main)
+
+    slice_parser = subparsers.add_parser("slice", help="Build or run a slicer CLI command.")
+    slice_parser.add_argument("--input", required=True)
+    slice_parser.add_argument("--output", required=True)
+    slice_parser.add_argument("--profile", required=True)
+    slice_parser.add_argument("--backend", default="auto", choices=["auto", *PREFERRED_BACKEND_ORDER])
+    slice_parser.add_argument("--dry-run", action="store_true", help="Print the planned slicer command without running it.")
+    slice_parser.add_argument("--execute", action="store_true", help="Run the slicer command and write local .gcode.")
+    slice_parser.add_argument("--search-path", help=argparse.SUPPRESS)
+    slice_parser.set_defaults(func=slice_main)
+
+    validate = subparsers.add_parser("validate", help="Statically validate generated G-code.")
+    validate.add_argument("--gcode", required=True)
+    validate.add_argument("--profile", required=True)
+    validate.add_argument("--json", action="store_true")
+    validate.set_defaults(func=validate_main)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except GCodeToolError as exc:
+        payload: dict[str, Any] = {"ok": False, "error": str(exc)}
+        payload.update(exc.details)
+        print_json(payload)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.qwenpaw-plugin/skills/sdf/LICENSE
+++ b/.qwenpaw-plugin/skills/sdf/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thompson Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.qwenpaw-plugin/skills/sdf/SKILL.md
+++ b/.qwenpaw-plugin/skills/sdf/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: sdf
+description: SDFormat/SDF model and world authoring, validation, and simulator handoff. Use for `.sdf` files, SDFormat XML, models, worlds, links, joints, poses, frames, inertials, visual/collision geometry, mesh URIs, sensors, lights, physics, plugins, includes, Gazebo, static SDF review, or simulator-specific metadata. Do not use for signed-distance-field geometry.
+---
+
+# SDF
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review.
+
+Use this skill when the deliverable is an SDFormat document. SDFormat describes simulator and world behavior: models, worlds, frames, poses, links, joints, inertials, visuals, collisions, sensors, lights, physics, plugins, includes, and simulator metadata.
+
+This skill is for **SDFormat**, not signed-distance-field geometry.
+
+The `.sdf` file is the source of truth: author and edit the XML directly. There is no `gen_sdf()` contract.
+
+## Setup
+
+This skill's commands are thin entrypoints over the `cadgen` distribution, which
+carries the Python build runtime and the JavaScript it executes. Install it once:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+Rendering additionally needs a browser, which pip cannot supply:
+
+```bash
+python -m playwright install chromium
+```
+
+## Core rules
+
+1. Author `.sdf` XML directly and validate every created or modified file with `cadgen sdf validate` before reporting completion.
+2. Identify the target consumer before editing: Gazebo/libsdformat version, another simulator, visualization-only tooling, model package, or world handoff.
+3. Decide document kind: model-level SDF, world-level SDF, or model-in-world. Prefer model-level SDF for reusable robot/object exports.
+4. Use SI units unless the target explicitly requires otherwise: meters, kilograms, seconds, radians.
+5. Prefer `version="1.12"` for new outputs unless the target consumer constrains the version.
+6. Establish the design ledger before writing poses, frames, joint axes, mesh scales, inertials, sensors, or plugins, and keep it as a comment block at the top of the `.sdf`. Use `references/design-ledger.md` and `references/llm-guardrails.md`.
+7. Write `relative_to` / `expressed_in` explicitly on every nontrivial pose and axis. Implicit frame defaults are the top SDF failure mode. See `references/frame-semantics.md`.
+8. Do not infer spatial transforms from visual impression alone. Derive poses, axes, scale, mass, inertia, and frame names from upstream source data, drawings, simulator documentation, measured values, or explicit assumptions. Never freehand computed numbers — use formulas or a throwaway helper script (inertia tensors, unit conversions).
+9. When the robot already has a URDF, derive the SDF from it instead of re-authoring geometry; see `references/interoperability.md`.
+10. Regenerate upstream geometry, mesh, robot-description, render, topology, or package assets with their owning workflows before editing SDF that references them.
+11. After authoring, run available checks: bundled validation, optional `gz sdf --check`, simulator load, joint motion, and plugin/sensor startup.
+12. Report assumptions, skipped checks, unresolved resource paths, and target-specific compatibility risks.
+
+## Scope
+
+Use this skill for SDFormat outputs. Do not use it for signed-distance-field modeling, raw geometry generation, planning semantics, or to paper over incorrect upstream robot/source data unless the task is explicitly simulator-only.
+
+## CAD Viewer Handoff
+
+After completing SDF work that creates or modifies a `.sdf`, you must ALWAYS hand the explicit file path to `$cad-viewer` when that skill is installed. `$cad-viewer` must start CAD Viewer if it is not already running and return link(s) to the relevant created or updated file(s); if `$cad-viewer` is unavailable or startup fails, report that instead of silently omitting the handoff.
+
+## Workflow
+
+1. Locate the target `.sdf` and its consumers.
+2. Read or create the design ledger comment block.
+3. Read `references/frame-semantics.md` before editing any `<pose>`, `<frame>`, joint axis, `relative_to`, `expressed_in`, nested scope, sensor frame, or plugin frame.
+4. Author the XML directly, following the worked examples in `references/examples.md`.
+5. Validate the explicit target with `cadgen sdf validate`; treat bundled validation as a guardrail, not simulator proof.
+6. Run target-consumer smoke tests when available (`references/smoke-tests.md`).
+7. Hand the file to `$cad-viewer`. Static rendering does not execute SDF plugins or read file-authored motion metadata.
+8. Report checks run, checks skipped, and assumptions.
+
+## Commands
+
+Run with the project or workspace Python environment. Treat `python` in examples as an interpreter placeholder; if bare `python` is unavailable, substitute `python3`, a project virtualenv interpreter, or the configured interpreter path. The validator uses only the Python standard library.
+
+```bash
+cadgen sdf validate path/to/model.sdf
+cadgen sdf validate path/to/model.sdf --strict
+cadgen sdf validate path/to/model.sdf --json
+cadgen sdf snapshot path/to/model.sdf review.png
+```
+
+The validator checks document shape, name scopes, pose/frame graphs, joints, geometry, mesh URIs, inertials, sensors, and plugins, and prints its findings plus a summary. One run validates ONE file: `--strict` treats warnings as failures and `--json` emits the machine-readable findings document. It exits nonzero if the target fails.
+
+Optional external checking:
+
+```bash
+cadgen sdf validate path/to/model.sdf --gz-check auto
+cadgen sdf validate path/to/model.sdf --gz-check required
+cadgen sdf validate path/to/model.sdf --gz-check never
+```
+
+`gz sdf --check` is optional target-consumer validation. It should be reported as skipped when unavailable unless explicitly required.
+
+## Required report shape
+
+When finishing an SDF task, include a compact report:
+
+```text
+Validated: path/to/model.sdf
+Checks run:
+- bundled SDF validation: passed
+- gz sdf --check: skipped, gz not installed
+- simulator load: skipped, target simulator unavailable
+- viewer handoff: `$cad-viewer` link returned
+Assumptions:
+- Assumed mesh units are meters.
+- Assumed lidar frame is coincident with lidar_link.
+Risks:
+- Camera plugin filename was not verified in the target simulator environment.
+```
+
+## Snapshot Tool
+
+`cadgen sdf snapshot` renders the robot to a PNG still, using the same shared
+CLI and headless browser runtime every rendering skill uses — so a snapshot matches what
+the CAD Viewer shows.
+
+```bash
+cadgen sdf snapshot path/to/robot.sdf review.png
+```
+
+It accepts `.sdf` only (a format door, same `TARGET [OUT]` grammar as the rest). Pose the robot with `--joint-values` — `{joint: degrees}` JSON,
+joints you do not name staying at the rest pose (the `"jointValues"` job field is the same
+thing in a packet). Robots are authored in metres and are framed on the robot scene scale
+automatically.
+
+Theme settings live under one `--theme`, mirroring the viewer's Theme tab. The default
+theme is `snapshot` — Workbench Light with the ground grid, origin axis and shadows
+removed, because in a still image those read as geometry. There is no `--display`: display
+settings (mode, clip, exploded, edges) are CAD topology settings, and a robot carries none.
+
+Link meshes are resolved relative to the description, so they must be present: an
+unhydrated Git LFS pointer fails as "No link mesh loaded for robot". Run
+`git lfs checkout <mesh dir>` first.
+
+The grammar is `cadgen sdf snapshot TARGET [OUT] [flags]`, the same one every
+format door uses. Use `cadgen sdf snapshot --help` for the complete current
+interface — the flags a robot cannot act on are absent from it, not refused by it.
+
+## References
+
+- SDF workflow: `references/sdf-workflow.md`
+- Worked examples (golden skeletons): `references/examples.md`
+- LLM guardrails: `references/llm-guardrails.md`
+- Design ledger: `references/design-ledger.md`
+- Frame semantics: `references/frame-semantics.md`
+- Validation scope: `references/validation.md`
+- Smoke tests: `references/smoke-tests.md`
+- Interoperability notes (URDF-derived SDF, meshes, Gazebo): `references/interoperability.md`

--- a/.qwenpaw-plugin/skills/sdf/agents/openai.yaml
+++ b/.qwenpaw-plugin/skills/sdf/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SDF"
+  short_description: "Author and validate SDFormat robot models."
+  default_prompt: "Use $sdf to author, update, and validate SDFormat/SDF robot or simulator models as direct XML, handing new or changed SDFs to $cad-viewer when available."

--- a/.qwenpaw-plugin/skills/sdf/references/design-ledger.md
+++ b/.qwenpaw-plugin/skills/sdf/references/design-ledger.md
@@ -1,0 +1,113 @@
+# SDF design ledger
+
+Create or update this ledger before writing SDF XML. The ledger's canonical home is a comment block at the top of the `.sdf` file itself, optionally expanded in an adjacent note for large worlds. The goal is to externalize spatial and simulator assumptions before they become hard-to-audit XML.
+
+## Document
+
+| Field | Value |
+|---|---|
+| SDF path | |
+| SDF version | `1.12` unless constrained |
+| Document kind | model / world / model-in-world |
+| Target consumer | Gazebo / other simulator / visualization-only / model package |
+| Units | meters, kilograms, seconds, radians unless documented otherwise |
+| Coordinate convention | REP-103-like / simulator-specific / documented exception |
+| World support needed | yes/no; reason |
+| Optional external checks | `gz sdf --check`, simulator load, CAD Viewer, other |
+
+## Model or world scope
+
+| Item | Value |
+|---|---|
+| Model/world name | |
+| Static or dynamic | |
+| Canonical link, if relevant | |
+| Model/world pose | xyz + rpy/quaternion |
+| Model/world pose `relative_to` | |
+| Includes | URI + purpose |
+| World physics/lights/plugins | source and target simulator |
+
+## Frames
+
+| Frame | Scope | Attached to | Pose | Pose `relative_to` | Purpose | Source |
+|---|---|---|---|---|---|---|
+| | | | | | | |
+
+Use named frames for clarity when multiple sensors, nested models, tool frames, plugin frames, or repeated transforms depend on the same relationship.
+
+## Links
+
+| Link | Physical / frame-like | Pose | Pose `relative_to` | Inertial source | Sensor/plugin attached | Notes |
+|---|---|---|---|---|---|---|
+| | | | | | | |
+
+Physical dynamic links need inertials. Frame-like links may omit inertials only when documented.
+
+## Joints
+
+| Joint | Type | Parent | Child | Pose | Pose frame / `relative_to` | Axis | Axis frame / `expressed_in` | Limits | Positive motion | Source |
+|---|---|---|---|---|---|---|---|---|---|---|
+| | | | | | | | | | | |
+
+For revolute and prismatic joints, record limit units: radians for revolute, meters for prismatic. Continuous joints should not be given artificial finite position limits unless a simulator-specific reason is documented.
+
+## Geometry
+
+| Owner | Visual/collision | Name | Geometry type | Pose | Pose `relative_to` | URI or dimensions | Mesh units | Scale | Source |
+|---|---|---|---|---|---|---|---|---|---|
+| | | | | | | | | | |
+
+Collision geometry should be selected for simulation cost and stability, not just visual similarity.
+
+## Inertials
+
+| Link | Mass | COM pose | Inertia tensor | Method/source | Confidence |
+|---|---|---|---|---|---|
+| | | | | | |
+
+Mark approximations clearly. Very small, zero, negative, or guessed inertias are high risk for simulation.
+
+## Sensors and plugins
+
+| Element | Parent | Pose/frame | Filename/type | Parameters | Source docs | Assumptions |
+|---|---|---|---|---|---|---|
+| | | | | | | |
+
+Do not invent plugin filenames, topics, frame names, namespaces, controller parameters, or update rates. Derive them from simulator documentation or user-provided configuration.
+
+## Mesh URI policy
+
+| URI kind | Allowed? | Resolution expectation | Notes |
+|---|---|---|---|
+| Relative local path | | Relative to the `.sdf` file location | |
+| `file://` | | Absolute local file | |
+| `model://` | | Simulator model path | |
+| `package://` | | Simulator/ROS package environment | |
+| `fuel://`, `http://`, `https://` | | External resource | |
+
+## Assumptions to report
+
+List every guessed or inferred value:
+
+- transform or pose;
+- axis sign or positive-motion convention;
+- mesh unit or scale;
+- mass, COM, or inertia;
+- target simulator behavior;
+- plugin parameter;
+- unresolved external URI;
+- skipped validation or smoke test.
+
+If a value cannot be derived or safely assumed, generate a minimal placeholder only when the user asked for a placeholder, and label it as such.
+
+## Compact response template
+
+```text
+SDF file: path/to/model.sdf
+Target consumer: Gazebo Harmonic, SDF 1.12
+Bundled validation: passed with 2 warnings
+External checks: gz sdf --check skipped, gz not installed
+Assumptions:
+- Assumed mesh units are meters.
+- Assumed camera optical frame follows simulator plugin documentation.
+```

--- a/.qwenpaw-plugin/skills/sdf/references/examples.md
+++ b/.qwenpaw-plugin/skills/sdf/references/examples.md
@@ -1,0 +1,141 @@
+# SDF examples
+
+These examples illustrate the intended authoring style: explicit `relative_to` frames, a ledger comment block, computed inertials with their formula named, and structured assumptions.
+
+## Minimal model
+
+```xml
+<?xml version="1.0"?>
+<!--
+  model: calibration_box | consumer: Gazebo Harmonic (SDF 1.12)
+  units: meters, kilograms, radians
+  inertials: uniform-density solid-box formula, m=1.0 kg
+  assumptions: uniform density; box is rigid
+-->
+<sdf version="1.12">
+  <model name="calibration_box">
+    <link name="body">
+      <inertial>
+        <mass>1.0</mass>
+        <!-- solid box 0.1^3: ixx=iyy=izz=m(a^2+a^2)/12 -->
+        <inertia>
+          <ixx>0.0016666667</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.0016666667</iyy>
+          <iyz>0</iyz>
+          <izz>0.0016666667</izz>
+        </inertia>
+      </inertial>
+      <visual name="body_visual">
+        <geometry>
+          <box><size>0.1 0.1 0.1</size></box>
+        </geometry>
+      </visual>
+      <collision name="body_collision">
+        <geometry>
+          <box><size>0.1 0.1 0.1</size></box>
+        </geometry>
+      </collision>
+    </link>
+  </model>
+</sdf>
+```
+
+## Minimal world
+
+```xml
+<?xml version="1.0"?>
+<!--
+  world: empty_lit_world | consumer: Gazebo Harmonic (SDF 1.12)
+  world intentionally contains no inline model
+-->
+<sdf version="1.12">
+  <world name="empty_lit_world">
+    <light name="sun" type="directional">
+      <pose relative_to="world">0 0 10 0 0 0</pose>
+      <cast_shadows>true</cast_shadows>
+    </light>
+  </world>
+</sdf>
+```
+
+## Two-link model with an explicit joint frame
+
+Note the explicit `relative_to` on every nontrivial pose, and the joint axis with explicit `expressed_in`:
+
+```xml
+<?xml version="1.0"?>
+<!--
+  model: two_link_demo | consumer: Gazebo Harmonic (SDF 1.12)
+  frames: base_link at model origin; arm_link placed by shoulder_pan joint
+  inertials: solid-box formulas at stated masses (base 2.0 kg, arm 0.5 kg)
+  assumptions: positive shoulder_pan rotates arm counterclockwise viewed from +Z
+-->
+<sdf version="1.12">
+  <model name="two_link_demo">
+    <link name="base_link">
+      <inertial>
+        <mass>2.0</mass>
+        <!-- solid box 0.4 x 0.3 x 0.1 -->
+        <inertia>
+          <ixx>0.0166667</ixx><ixy>0</ixy><ixz>0</ixz>
+          <iyy>0.0283333</iyy><iyz>0</iyz>
+          <izz>0.0416667</izz>
+        </inertia>
+      </inertial>
+      <visual name="base_visual">
+        <geometry><box><size>0.4 0.3 0.1</size></box></geometry>
+      </visual>
+      <collision name="base_collision">
+        <geometry><box><size>0.4 0.3 0.1</size></box></geometry>
+      </collision>
+    </link>
+    <link name="arm_link">
+      <pose relative_to="shoulder_pan">0 0 0 0 0 0</pose>
+      <inertial>
+        <mass>0.5</mass>
+        <!-- solid box 0.3 x 0.05 x 0.05 -->
+        <inertia>
+          <ixx>0.000208333</ixx><ixy>0</ixy><ixz>0</ixz>
+          <iyy>0.00385417</iyy><iyz>0</iyz>
+          <izz>0.00385417</izz>
+        </inertia>
+      </inertial>
+      <visual name="arm_visual">
+        <geometry><box><size>0.3 0.05 0.05</size></box></geometry>
+      </visual>
+      <collision name="arm_collision">
+        <geometry><box><size>0.3 0.05 0.05</size></box></geometry>
+      </collision>
+    </link>
+    <joint name="shoulder_pan" type="revolute">
+      <pose relative_to="base_link">0 0 0.05 0 0 0</pose>
+      <parent>base_link</parent>
+      <child>arm_link</child>
+      <axis>
+        <xyz expressed_in="base_link">0 0 1</xyz>
+        <limit>
+          <lower>-1.5708</lower>
+          <upper>1.5708</upper>
+        </limit>
+      </axis>
+    </joint>
+  </model>
+</sdf>
+```
+
+This uses the SDF 1.8+ frame-graph pattern: the joint pose is expressed relative to the parent link, and the child link's pose is `relative_to` the joint frame. That mirrors URDF semantics and makes URDF-derived SDF mechanical to audit.
+
+## Plugin block from documentation
+
+When a plugin block is copied from target simulator documentation, preserve its explicit parameters and cite the source in a comment:
+
+```xml
+<!-- Source: gz-sim diff_drive tutorial (Harmonic docs). Unverified in target env. -->
+<plugin name="example_control" filename="libexample_control.so">
+  <namespace>robot1</namespace>
+</plugin>
+```
+
+Do not invent plugin fields. If the documentation source is not available, mark the plugin as unverified in the ledger and the final report.

--- a/.qwenpaw-plugin/skills/sdf/references/frame-semantics.md
+++ b/.qwenpaw-plugin/skills/sdf/references/frame-semantics.md
@@ -1,0 +1,87 @@
+# SDF frame and pose semantics
+
+Use this reference before editing any SDF `<pose>`, `<frame>`, `<joint>`, `<axis>`, `<visual>`, `<collision>`, sensor, or plugin placement.
+
+## Core pose rules
+
+A typical SDF pose is:
+
+```xml
+<pose relative_to="some_frame">x y z roll pitch yaw</pose>
+```
+
+or, when using quaternion rotation:
+
+```xml
+<pose rotation_format="quat_xyzw" relative_to="some_frame">x y z qx qy qz qw</pose>
+```
+
+Rules to keep in mind:
+
+- The first three values are position.
+- With the default `rotation_format="euler_rpy"`, the pose has six values: `x y z roll pitch yaw`.
+- With `rotation_format="quat_xyzw"`, the pose has seven values: `x y z qx qy qz qw`.
+- Euler angles are radians by default. `degrees="true"` is valid SDF but should be avoided unless the target explicitly requires it.
+- `relative_to` names the frame in which the pose is expressed.
+- If `relative_to` is omitted, SDF applies element-specific defaults, commonly the frame of the parent XML element. This may be valid but is easy to misread. Prefer explicit `relative_to` for every nontrivial pose.
+- Nested scopes may use `::`, for example `outer_model::inner_model::sensor_frame`.
+
+## Joint pose and axes
+
+For SDF joints:
+
+- `<parent>` names the parent frame or `world`.
+- `<child>` names the child frame; `world` is not valid as the child.
+- Joint pose defaults are easy to misinterpret. Use explicit `<pose relative_to="...">` when the joint frame is not obviously the child-link frame.
+- `<axis><xyz>...</xyz></axis>` is the unit axis vector.
+- An axis is expressed in the joint frame unless the axis `expressed_in` attribute specifies another frame.
+- `axis2` is used for multi-axis joints such as `revolute2` and `universal`.
+- Axis vectors should be finite, nonzero, and normalized.
+
+Record the expected positive motion in the design ledger. Example: “positive shoulder_pan rotates the arm counterclockwise when viewed from +Z.”
+
+## Visual and collision poses
+
+A `<visual>` or `<collision>` pose places that geometry owner relative to its parent frame unless `relative_to` says otherwise. In ordinary model-level use, that parent is the link frame.
+
+Do not use visual offsets to hide a wrong link or joint frame. If a mesh needs an offset because the mesh asset origin is not the link frame, record that fact in the geometry table.
+
+## Named frames
+
+Use `<frame>` when a reusable transform is meaningful:
+
+```xml
+<frame name="camera_optical_frame" attached_to="camera_link">
+  <pose relative_to="camera_link">0 0 0 -1.57079632679 0 -1.57079632679</pose>
+</frame>
+```
+
+Frames are useful for sensors, plugins, tool frames, nested models, and repeated placement logic. They also make SDF more auditable.
+
+`attached_to` and `relative_to` are different:
+
+- `attached_to` says what the frame moves with.
+- `relative_to` says how the frame's pose numbers are represented.
+
+The `attached_to` chain should not cycle and should eventually resolve to a link, model, world, joint, or another valid frame target.
+
+## LLM guardrails
+
+Do not infer any of the following from prose alone:
+
+- sign of a joint axis;
+- frame in which an axis is expressed;
+- RPY order or units;
+- mesh origin convention;
+- `relative_to` frame;
+- nested-scope reference;
+- sensor optical-frame transform;
+- plugin frame/topic semantics.
+
+When data is missing, either ask for the source data or write an explicitly labeled assumption.
+
+## Useful official references
+
+- SDFormat pose semantics: `https://sdformat.org/tutorials?tut=pose_frame_semantics`
+- SDFormat pose fields: `https://sdformat.org/spec/1.12/world/`
+- SDFormat joint element: `https://sdformat.org/spec/1.12/joint/`

--- a/.qwenpaw-plugin/skills/sdf/references/interoperability.md
+++ b/.qwenpaw-plugin/skills/sdf/references/interoperability.md
@@ -1,0 +1,78 @@
+# SDF interoperability notes
+
+Use this reference when SDF work touches upstream geometry, robot-description data, Gazebo/libsdformat, model packages, or CAD Viewer.
+
+## Geometry assets
+
+SDF should reference geometry and mesh assets; it should not regenerate them.
+
+When SDF references exported mesh assets, record:
+
+- source geometry file;
+- exported mesh path;
+- mesh unit convention;
+- mesh origin convention;
+- visual scale;
+- collision simplification decision.
+
+Regenerate geometry and mesh artifacts with their owning workflow before regenerating SDF if geometry changed.
+
+## Robot descriptions
+
+Keep the simulator document aligned with the upstream robot-description source when one exists.
+
+**Derive, don't re-author.** When a robot already has a URDF, the SDF model for that robot is derived from it: same link/joint names, same tree, same limits, same inertials, same mesh assets. Translate mechanically — URDF joint `<origin>` becomes the SDF joint `<pose relative_to="parent_link">`, and each child link gets `<pose relative_to="joint_name">0 0 0 0 0 0</pose>` — or use `gz sdf -p robot.urdf` as a starting point when Gazebo tooling is available, then review its output against this skill's contract. Independently re-authoring the same robot in SDF creates divergence that no validator catches. Record the source URDF (path and revision) in the SDF ledger comment.
+
+Upstream robot-description data usually owns:
+
+- link and joint structure used by robot-state publishing;
+- physical joint limits;
+- inertials and visual/collision geometry when that source is authoritative;
+- control-related structure and runtime interfaces.
+
+Use SDF for simulator/world concerns:
+
+- simulator plugins;
+- sensors requiring simulator-specific XML;
+- surfaces/contact/friction;
+- lights, terrain, physics, and worlds;
+- nested models and includes;
+- simulator-specific metadata.
+
+Do not use SDF to paper over a wrong upstream frame tree unless the task explicitly targets a simulator-only model.
+
+## Planning metadata
+
+SDF should not define planning groups, end-effectors, group states, or disabled-collision matrices. If the task becomes IK or path-planning work, use the planning metadata workflow that owns those semantics.
+
+## CAD Viewer
+
+CAD Viewer can review `.sdf` files visually through `$cad-viewer` and help catch gross placement or resource issues. It cannot prove simulator dynamics, inertial validity, plugin loading, sensor topics, or joint-axis semantics.
+
+Pass explicit new or modified `.sdf` paths to `$cad-viewer` whenever it is available, and return the live viewer link it prints.
+
+CAD Viewer renders SDF as static structure plus direct inspection controls. It lists plugins, sensors, lights, includes, and nested models as metadata, but does not execute plugins or consume file-authored motion contracts.
+
+## Gazebo / libsdformat
+
+The bundled validator is a lightweight preflight check. Use the target simulator's parser and loader when compatibility matters.
+
+Good checks include:
+
+```bash
+gz sdf --check path/to/model.sdf
+```
+
+and a real simulator load in the target environment.
+
+## Model packages and URIs
+
+SDF resource resolution is environment-dependent. Record which URI forms the target consumer can resolve:
+
+- relative paths from the `.sdf` file location;
+- `model://` paths under the simulator model path;
+- `package://` paths under ROS/package resolution;
+- `fuel://` resources;
+- `http://` or `https://` assets if external fetches are allowed.
+
+The bundled validator can confirm local relative paths, but it cannot prove external simulator resource paths unless the target environment is available.

--- a/.qwenpaw-plugin/skills/sdf/references/llm-guardrails.md
+++ b/.qwenpaw-plugin/skills/sdf/references/llm-guardrails.md
@@ -1,0 +1,107 @@
+# LLM guardrails for SDF authoring
+
+This skill assumes agents are useful at structuring SDFormat documents and weak at silently deriving precise spatial, physical, and simulator-specific values. The workflow should route those weaknesses into explicit ledgers, constants, helpers, validators, and smoke tests.
+
+## What agents can usually do well
+
+- organize an SDF model or world into links, joints, frames, visuals, collisions, sensors, plugins, and includes;
+- translate user intent into a plausible document structure;
+- maintain naming consistency when names are explicit;
+- write small throwaway Python scripts for derived numbers and transformations;
+- explain assumptions and create checklists;
+- preserve existing patterns when examples are nearby.
+
+## What agents should not be trusted to infer silently
+
+- exact link poses, frame transforms, or joint origins;
+- positive joint-axis directions from visual theme;
+- mesh units, mesh scale, or coordinate-system conventions;
+- center of mass or inertia tensors from rendered shape alone;
+- plugin filenames, parameters, topics, namespaces, or sensor schemas;
+- whether a plugin is a simulator runtime plugin or a CAD Viewer visualization-only extension;
+- target simulator support for a given SDFormat version or extension;
+- whether collision geometry is stable for physics;
+- whether external URIs resolve in the deployment environment.
+
+## Required mitigation pattern
+
+For every spatial, physical, or simulator-specific value, use one of these sources:
+
+1. user-provided requirement;
+2. upstream geometry, robot-description, planning-metadata, mesh manifest, or model package source;
+3. target simulator documentation;
+4. measured or calculated value with method stated;
+5. explicit assumption recorded in the ledger comment block and the final report.
+
+Do not hide guessed values in raw XML: every non-obvious number carries a comment or a ledger line naming its source.
+
+## Placeholder policy
+
+Placeholders are allowed only when the user asks for a scaffold, draft, or minimal example. Mark them as placeholders and keep them easy to replace.
+
+Examples of acceptable placeholders:
+
+```xml
+<!-- placeholder_inertial: primitive approximation pending measured mass properties -->
+<inertial>
+  <mass>0.5</mass>
+  ...
+</inertial>
+```
+
+Examples of unacceptable placeholders:
+
+- invented plugin filenames;
+- adding CAD Viewer-only motion plugins to SDF files;
+- arbitrary inertia values on a dynamic robot without a warning;
+- guessed mesh scale that makes the visual look plausible;
+- silently flipping a joint axis to match an expected screenshot.
+
+## Spatial reasoning checklist
+
+Before generating or modifying SDF, answer these questions in the ledger or final report:
+
+| Question | Required evidence |
+|---|---|
+| What frame is each pose expressed in? | `relative_to`, source file, or documented default |
+| What frame is each joint axis expressed in? | `expressed_in` or documented default |
+| What is positive motion for each non-fixed joint? | command/test expectation or upstream source |
+| Are mesh units and scales known? | manifest, CAD export config, or explicit assumption |
+| Are visual and collision poses intentionally different? | simulation reason or source geometry |
+| Are inertials measured, calculated, approximated, or omitted? | method and confidence |
+| Are plugin and sensor parameters copied from target docs? | target simulator/version and source |
+
+## Authoring style
+
+Prefer this pattern:
+
+```xml
+<!-- Source: project CAD frame export 2026-05-12. RPY radians. -->
+<pose relative_to="base_link">0.18 0 0.12 0 -0.2 0</pose>
+```
+
+Avoid this pattern:
+
+```xml
+<pose>0.18 0 .12 0 -11.5 0</pose>
+```
+
+The second version omits the frame, uses degrees without saying so, and makes the source of the transform impossible to audit.
+
+## Validation expectations
+
+The validator should catch cheap deterministic mistakes, but it cannot prove the design is physically or simulator-correct. After bundled validation, use optional external checks and simulator smoke tests when the task depends on simulator behavior.
+
+Report skipped checks explicitly. A skipped check is not automatically a failure, but it is relevant risk information.
+
+## Response behavior for agents
+
+When finishing an SDF task, state:
+
+- the `.sdf` path(s) created or modified;
+- checks run and their result;
+- checks skipped and why;
+- assumptions and placeholders;
+- risks that need simulator verification.
+
+Do not simply say that the file is valid. Say which validator or smoke test passed.

--- a/.qwenpaw-plugin/skills/sdf/references/sdf-workflow.md
+++ b/.qwenpaw-plugin/skills/sdf/references/sdf-workflow.md
@@ -1,0 +1,78 @@
+# SDF workflow
+
+Use this reference when editing SDF robot model structure, world structure, mesh references, or simulator metadata.
+
+## Edit loop
+
+1. Locate the target `.sdf`. It is the source of truth; author and edit the XML directly.
+2. Identify the target consumer and required SDFormat version.
+3. Decide whether the output is model-level, world-level, or model-in-world.
+4. Fill or update the design ledger before writing XML; keep the compact form as a comment block in the `.sdf` (see `references/design-ledger.md`).
+5. If the model describes a robot that already has a URDF, derive the SDF from that URDF rather than re-authoring geometry from scratch (see `references/interoperability.md`).
+6. For every pose and axis, state the frame in which it is expressed. Write `relative_to` / `expressed_in` explicitly wherever ambiguity would otherwise remain (see `references/frame-semantics.md`).
+7. Author the XML per the golden skeletons in `references/examples.md`. Compute derived numbers — inertia tensors, unit conversions — with formulas or a throwaway helper script; never freehand them.
+8. Validate with `cadgen sdf validate <file.sdf>`; review errors as structural guardrails, not exhaustive simulator proof.
+9. Hand new or modified `.sdf` files to `$cad-viewer` for live viewer links when available.
+10. Run available smoke tests (`gz sdf --check`, simulator load).
+11. Report assumptions and skipped checks.
+
+## Model vs world
+
+Use **model-level SDF** when exporting a reusable robot or object model that another world can include.
+
+Use **world-level SDF** when the task includes:
+
+- physics engine settings;
+- lights or scene setup;
+- terrain or ground plane;
+- multiple initial model placements;
+- world plugins;
+- includes of external model packages;
+- simulator scene setup.
+
+Use **model-in-world SDF** when the task explicitly needs both an inline model and world-specific context.
+
+The lightweight validator should allow pure world-only documents. A world-only document with lights, physics, actors, or includes can be valid SDFormat even when it contains no inline `<model>`.
+
+## Mesh references
+
+SDF mesh URIs should be stable from the `.sdf` file's perspective or use a simulator/package URI convention understood by the consumer.
+
+Good URI choices include:
+
+- relative paths beside the SDF when the model is self-contained;
+- `model://...` for simulator model packages;
+- `package://...` when the simulator environment resolves package roots;
+- `fuel://...`, `http://...`, or `https://...` only when the consumer is expected to fetch external assets.
+
+Mesh assets themselves are owned by the CAD/mesh workflow: one asset per link, exported in the link's own frame, with source units recorded. If a mesh is wrong, fix the export, not the SDF poses.
+
+## Inertials and physics
+
+For dynamic models, inertial data is simulation-critical. If inertials are estimated, record the approximation method. Do not copy visual origins into inertial origins unless that is physically justified.
+
+Collision geometry should be selected for stable and fast physics, not visual fidelity. Use primitive or simplified collision geometry when possible.
+
+## Plugins and sensors
+
+For plugins and sensors, record:
+
+- plugin filename or sensor type;
+- expected simulator distribution/version;
+- topics, frames, update rates, namespaces;
+- parameter source;
+- startup smoke test result.
+
+Do not invent plugin parameters. Incorrect plugin XML can pass lightweight validation and still fail at simulator load time.
+
+CAD Viewer reviews SDF files as static model/world structure through `$cad-viewer` links. Do not add Explorer-only motion plugins; use simulator-native controllers, plugins, or test harnesses for simulator behavior.
+
+## Existing SDF inspection
+
+When inspecting existing `.sdf` files, separate three questions:
+
+1. Is the XML structurally valid enough for the bundled validator?
+2. Is it compatible with the target SDFormat/libsdformat/simulator version?
+3. Does it satisfy this project's packaging, mesh, and workflow policy?
+
+Do not reject valid SDF solely because it violates a project preference unless the task or repository policy requires that preference.

--- a/.qwenpaw-plugin/skills/sdf/references/smoke-tests.md
+++ b/.qwenpaw-plugin/skills/sdf/references/smoke-tests.md
@@ -1,0 +1,98 @@
+# SDF smoke tests
+
+Use smoke tests after the SDF passes bundled validation. The goal is to catch simulator and spatial failures that dependency-light XML checks cannot detect.
+
+## Recommended checks
+
+### Bundled validation
+
+```bash
+cadgen sdf validate path/to/model.sdf
+cadgen sdf validate path/to/model.sdf --strict
+```
+
+Bundled validation runs during explicit target generation. Use `--strict` when warnings should block handoff.
+
+### SDFormat parser check
+
+When Gazebo tooling is installed:
+
+```bash
+gz sdf --check path/to/model.sdf
+```
+
+or through the skill CLI:
+
+```bash
+cadgen sdf validate path/to/model.sdf --gz-check auto
+```
+
+Use the exact simulator environment that will consume the file when possible.
+
+### Simulator load check
+
+Load the model or world in the target simulator and check:
+
+- no parser warnings or plugin load errors;
+- model appears at the intended pose;
+- visual and collision assets resolve;
+- collision geometry is not visibly offset from visuals;
+- dynamic model does not explode, fall through the floor, or produce invalid inertia warnings.
+
+### Joint motion check
+
+For each non-fixed joint:
+
+- command a small positive motion;
+- confirm the moving child moves in the expected direction;
+- confirm limits stop motion where expected;
+- confirm continuous joints can rotate continuously if intended.
+
+### CAD Viewer static review
+
+After generating or modifying an `.sdf`, hand the explicit path to `$cad-viewer` for a live viewer link when available.
+
+- confirm direct model links, joints, frames, visuals, and collisions are placed correctly;
+- confirm includes, plugins, sensors, lights, nested models, and unsupported geometry are listed as static metadata;
+- record any simulator-only behavior that CAD Viewer cannot execute.
+
+### Sensor and plugin check
+
+For each sensor or plugin:
+
+- confirm plugin library loads;
+- confirm expected topics/services appear;
+- confirm frame names match the design ledger;
+- confirm update rate and namespace behavior;
+- capture one sample output if practical.
+
+### Visual review
+
+When CAD Viewer or an equivalent viewer is available through `$cad-viewer`, return the viewer link. Visual review is useful but insufficient: it can catch gross placement and mesh problems, but it cannot prove axis frames, inertials, dynamics, or plugin behavior.
+
+## Report format
+
+Use a compact report:
+
+```text
+Checks run:
+- bundled SDF validation: passed
+- gz sdf --check: skipped, gz not installed
+- simulator load: passed in Gazebo Harmonic
+- joint motion: shoulder_pan positive motion verified; gripper joints skipped
+- plugin startup: camera plugin unresolved, requires target simulator package
+
+Assumptions:
+- Assumed mesh units are meters.
+- Assumed lidar frame is coincident with lidar_link.
+```
+
+## When to stop
+
+Stop and fix the SDF (or its upstream assets) when:
+
+- bundled validation has errors;
+- `gz sdf --check` fails under a required external-check policy;
+- the simulator reports invalid inertias or unresolved required assets;
+- a joint moves opposite from the documented positive direction;
+- plugin startup fails for a plugin required by the task.

--- a/.qwenpaw-plugin/skills/sdf/references/validation.md
+++ b/.qwenpaw-plugin/skills/sdf/references/validation.md
@@ -1,0 +1,160 @@
+# SDF validation
+
+Every created or modified `.sdf` is validated with `cadgen sdf validate <file.sdf>` before the task is reported complete. The validator collects all findings in one pass (severity, code, XML path); `--strict` fails on warnings and `--json` emits a machine-readable document. The bundled validation is dependency-light and intended to catch common structural errors. It is not a replacement for libsdformat, Gazebo, or target-simulator validation.
+
+## Validation model
+
+The validator should produce structured diagnostics with severities:
+
+- `error`: invalid or unsafe enough to block writing output;
+- `warning`: likely problem or unverified simulator behavior; output can be written unless `--strict` is used;
+- `info`: assumption, skipped check, or useful context.
+
+`--strict` treats warnings as failures.
+
+## Bundled checks
+
+### Root and document shape
+
+The validator should check that:
+
+- the root element is `<sdf>`;
+- the root has a non-empty `version` attribute;
+- the version looks like `major.minor`;
+- the document contains meaningful SDF content such as a model, world, actor, light, include, or plugin;
+- structurally valid pure world files are accepted even when they contain no inline model.
+
+### Names and scopes
+
+The validator should check that:
+
+- world names are non-empty and unique at root scope;
+- root model names are non-empty and unique;
+- model link, joint, frame, sensor, light, visual, and collision names are non-empty where required and unique within their owner scope;
+- links, joints, frames, and nested models share one frame-graph namespace per scope: cross-type name collisions are errors;
+- a model with no links, includes, or nested models is an error;
+- unknown elements under model/link/joint/visual/collision/inertial warn (misspelled elements are otherwise silently ignored);
+- the version must be a known SDFormat release (1.4–1.12) or it warns;
+- world- and link-level lights need a valid type (`point`/`directional`/`spot`) and validated poses;
+- duplicate names are reported with a path and scope.
+
+### Poses
+
+The validator should check all `<pose>` elements:
+
+- default `rotation_format="euler_rpy"` has exactly six finite values;
+- `rotation_format="quat_xyzw"` has exactly seven finite values;
+- unsupported `rotation_format` is an error;
+- quaternion values are approximately normalized;
+- `degrees="true"` is a warning unless strict mode is enabled;
+- nontrivial omitted `relative_to` is a warning;
+- `relative_to` resolves within local scope when possible;
+- nested `::` references have valid syntax and resolve when the local tree is available.
+
+### Frames
+
+The validator should check that:
+
+- `<frame name="...">` has a non-empty unique name in its scope;
+- `attached_to`, when present, resolves locally when possible;
+- frame attachment chains do not cycle;
+- unresolved nested or external frame references are reported as warnings when local validation cannot prove them invalid.
+
+### Joints
+
+Known SDF 1.12 joint types:
+
+```text
+continuous, revolute, gearbox, revolute2, prismatic, ball, screw, universal, fixed
+```
+
+The validator should check that:
+
+- joint type is non-empty and known;
+- `<parent>` and `<child>` text exists;
+- `world` is allowed as parent but not child;
+- unscoped parent/child references exist in the same model;
+- `axis` and `axis2` vectors are finite, nonzero, and normalized;
+- `axis2` is used only where the joint type supports a second axis;
+- `expressed_in` resolves when local resolution is possible;
+- limit and dynamics values are finite or documented infinities where SDFormat permits them;
+- effort/velocity/stiffness/dissipation must be non-negative (`-1` is accepted as the unlimited sentinel for effort/velocity); axis `<dynamics>` damping/friction must be non-negative;
+- finite lower limits do not exceed finite upper limits;
+- continuous joints with fake finite position limits produce a warning.
+
+### Geometry and mesh URIs
+
+The validator should check that:
+
+- each visual/collision owner has one geometry element;
+- each geometry has exactly one known primitive or mesh child when possible;
+- box size has 3 positive finite values;
+- cylinder radius and length are positive and finite;
+- sphere radius is positive and finite;
+- plane size has 2 positive finite values;
+- mesh URI values are non-empty;
+- mesh scale has 3 nonzero finite values when present (negative scale mirrors the mesh and warns — consumer support varies);
+- local mesh references resolve relative to the `.sdf` file's location;
+- known external URI schemes such as `model://`, `package://`, `fuel://`, `http://`, and `https://` are accepted without local filesystem resolution.
+
+### Inertials
+
+The validator should check that:
+
+- mass is positive and finite;
+- inertial pose is valid when present;
+- inertia tensor components are finite;
+- inertia matrix is positive semidefinite within tolerance; principal moments violating the triangle inequality warn;
+- missing inertial data on dynamic physical links is at least a warning;
+- frame-like or static links can omit inertials when documented.
+
+### Sensors and plugins
+
+The validator should check that:
+
+- sensor names are non-empty and unique within owner scope;
+- sensor `type` is non-empty and from the known SDFormat sensor-type list (unknown types warn);
+- sensor `update_rate`, when present, is finite and non-negative;
+- sensor pose is valid;
+- plugin filename is non-empty;
+- plugin name, when present, is non-empty;
+- arbitrary simulator-specific plugin schemas are not invented by the validator.
+
+Plugin filenames and parameters can pass bundled validation and still fail in the target simulator. Use smoke tests.
+
+### CAD Viewer review
+
+CAD Viewer treats SDF plugins, sensors, lights, includes, and nested models as static metadata. The bundled validator checks generic structure only; it does not validate Explorer-only motion contracts or execute simulator plugins.
+
+After `.sdf` files are created or modified, hand explicit paths to `$cad-viewer` for live viewer links when available.
+
+This plugin is for CAD Viewer visualization and review. It is not a Gazebo physics/controller plugin and should not be represented as simulator runtime behavior.
+
+## External checks
+
+When Gazebo tooling is available, run:
+
+```bash
+gz sdf --check path/to/file.sdf
+```
+
+The CLI option should be:
+
+```bash
+cadgen sdf validate path/to/file.sdf --gz-check auto
+```
+
+External checks should be recorded in the diagnostics report. A skipped optional check is not a bundled-validation failure unless the user requested `--gz-check required`.
+
+## SDF validity vs project policy
+
+Separate these categories:
+
+| Category | Examples |
+|---|---|
+| SDF structural validity | root `<sdf>`, version, legal element shape, non-empty names, references |
+| Numeric plausibility | finite poses, positive dimensions, positive mass, normalized axes, PSD inertia |
+| Simulator compatibility | libsdformat version, supported joint types, plugin availability, sensor support |
+| Project policy | mesh location, preferred URI style, STL/DAE preference, collision simplification, no unresolved external URIs |
+
+Do not reject valid SDF merely because it violates a project policy unless the task or repository requires that policy. Prefer warnings and strict-mode controls.

--- a/.qwenpaw-plugin/skills/sdf/requirements.txt
+++ b/.qwenpaw-plugin/skills/sdf/requirements.txt
@@ -1,0 +1,1 @@
+cadgen[snapshot]==0.5.1

--- a/.qwenpaw-plugin/skills/sendcutsend/LICENSE
+++ b/.qwenpaw-plugin/skills/sendcutsend/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thompson Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.qwenpaw-plugin/skills/sendcutsend/SKILL.md
+++ b/.qwenpaw-plugin/skills/sendcutsend/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: sendcutsend
+description: Review DXF and STEP/STP uploads for SendCutSend.com orders using its ordering guide, catalog, and specs. Use only for SendCutSend.com preflight reports covering upload readiness, selected material/SKU/thickness/service availability, and service-specific checks for laser cutting, CNC routing, bending, tapping, countersinking, hardware insertion, and finishing.
+---
+
+# SendCutSend
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review.
+
+Use this skill to produce conservative, evidence-backed SendCutSend preflight reports for DXF and STEP/STP files.
+
+Treat SendCutSend's ordering guide, catalog JSON, and specs JSON as evidence feeds, not stable APIs. Field names, types, and coverage may vary. Do not turn missing, unparsable, `N/A`, or conflicting source data into a pass or fail. Fetch sources directly from official URLs and use local inspection code only to measure specific file facts; write the final report from explicit comparisons.
+
+## Geometry Inspection
+
+Use the active project Python environment for local geometry inspection code. If the `$cad` skill is available, use it first for STEP/STP/DXF geometry inspection, measurement, and validation workflows, then add any SendCutSend-specific targeted measurements that are still missing. Use `build123d.import_step` for STEP/STP inspection and the `ezdxf` package directly (`import ezdxf`; it installs alongside build123d) for DXF inspection when geometry facts are required. There is no `build123d.ezdxf`. Do not use raw text parsing or alternate geometry backends for geometry facts.
+
+## CAD Viewer Handoff
+
+After completing SendCutSend work that creates or modifies a `.dxf`, `.step`, or `.stp` upload candidate, you must ALWAYS hand the explicit file path(s) to `$cad-viewer` when that skill is installed. `$cad-viewer` must start CAD Viewer if it is not already running and return link(s) to the relevant created or updated file(s); if `$cad-viewer` is unavailable or startup fails, report that instead of silently omitting the handoff.
+
+## Official Sources
+
+Before each review, fetch and inspect the current SendCutSend source documents directly from the official URLs listed in `references/official-sources.md`:
+
+Use the source URL, access date, and JSON `_meta` values in the source bibliography when helpful. If a source cannot be fetched, report that current SendCutSend sources were unavailable and avoid ready verdicts for dependent checks.
+
+## Workflow
+
+1. Collect order intent.
+   - Prefer DXF for laser sheet cutting and 2D sheet profiles.
+   - Prefer STEP/STP for CNC routing and 3D model upload workflows.
+   - Record file type, intended process, material/SKU, thickness, quantity, services, finish, and hardware.
+   - If order context is missing or ambiguous, inspect enough source data to present concrete options, then ask the user to confirm before writing a readiness verdict. Include candidate SKUs/materials/thicknesses/services with relevant source links; include `photo_url` images and `learn_more_url` links from the specs JSON when available.
+2. Read `references/official-sources.md`, fetch the official sources directly, then inspect the returned documents. Normalize source facts defensively: parse numeric strings, size strings, `N/A`, missing fields, mixed types, and absent service arrays into explicit notes.
+3. Inspect the exact upload file with `$cad` when available and with targeted Python/`build123d` for any missing facts. Do not inspect only the source generator, CAD model, or generator console summary.
+   - DXF: measure units, bounds, layers, entity types, open/duplicate geometry, unsupported annotations, candidate holes/circles, linework stats, bend-line candidates, bend-to-cut distances, bend-adjacent cut geometry, local flange depths, and degenerate zero-area contours as needed for the selected service.
+   - STEP/STP: measure parseability, units hints, solid/surface signals, bounding box, shell/body signals, validity, sheet thickness where available, cylindrical bend-face radii where bending is in scope, and limitations as needed for the selected service.
+   - Keep each inspection helper fact-only. It may report measurements, parse errors, and limitations, but it must not emit pass/fail/readiness statuses.
+4. Select source records by evidence quality.
+   - Use exact SKU as the only authoritative catalog/spec join.
+   - If only material and thickness are provided, use a selected material only when the candidate match is unique and exact enough; otherwise list candidates with links/images from the source records and ask the user to choose.
+   - Use the catalog JSON for orderability: stock, cutting process, available services, size limits, hardware, and finishes.
+   - Use the specs JSON for engineering values: tolerances, holes, bridges, bending, tapping, countersinking, hardware insertion, finishing, and material properties.
+   - Use the ordering guide for plain-language workflow and general file-format rules.
+
+## Comparison
+
+Compare only trustworthy pairs of evidence.
+
+- Determine whether a check applies.
+- Cite the source field path or guide section.
+- Cite the measured file fact.
+- Compare only when both the source requirement and measured file fact are available and trustworthy.
+- If a needed measurement is missing or risky, write a small targeted `build123d`/`ezdxf` inspector for that specific geometry fact.
+- Treat every measured upload risk, manufacturability issue, or cited requirement violation as an error for now. Do not infer any alternate SendCutSend UI classification.
+- For DXF units, inspect `$INSUNITS`, header extents, measured bounds, and order context together. If `$INSUNITS` is missing, unsupported, or not one of the SendCutSend guide's expected DXF unit codes (`1` inches or `4` mm), report a unit/scale error and recommend re-exporting or confirming units before applying size-, flange-, or material-specific comparisons. Do not silently rescale geometry or use an uncertain scale to issue material-specific pass/fail checks.
+- For 2D files with bend lines, check flange length locally along every bend line. Measure the nearest cut/free edge on both sides of each bend at each span or sample point, including notches, slots, gaps, split tabs, and cutouts that interrupt the bend span or create a local free edge. Compare the minimum local flange depth to the selected SKU's `bending_specs.min_flange_length_before_bend` and `bending_specs.min_flange_length_after_bend`. Do not apply flange-length limits to ordinary enclosed holes or interior cutouts unless a cited source gives a hole-to-bend or feature-to-bend rule for that service; report those separately with centerline-to-bend or edge-to-bend measurements as the cited rule requires. Do not treat nearby bend-adjacent cut geometry as only corner relief unless the remaining local flange still passes the flange-length minimum. If any local flange depth is below the SKU minimum, report `❌ fail`. Do not rely on aggregate source-level values when exported geometry has local cutouts, interrupted bends, split bend segments, reliefs, tabs, or unsupported regions.
+- Keep bend findings separate by physical cause. Do not collapse bend-adjacent geometry into a generic flange failure. Report distinct rows for minimum flange/contact length errors, bend line or die-area geometry crossings, insufficient bend contact/support from nearby free edges or cutouts, bend lines that do not span the bent region, split/common-axis bend segments, and cut geometry touching or crossing bend lines. If a SendCutSend source does not expose the exact die-area/contact threshold, cite the measured file fact as direct file inspection and mark the source-limited comparison explicitly.
+- For STEP/STP bent parts, inspect bend radii when the model contains sheet-metal bend geometry or the intended service includes bending. Extract cylindrical or toroidal bend faces and their radii with `$cad`/`build123d`/OCP where possible, group repeated bend radii, and compare them to the selected SKU's `bending_specs.effective_bend_radius` or `bending_specs.bend_radius`. If the selected material/SKU is unknown, report the measured bend-radius set and ask for material/thickness before readiness verdicts. If measured radii conflict with the selected SKU tooling radius, report a bend-radius mismatch error.
+
+Report with restrained status labels:
+
+- `✅ pass`: the measured file fact satisfies the cited current requirement.
+- `❌ fail`: a measured upload risk, manufacturability issue, or direct measured violation of a cited current requirement.
+- `❓ need more info`: missing context, missing source evidence, unmeasured geometry, source conflicts, or tool limitations.
+
+## Diagnostic Images
+
+When findings would be easier to understand visually, produce a concise diagnostic diagram proactively if image-generation or image-editing capabilities are available. Use generated or edited images for callouts, legends, and before/after explanations. Do this without waiting for the user to ask whenever there is a `❌ fail`, a spatially ambiguous geometry issue, or a geometry edit that needs a before/after explanation. If image-generation tools are unavailable, state that limitation and describe the intended diagram in the report.
+
+Before generating an image, run a layout preflight:
+
+- Choose the smallest set of callouts needed to explain the fix.
+- Estimate whether labels will crowd the geometry, overlap each other, or run outside the canvas. If crowding is likely, flag it before generation and switch to numbered markers plus a side legend, a larger canvas, or separate detail views.
+- Keep long measured values and rule text in the legend, not directly over dense geometry.
+- Include the measured failing distance, the cited minimum, and the proposed movement or clearance target.
+
+After generating an image, inspect the rendered image before delivery. If labels overlap, are clipped, are hard to read, or obscure the geometry, regenerate or revise the diagram before reporting it.
+
+## DXF Review
+
+For laser sheet cutting, start from the refreshed sources and measured DXF geometry facts.
+
+Check for:
+
+- single, uploadable DXF file with model geometry at 1:1 scale
+- units and overall part size; treat missing, unsupported, or unexpected `$INSUNITS` as a scale error until the user confirms units
+- closed cut profiles where the service requires closed contours
+- degenerate or zero-area closed contours, two-point closed polylines, and odd-degree cut endpoints
+- duplicate or overlapping cut geometry
+- unsupported annotation, text, dimensions, images, construction lines, or hidden instruction layers
+- layer/color/linework conventions from the ordering guide and upload workflow
+- bend-line entities, bend segment lengths, split/common-axis bends, local flange depth on both sides of each bend line, nearest non-bend cut edge or cutout distances, bend-line span coverage, insufficient bend contact/support, die-area or bend-adjacent cut geometry crossings, and cut geometry touching or crossing bend lines when bending is in scope
+- minimum holes, slots, web widths, interior geometry, part density, nesting, and spacing only when both source facts and measured file facts support a comparison
+- secondary-service requirements for bending, tapping, countersinking, hardware, finishing, or deburring when requested
+
+## STEP Review
+
+For CNC routing or 3D model upload, start from the refreshed sources and measured STEP geometry facts.
+
+Check for:
+
+- STEP/STP file readability and a solid body rather than loose curves or surfaces
+- units, scale, bounding box, thickness, and feature dimensions
+- sheet-metal bend radii when bending is in scope; compare measured cylindrical bend-face radii to the selected SKU's `bending_specs.effective_bend_radius` or `bending_specs.bend_radius`
+- sharp inside corners, small holes/slots, thin walls, islands, deep pockets, tool access, and tolerances only when the file inspection can measure the fact
+- whether geometry represents a sheet profile better served as DXF for laser cutting
+- material, thickness, finish, and secondary-service compatibility
+
+## Reporting
+
+Include the file path, assumed service, material/order context, source files checked with access date, inspected geometry facts, findings ordered by practical impact, and specific next edits. In the findings table, include a `Rule source` column with Markdown links to the source URL plus the specific JSON field path or guide section used for that row. If a row is based only on direct file inspection and has no external rule, say `Direct file inspection`; do not leave the source blank. Do not call a file "SendCutSend ready" unless every required cited check either passes or is explicitly outside the selected service.
+
+Use `references/report-template.md` when a structured report would help.
+
+## References
+
+- Official source selection: `references/official-sources.md`
+- Report shape: `references/report-template.md`

--- a/.qwenpaw-plugin/skills/sendcutsend/agents/openai.yaml
+++ b/.qwenpaw-plugin/skills/sendcutsend/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SendCutSend"
+  short_description: "Review DXF/STEP against SendCutSend specs."
+  default_prompt: "Use $sendcutsend to review this DXF or STEP file for SendCutSend upload readiness."

--- a/.qwenpaw-plugin/skills/sendcutsend/references/official-sources.md
+++ b/.qwenpaw-plugin/skills/sendcutsend/references/official-sources.md
@@ -1,0 +1,40 @@
+# Official SendCutSend Source Map
+
+Use these sources as live evidence, not as a stable API. Field coverage, value types, and `N/A` usage can vary. Before making pass/fail claims, cite the exact source URL and, for JSON facts, the field path used.
+
+## Core Entry Points
+
+- Ordering guide: https://cdn.sendcutsend.com/specs/sendcutsend-ordering-guide.md
+- Catalog JSON: https://cdn.sendcutsend.com/specs/sendcutsend-catalog.json
+- Engineering specs JSON: https://cdn.sendcutsend.com/specs/sendcutsend-specs.json
+
+Fetch these URLs directly before each review. Use the current response bodies as the evidence for material/service checks, and cite the URL plus the access date in the report.
+
+## Source Roles
+
+- Ordering guide: use for ordering flow, accepted file formats, plain-language design rules, and general service explanations.
+- Catalog JSON: use for orderability facts such as material SKUs, material names, thicknesses, stock status, cutting process, min/max part size, available services, hardware items, and finish options.
+- Engineering specs JSON: use for SKU-keyed design validation facts such as tolerances, minimum hole/bridge/edge values, bending parameters, tapping, countersinking, hardware insertion, dimple forming, finishing constraints, and material properties.
+
+## Provenance To Capture
+
+- Source URL
+- Access date
+- JSON `_meta.schema_version`
+- JSON `_meta.generated_at`
+- JSON `_meta.source_data_generated_at` when present
+- Field path for row-level citations, such as `sendcutsend-specs.json materials[sku=ALU-063].cutting_specs.min_hole_size`
+
+## Conflict Handling
+
+Prefer exact SKU joins across catalog and specs. If source facts conflict or a field is missing, unparsable, or `N/A`, report the uncertainty and mark the dependent row `❓ need more info` unless another more specific, cited source resolves it.
+
+Use this precedence for source facts:
+
+1. material/thickness/service-specific configurator or current quote/upload result
+2. exact SKU entry in engineering specs JSON
+3. exact SKU entry in catalog JSON
+4. ordering guide
+5. broader official SendCutSend human-readable page, only when the three source files are insufficient
+
+Record the conflict and the page you relied on.

--- a/.qwenpaw-plugin/skills/sendcutsend/references/report-template.md
+++ b/.qwenpaw-plugin/skills/sendcutsend/references/report-template.md
@@ -1,0 +1,42 @@
+# SendCutSend Validation Report Template
+
+Use this structure when the user asks for a review, validation, preflight, or manufacturing readiness report.
+
+## Context
+
+- File: `<path>`
+- Assumed service: `DXF laser sheet cutting` or `STEP CNC routing`
+- Order context: material, thickness, primary process, finish, quantity, secondary operations
+- Date checked: `<YYYY-MM-DD>`
+
+## Sources Checked
+
+List official SendCutSend URLs used for the checks as Markdown links. Include only sources actually consulted. Include the access date and JSON `_meta.generated_at` values when available. The findings table must also link the specific rule source for each row, so this section is a bibliography, not a substitute for row-level citations.
+
+## Geometry Facts
+
+Summarize facts from `$cad` inspection when available and targeted `build123d`/`ezdxf` inspection code: file type, units, extents/bounding box, entity/body counts, layers, unsupported entities, obvious open/duplicate geometry, and parsing limitations.
+
+If the reviewed upload was generated or updated in this workflow, include the `$cad-viewer` viewer link when available.
+
+For bent 2D files, include bend geometry facts from the exported file: bend-line count and layers, individual bend line lengths, nearest non-bend cut geometry for each bend line, local flange depths, bend-line span coverage, bend-adjacent cut geometry, insufficient contact/support observations, and any split/interrupted/common-axis bend observations. Use those facts for comparison against the current material/thickness service page.
+
+For bent STEP/STP files, include measured sheet thickness when available and the extracted bend-radius set. Compare bend radii to the selected material/SKU only when that order context is known.
+
+## Findings
+
+Use one row per issue. In `Rule source`, link the specific official page or JSON file that defines the requirement being checked, and include the field path when the source is JSON. Example: `[sendcutsend-specs.json](https://cdn.sendcutsend.com/specs/sendcutsend-specs.json) materials[sku=ALU-063].cutting_specs.min_hole_size`. Prefer exact SKU-specific sources over generic guide text. If no external rule applies, write `Direct file inspection`.
+
+| Status | Check | Evidence | Rule source | Recommendation |
+| --- | --- | --- | --- | --- |
+| ✅ pass / ❌ fail / ❓ need more info | requirement name | file fact | Markdown link to specific rule doc/table, or `Direct file inspection` | concrete next action |
+
+## Verdict
+
+Use a limited verdict:
+
+- `Ready to upload for this assumed context`
+- `Needs edits before upload`
+- `Insufficient context to validate`
+
+Never use a ready verdict if any required current official requirement check is marked `❌ fail` or `❓ need more info`. Use `Ready to upload for this assumed context` only when every required cited check has sufficient order context, source evidence, measured file facts, and passes or is explicitly outside the selected service. Until an explicit SendCutSend UI classification model is deliberately added, treat measured upload risks and manufacturability issues as `❌ fail`.

--- a/.qwenpaw-plugin/skills/srdf/LICENSE
+++ b/.qwenpaw-plugin/skills/srdf/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thompson Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.qwenpaw-plugin/skills/srdf/SKILL.md
+++ b/.qwenpaw-plugin/skills/srdf/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: srdf
+description: MoveIt2 SRDF authoring, validation, and planning-semantics workflow. Use when creating, editing, inspecting, or validating `.srdf` files, MoveIt planning groups, virtual joints, passive joints, end effectors, group states, disabled collisions, URDF-paired planning semantics, or SRDF handoff for live review. Use the URDF skill for robot structure, the SDF skill for simulator descriptions, and the cad-viewer skill for rendering and live review links.
+---
+
+# SRDF
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review.
+
+Use this skill for MoveIt semantic robot descriptions on top of an existing valid URDF. SRDF defines planning semantics; it does not define physical robot structure. The `.srdf` file is the source of truth: author and edit the XML directly. There is no `gen_srdf()` contract.
+
+SRDF correctness is a **planning semantics** problem. The common failure is not invalid XML; it is a plausible SRDF that gives MoveIt the wrong planning group, wrong tool link, wrong default state, unsafe disabled-collision matrix, or wrong joint units. Because language models are weak at spatial and kinematic reasoning, derive planning groups, end effectors, group states, and disabled collisions from the URDF topology, MoveIt Setup Assistant output, sampled collision analysis, or explicit user data. Do not infer them from visual theme alone — and do not type any link or joint name from memory: extract the URDF's link/joint table first and copy names from it.
+
+## Setup
+
+This skill's commands are thin entrypoints over the `cadgen` distribution, which
+carries the Python build runtime and the JavaScript it executes. Install it once:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+Rendering additionally needs a browser, which pip cannot supply:
+
+```bash
+python -m playwright install chromium
+```
+
+## Format boundary
+
+- **URDF** owns physical robot structure: links, joints, geometry, inertials, limits, mimic joints, transmissions, and robot-state publishing.
+- **SRDF** owns MoveIt semantics: virtual joints, passive joints, planning groups, group states, end effectors, and disabled collision pairs.
+- **SDF** owns simulator/world semantics: physics, sensors, lights, plugins, worlds, and simulation-specific metadata.
+
+Do not place geometry, inertials, joint origins, link poses, mesh references, physical joint limits, transmissions, or `ros2_control` interfaces in SRDF.
+
+## CAD Viewer Handoff
+
+After completing SRDF work that creates or modifies a `.srdf`, you must ALWAYS hand the explicit file path to `$cad-viewer` when that skill is installed. `$cad-viewer` must start CAD Viewer if it is not already running and return link(s) to the relevant created or updated file(s). If `$cad-viewer` is unavailable or startup fails, report that instead of silently omitting the handoff.
+
+## Required workflow
+
+1. **Start from a valid URDF.** Author or fix the URDF first with `$urdf` and validate it. The SRDF pairs with that URDF by colocation and robot name, and every name in the SRDF must exist in it.
+2. **Extract the URDF table.** Before writing any SRDF XML, list the URDF's robot name, links, joints (with type, parent, child, limits, mimic flags). Copy names from this table only; never type them from memory. See `references/srdf-workflow.md`.
+3. **Identify the planning task.** Record whether the goal is arm IK, gripper control, mobile base planning, dual-arm planning, tool use, or local smoke testing.
+4. **Create or update the planning ledger.** Use `references/planning-ledger.md` before writing XML; keep a compact copy as a comment block in the `.srdf`.
+5. **Pair with the URDF by colocation.** Save the `.srdf` in the same folder as its `.urdf`, with the same `<robot name>` — that is the only linking mechanism. The validator and the viewer both resolve the pairing by scanning the folder for the URDF whose robot name matches; exactly one URDF per robot name per folder. No metadata element links the files. See `references/authoring-contract.md`.
+6. **Define virtual and passive joints deliberately.** Use them when needed by the robot model.
+7. **Define planning groups from URDF topology.** Prefer chain groups for serial manipulators when base/tip form a real parent-to-child path in the URDF tree (the validator verifies this). Use joint/link/subgroup definitions only when they are deliberate.
+8. **Define end effectors after group membership is known.** Avoid overlap between an end-effector group and its parent group. Record the actual target/TCP link.
+9. **Define group states in URDF-native units.** Revolute and continuous values are radians; prismatic values are meters. Do not store degrees in SRDF. Values must lie within URDF limits and must not set fixed or mimic joints.
+10. **Generate disabled collisions from evidence.** Use adjacency derived from the URDF joint table, MoveIt Setup Assistant sampling, or explicit user-provided collision matrices. Do not invent broad disable lists. See `references/disabled-collisions.md`.
+11. **Validate every created or modified `.srdf`** with `cadgen srdf validate`; it cross-validates all names, chains, states, and pairs against the paired URDF. Fix findings and re-validate until clean.
+12. **Run MoveIt smoke tests when available.** Use MoveIt Setup Assistant or a project MoveIt launch directly.
+13. **Report assumptions and skipped checks.** Include incomplete validation, missing MoveIt environment, manually reasoned collision disables, and inferred target links.
+
+## Commands
+
+Run with the Python environment for the project or workspace. Treat `python` in examples as an interpreter placeholder; if bare `python` is unavailable, substitute `python3`, a project virtualenv interpreter, or the configured interpreter path. The validator uses only the Python standard library.
+
+The validator shape is:
+
+```bash
+cadgen srdf validate path/to/robot.srdf
+cadgen srdf validate path/to/robot.srdf --strict
+cadgen srdf validate path/to/robot.srdf --json
+```
+
+The validator collects all findings in one pass (severity, code, XML path). It parses the SRDF, resolves the paired URDF (the same-folder `.urdf` whose robot name matches; none or several is an error), and cross-validates: group/joint/link/subgroup name existence, chain path resolvability, subgroup cycles, virtual/passive joints, end-effector topology, group-state membership/limits/completeness, disabled-collision pairs (including Adjacent-reason truthfulness), and misspelled elements. One run validates ONE file: `--strict` treats warnings as failures and `--json` emits the machine-readable findings document. It exits nonzero if the target fails. Relative targets resolve from the current working directory.
+
+## Hard rules
+
+- The SRDF lives in the same folder as its URDF and shares its `<robot name>`; that colocation-plus-name match is the only pairing mechanism, and exactly one URDF per robot name may exist in the folder.
+- Every link, joint, group, and subgroup name must come from the URDF table or a group defined in the same file.
+- Group states use URDF-native units: radians for revolute/continuous, meters for prismatic.
+- Disabled collision pairs require truthful reasons and provenance.
+- End-effector groups should not share links with their parent planning group.
+- Visual rendering review is useful but cannot prove planning correctness.
+
+## Snapshot Tool
+
+`cadgen snapshot` renders the robot to a PNG still, using the same shared
+CLI and headless browser runtime every rendering skill uses — so a snapshot matches what
+the CAD Viewer shows.
+
+```bash
+cadgen snapshot path/to/robot.srdf review.png
+```
+
+Hand it the `.srdf`; it routes by suffix and renders the paired URDF's geometry. Pose the robot with `--joint-values` — `{joint: degrees}` JSON,
+joints you do not name staying at the rest pose (the `"jointValues"` job field is the same
+thing in a packet). Robots are authored in metres and are framed on the robot scene scale
+automatically.
+
+Theme settings live under one `--theme`, mirroring the viewer's Theme tab. The default
+theme is `snapshot` — Workbench Light with the ground grid, origin axis and shadows
+removed, because in a still image those read as geometry. Leave `--display` off: display
+settings (mode, clip, exploded, edges) are CAD topology settings, and a robot carries none.
+
+Link meshes are resolved relative to the description, so they must be present: an
+unhydrated Git LFS pointer fails as "No link mesh loaded for robot". Run
+`git lfs checkout <mesh dir>` first.
+
+An SRDF's geometry comes from the URDF beside it, so it has no snapshot door of its
+own; the polymorphic `cadgen snapshot` routes one by suffix. The grammar is
+`cadgen snapshot TARGET [OUT] [flags]`, the same one every format door uses. Use
+`cadgen snapshot --help` for the complete current interface.
+
+## References
+
+- Authoring contract (structure, URDF pairing, golden skeleton): `references/authoring-contract.md`
+- SRDF workflow (URDF table extraction, edit loop): `references/srdf-workflow.md`
+- Planning ledger: `references/planning-ledger.md`
+- Validation and verification recipe: `references/validation.md`
+- End effectors: `references/end-effectors.md`
+- Disabled collisions: `references/disabled-collisions.md`
+

--- a/.qwenpaw-plugin/skills/srdf/agents/openai.yaml
+++ b/.qwenpaw-plugin/skills/srdf/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SRDF"
+  short_description: "Author and validate MoveIt2 SRDF semantics."
+  default_prompt: "Use $srdf to author and validate MoveIt2 SRDF files as direct XML paired with their URDF, then hand new or changed SRDFs to $cad-viewer for review and optional MoveIt2 controls."

--- a/.qwenpaw-plugin/skills/srdf/references/authoring-contract.md
+++ b/.qwenpaw-plugin/skills/srdf/references/authoring-contract.md
@@ -1,0 +1,70 @@
+# SRDF Authoring Contract
+
+Use this reference when writing or editing SRDF XML directly. The `.srdf` file is the source of truth and must be auditable on its own: planning intent and provenance live in the file, and the paired URDF is found by convention.
+
+## File Shape
+
+Every authored `.srdf` follows this shape, in this order:
+
+1. XML declaration: `<?xml version="1.0"?>`.
+2. Planning-ledger comment block (compact form of `references/planning-ledger.md`).
+3. One `<robot>` root with the **same `name` as the paired URDF**: `<robot name="...">`.
+4. `<virtual_joint>` elements, then `<group>`, `<group_state>`, `<end_effector>`, `<passive_joint>`, `<disable_collisions>` — grouped by element type, in that order.
+
+Keep two-space indentation. Comment nontrivial decisions inline (why a chain tip, why a pair is disabled).
+
+## URDF Pairing (non-negotiable)
+
+An SRDF pairs with its URDF by **colocation and robot name** — nothing else:
+
+- Save the `.srdf` in the **same folder** as the `.urdf` it describes.
+- Both files declare the identical `<robot name="...">`.
+- Exactly one `.urdf` in that folder may declare that robot name; the validator and the CAD Viewer resolve the pairing by scanning the folder, and they error when zero or several URDFs match.
+- Matching basenames (`so101.srdf` next to `so101.urdf`) are conventional and recommended for readability, but the robot name is what pairs the files. Multiple SRDF planning variants for one robot (`so101_dual.srdf`, `so101_precise.srdf`) all pair with the same URDF through its name.
+- There is no link element: an SRDF pairs with the same-folder URDF whose robot name matches.
+
+## Names Come From the URDF Table
+
+Every `link`, `joint`, `base_link`, `tip_link`, `parent_link`, and group-state joint name must be copied from the extracted URDF table (see `references/srdf-workflow.md`). Never type a name from memory or from a similar robot; near-miss names (`wrist_roll` vs `wrist_roll_joint`) are the most common SRDF defect and validation will reject them.
+
+## Element Contract
+
+- `<group>`: prefer exactly one `<chain base_link tip_link>` for a serial manipulator — base to tip must be a real parent→child path in the URDF tree. Use explicit `<joint>`/`<link>` members for non-chain groups (grippers, heads), and `<group>` subgroups for unions (dual-arm, whole-body). Do not mix representations in one group without reason.
+- `<group_state name group>`: one `<joint name value>` per **movable, non-mimic** joint in the group. Radians for revolute/continuous, meters for prismatic, values within URDF limits.
+- `<end_effector name parent_link group parent_group>`: the EE group must not share links with `parent_group`; `parent_link` belongs to the parent group (or is adjacent to the EE group) and is typically the attachment/flange link.
+- `<virtual_joint name type parent_frame child_link>`: attaches the robot root to an external frame (`world`). `fixed` for fixed-base arms; `planar`/`floating` only when planning genuinely needs that freedom.
+- `<passive_joint name>`: unactuated joints that planners must not command.
+- `<disable_collisions link1 link2 reason>`: evidence-backed only; see `references/disabled-collisions.md`. No duplicate or reversed-duplicate pairs.
+
+## Golden Skeleton
+
+```xml
+<?xml version="1.0"?>
+<!--
+  srdf: example_arm | urdf: example_arm.urdf | task: arm IK + gripper control
+  groups: arm (chain base_link->tool0), gripper (joint members)
+  states: home, ready (radians, within URDF limits)
+  disabled collisions: URDF-adjacent pairs only (reason Adjacent)
+  assumptions: tool0 is the TCP; no sampled collision matrix yet
+-->
+<robot name="example_arm">
+  <virtual_joint name="world_to_base" type="fixed" parent_frame="world" child_link="base_footprint" />
+  <group name="arm">
+    <chain base_link="base_link" tip_link="tool0" />
+  </group>
+  <group name="gripper">
+    <joint name="finger_joint" />
+  </group>
+  <group_state name="home" group="arm">
+    <joint name="shoulder_pitch" value="0" />
+    <joint name="elbow_pitch" value="0" />
+    <joint name="wrist_roll" value="0" />
+  </group_state>
+  <end_effector name="gripper_eef" parent_link="tool0" group="gripper" parent_group="arm" />
+  <disable_collisions link1="base_link" link2="shoulder_link" reason="Adjacent" />
+</robot>
+```
+
+## Helper Scripts
+
+Adjacent-pair lists, subgroup unions for many-jointed robots, and degree-to-radian tables are computations: derive them with a short throwaway script over the URDF rather than by hand when the robot has more than a handful of joints. The script is scaffolding; the checked-in `.srdf` remains canonical.

--- a/.qwenpaw-plugin/skills/srdf/references/disabled-collisions.md
+++ b/.qwenpaw-plugin/skills/srdf/references/disabled-collisions.md
@@ -1,0 +1,55 @@
+# SRDF disabled collisions
+
+Disabled collisions are planning-safety data. Treat them as derived evidence, not as decorative XML.
+
+## Valid sources
+
+Use one of these sources:
+
+- adjacent-link policy from the URDF kinematic graph;
+- MoveIt Setup Assistant self-collision matrix generation;
+- sampled collision analysis from a known MoveIt configuration;
+- explicit user-provided collision matrix;
+- a manually reviewed pair with a specific rationale.
+
+Do not infer disabled collision pairs from visual theme or vague prose.
+
+## XML shape
+
+```xml
+<disable_collisions link1="base_link" link2="shoulder_link" reason="Adjacent"/>
+```
+
+The current runtime requires:
+
+- `link1` and `link2`;
+- both links to exist in the URDF;
+- distinct link names;
+- a non-empty `reason`;
+- no duplicate or reversed duplicate pairs.
+
+## Reason and provenance
+
+Use truthful reasons. Examples:
+
+| Reason | Typical source |
+|---|---|
+| `Adjacent` | URDF graph adjacency |
+| `Never` | Setup Assistant sampled matrix |
+| `Always` | Setup Assistant sampled matrix |
+| `Default` | Setup Assistant sampled matrix |
+| `Manual: tool fixture is outside workspace envelope` | Explicit human review |
+
+The current parser classifies reasons into broad provenance buckets such as adjacent, sampled, setup assistant, manual, or assumed. Avoid `assumed` unless the user explicitly requested a provisional SRDF and the risk is reported.
+
+## Review checklist
+
+Before committing a disabled collision pair:
+
+- Is the pair adjacent or sampled-safe?
+- Does disabling the pair hide a possible real collision during the planned task?
+- Was the pair generated with sufficient sampling density?
+- Is the pair still valid after geometry, limits, or group membership changed?
+- Was manual rationale written down?
+
+If many manual pairs are present, prefer regenerating the self-collision matrix with MoveIt Setup Assistant.

--- a/.qwenpaw-plugin/skills/srdf/references/end-effectors.md
+++ b/.qwenpaw-plugin/skills/srdf/references/end-effectors.md
@@ -1,0 +1,50 @@
+# SRDF end effectors
+
+Use this reference when creating or editing `<end_effector>` entries.
+
+## Concept
+
+An end effector is a semantic designation for a tool, gripper, sensor head, or other terminal group. It is typically connected to a parent planning group through a fixed joint or attachment link.
+
+Typical shape:
+
+```xml
+<group name="gripper">
+  <joint name="finger_joint"/>
+</group>
+
+<end_effector
+  name="gripper_eef"
+  parent_link="tool0"
+  group="gripper"
+  parent_group="manipulator"/>
+```
+
+## Required ledger fields
+
+Record:
+
+- end-effector name;
+- end-effector group;
+- parent planning group;
+- parent link where the end effector attaches;
+- target/TCP link used for IK and planning;
+- whether the end-effector group overlaps the parent group;
+- whether the parent link is adjacent to the end-effector group in the URDF graph.
+
+## Checks
+
+Before authoring:
+
+- The end-effector group exists.
+- The parent group exists when specified.
+- The parent link exists in the URDF.
+- The end-effector group and parent group do not share links.
+- The parent link is in the parent group or adjacent to the end-effector group.
+- The target/TCP link is explicit when it differs from the inferred group tip.
+
+The current runtime enforces several of these checks, but target/TCP choice remains a semantic decision. Do not rely on inference when planning to a tool center point.
+
+## Handoff
+
+When handing an SRDF to another tool or reviewer, state the intended target/TCP link explicitly whenever it differs from the inferred group tip — target choice is a semantic decision no consumer can infer.

--- a/.qwenpaw-plugin/skills/srdf/references/planning-ledger.md
+++ b/.qwenpaw-plugin/skills/srdf/references/planning-ledger.md
@@ -1,0 +1,102 @@
+# SRDF planning ledger
+
+Create or update this ledger before writing SRDF XML. The ledger makes planning assumptions explicit and helps prevent plausible but incorrect MoveIt configurations.
+
+## URDF dependency
+
+| Field | Value |
+|---|---|
+| URDF path | |
+| SRDF output path | |
+| Robot name | |
+| URDF validated? | yes/no; tool/check |
+| Root link | |
+| Active joints | |
+| Fixed joints | |
+| Mimic joints | |
+| Passive joints | |
+| Links used for collision checking | |
+| Known URDF limitations | |
+
+## Planning task
+
+| Field | Value |
+|---|---|
+| Main task | IK / plan-to-pose / gripper / mobile base / dual arm / other |
+| Primary planning group | |
+| Expected end-effector or TCP | |
+| Required solver or planner | |
+| Position-only IK? | yes/no; reason |
+| Orientation constraints? | yes/no; representation |
+
+## Virtual joints
+
+| Name | Type | Parent frame | Child link | Required? | Rationale |
+|---|---|---|---|---|---|
+| | fixed / planar / floating | | | | |
+
+Virtual joints describe the robot root pose relative to an external frame. Use fixed for fixed-base manipulators when the planning setup needs a world attachment; use planar/floating only when the robot model requires that planning freedom.
+
+## Passive joints
+
+| Joint | URDF type | Reason passive | Affected groups | Notes |
+|---|---|---|---|---|
+| | | | | |
+
+Passive joints are unactuated. They should not be treated as controllable planning variables.
+
+## Planning groups
+
+| Group | Representation | Members | Base link | Tip link | Active joints | Excluded joints | Purpose | Solver expectation |
+|---|---|---|---|---|---|---|---|---|
+| | joints / links / chain / subgroups | | | | | | | |
+
+For serial arms, prefer a chain only when the URDF graph has a real path from base link to tip link. For subgroup groups, check for cycles and duplicate semantics.
+
+## End effectors
+
+| Name | End-effector group | Parent group | Parent link | Target/TCP link | Overlap checked? | Adjacent? | Notes |
+|---|---|---|---|---|---|---|---|
+| | | | | | | | |
+
+The end-effector group should normally not share links with its parent group. The target/TCP link should be explicit when it differs from the inferred group tip.
+
+## Group states
+
+| State | Group | Joint values | Unit check | Limit check | Purpose |
+|---|---|---|---|---|---|
+| | | revolute/continuous rad; prismatic m | | | |
+
+Do not store degrees in SRDF group states. Do not set fixed or mimic joints in group states.
+
+## Disabled collisions
+
+| Link 1 | Link 2 | Reason | Source | Evidence | Risk note |
+|---|---|---|---|---|---|
+| | | Adjacent / Never / Always / Default / Manual | Setup Assistant / sampled / adjacency / user | | |
+
+Do not infer disabled collisions from visual impression. Each pair needs a reason and provenance.
+
+## MoveIt smoke tests
+
+| Test | Group | Target link | Target pose/state | Expected result | Actual result | Notes |
+|---|---|---|---|---|---|---|
+| IK solve | | | | | | |
+| Plan-to-pose | | | | | | |
+| Named state | | | | | | |
+| Collision check | | | | | | |
+
+## Assumptions to report
+
+List every guessed or inferred value:
+
+- planning group membership;
+- chain base/tip;
+- target/TCP link;
+- virtual joint attachment;
+- passive joint classification;
+- group-state value;
+- disabled collision pair;
+- solver or planner setting;
+- orientation/position-only IK assumption;
+- skipped MoveIt validation.

--- a/.qwenpaw-plugin/skills/srdf/references/srdf-workflow.md
+++ b/.qwenpaw-plugin/skills/srdf/references/srdf-workflow.md
@@ -1,0 +1,38 @@
+# SRDF Workflow
+
+Use this reference when creating or editing MoveIt planning semantics for an existing URDF.
+
+## Step 0: Extract the URDF Table
+
+Do this before writing any SRDF XML. Parse the paired URDF (read it, or run a three-line ElementTree script for large robots) and write down:
+
+- robot `name` (the SRDF must match it exactly);
+- every link name;
+- every joint: name, type, parent link, child link, lower/upper limits, and whether it has `<mimic>`;
+- the root link and the main serial chains (walk parent→child).
+
+Every name that appears in the SRDF is **copied from this table**. If a name you want is not in the table, the URDF is wrong or your assumption is — resolve that first with `$urdf`. This single habit eliminates the most common SRDF failure class: plausible near-miss names and chains that do not exist in the tree.
+
+## Edit Loop
+
+1. Confirm the URDF is valid (`$urdf` validator) and extract the URDF table.
+2. Read or create the planning ledger (`references/planning-ledger.md`); keep the compact form as a comment block in the `.srdf`.
+3. Author or edit the SRDF XML directly per `references/authoring-contract.md`, in element order: virtual joints, groups, group states, end effectors, passive joints, disabled collisions. Save it next to the URDF with the same robot name — colocation plus name match is how every consumer pairs the files.
+4. Derive — do not invent — disabled collisions (`references/disabled-collisions.md`) and group-state values (URDF-native units, within limits).
+5. Validate with `cadgen srdf validate <file.srdf>`; fix findings until clean.
+6. Hand the file to `$cad-viewer` and return the live review link.
+7. Run MoveIt smoke tests when a MoveIt environment is available; otherwise report them skipped.
+8. Report assumptions: inferred TCP links, manual collision pairs, unverified planner behavior.
+
+## Group Design
+
+- **Serial manipulator** → one chain group, `base_link` at the mount, `tip_link` at the flange/TCP link. The validator rejects chains that are not a real parent→child path.
+- **Gripper / hand** → joint-member group listing its actuated joints; it becomes the end-effector group.
+- **Dual-arm / whole-body** → subgroup unions. Check for duplicate semantics (a joint reachable through two subgroups) and cycles.
+- **Mobile base** → typically a planar/floating virtual joint plus a group for the base; do not model wheel joints as planning DOF unless the planner consumes them.
+
+Fixed and mimic joints are never planning variables: they do not belong in group states, and chain-derived groups exclude them automatically.
+
+## When the URDF Changes
+
+Renamed links or joints, changed limits, or restructured chains invalidate the SRDF silently. After any URDF edit, re-run the SRDF validator on the paired `.srdf`, and re-check group states against the new limits. Treat URDF+SRDF as a pair in every task that touches either.

--- a/.qwenpaw-plugin/skills/srdf/references/validation.md
+++ b/.qwenpaw-plugin/skills/srdf/references/validation.md
@@ -1,0 +1,44 @@
+# SRDF Validation and Verification
+
+Every created or modified `.srdf` runs this recipe before the task is reported complete.
+
+## Recipe
+
+1. **Bundled validator** (always): `cadgen srdf validate path/to/robot.srdf`. It collects *all* findings in one pass (severity, code, XML path); fix them and re-run until clean. Use `--strict` to fail on warnings and `--json` for machine-readable output.
+2. **Viewer review** (whenever `$cad-viewer` is available): load the SRDF, confirm the paired URDF resolves and renders, and exercise named group states.
+3. **MoveIt smoke test** (when a MoveIt environment is available): load the URDF+SRDF pair in MoveIt Setup Assistant or a project launch; solve IK for the primary group; plan to a named state. Report as skipped when unavailable.
+
+## What the Bundled Validator Checks
+
+Structure and linkage:
+
+- root is `<robot>` with a non-empty name;
+- a paired URDF resolves: exactly one `.urdf` in the same folder declares the SRDF's robot name (`no_paired_urdf` / `ambiguous_paired_urdf` errors otherwise); a leftover `<tcad:urdf>`/`<explorer:urdf>` element warns as deprecated and is ignored;
+- unique group, end-effector, group-state, and collision-pair identities.
+
+Against the paired URDF:
+
+- every group joint/link/subgroup name exists (joints in the URDF, links in the URDF, subgroups in the SRDF);
+- every chain `base_link`/`tip_link` exists **and** the chain is a real parent→child path in the URDF tree;
+- subgroup references contain no cycles;
+- at least one planning group is defined;
+- virtual joints: valid type (`fixed`/`floating`/`planar`), non-empty `parent_frame`, `child_link` exists in the URDF (name collisions with URDF joints warn);
+- passive joints exist in the URDF and are never set by group states;
+- end effectors: group exists, parent group exists when named, parent link exists, no link overlap between EE group and parent group, parent link in parent group or adjacent to the EE group;
+- group states: group exists, each joint exists and belongs to the group, no fixed/mimic/passive joints, values within URDF revolute/prismatic limits; states that omit group joints warn (MoveIt fills them from the current state);
+- disabled collisions: both links exist, distinct, non-empty reason, no (reversed) duplicates; pairs claiming reason `Adjacent` that are not actually joined by a URDF joint warn; warns when 25+ pairs are manually reasoned;
+- unknown elements under `<robot>` or `<group>` warn — misspelled elements are otherwise silently ignored by MoveIt;
+- a paired URDF that is not a single-rooted tree warns (chain/adjacency checks become unreliable).
+
+## What Validation Cannot Prove
+
+- That the planning group matches the user's task intent (right arm vs left arm).
+- That the TCP/target link is the physically correct tool point.
+- That disabled pairs are safe at every reachable configuration — only sampling (Setup Assistant) approaches that.
+- That group-state poses are collision-free or useful.
+
+These are semantic decisions: document them in the ledger and verify interactively in the viewer or MoveIt when confidence matters. Visual rendering review alone cannot prove planning correctness.
+
+## Failure Handling
+
+When validation fails against the URDF, decide which side is wrong before editing: a missing name may mean a typo in the SRDF **or** a rename in the URDF that invalidated existing semantics. Fix the owning file (`$urdf` for structure), then re-run the validator on the pair.

--- a/.qwenpaw-plugin/skills/srdf/requirements.txt
+++ b/.qwenpaw-plugin/skills/srdf/requirements.txt
@@ -1,0 +1,1 @@
+cadgen[snapshot]==0.5.1

--- a/.qwenpaw-plugin/skills/step-parts/LICENSE
+++ b/.qwenpaw-plugin/skills/step-parts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thompson Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.qwenpaw-plugin/skills/step-parts/SKILL.md
+++ b/.qwenpaw-plugin/skills/step-parts/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: step-parts
+description: Find, evaluate, and download common purchasable CAD parts from step.parts, including named off-the-shelf actuators, servos, motors, electronics boards, connectors, screws, bolts, nuts, washers, bearings, standoffs, and other catalog components. Use when Codex needs to search the hosted step.parts catalog before creating simplified placeholder geometry, resolve fuzzy part names, standards, aliases, or dimensions, choose a matching part, fetch a canonical .step file, verify checksums, or use the step.parts API/OpenAPI/catalog endpoints for standard part discovery.
+---
+
+# CAD Parts
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review.
+
+## Overview
+
+Use the hosted step.parts machine endpoints instead of scraping HTML or relying on local repository files. Treat `https://api.step.parts` as the canonical API origin and `https://www.step.parts` as the site/static-asset origin unless the user provides a different hosted mirror. Network/DNS failures are inconclusive: if `api.step.parts` cannot be reached from the sandbox, retry once with network permission before reporting a miss or using placeholder geometry. Do not describe a part as unavailable unless the API was reachable and returned no relevant candidates.
+
+When a CAD assembly includes named off-the-shelf actuators, servos, motors, electronics boards, connectors, or other purchasable components, search step.parts before creating simplified placeholder geometry. For named servos, motors, and actuators, search both exact model strings and common aliases/vendor spellings before giving up. For example, `STS3215` may also appear as `ST3215`, `3215`, `Waveshare Feetech ST3215`, or under `family=feetech`. If the API was reachable and no exact or near-exact match is available, record the search miss and then use a documented envelope or simplified stand-in.
+
+## Quick Workflow
+
+1. Interpret the requested part into search terms and optional facets:
+   - `q` for fuzzy tokens, standards, aliases, dimensions, source/product URLs, and attribute names/values.
+   - `category`, `family`, `standard`, or `tag` when the user gives an exact facet.
+2. Search `/v1/parts` and inspect `items`, `total`, and `facets`. For actuator model numbers, retry likely aliases, dropped letters, vendor names, and relevant family facets before treating an empty result as a miss.
+3. If results are ambiguous, present the best few options with `id`, `name`, `standard`, and key attributes before choosing. If one result clearly matches, return the selected record details without downloading unless the user asked for a local STEP file.
+4. When an exact or near-exact off-the-shelf actuator model is found, prefer downloading and using its STEP file unless there is a clear assembly-time reason to use a simplified envelope. Record that choice explicitly.
+5. When the user asks to download or save a STEP file, download its `stepUrl`, then verify the file with the record's `sha256` when present.
+6. Return the local path when downloaded, plus the selected part id and page/API URLs so the user can trace provenance.
+
+## CAD Viewer Handoff
+
+After completing step.parts work that creates or updates a local `.step` or `.stp` file, you must ALWAYS hand the explicit file path to `$cad-viewer` when that skill is installed. `$cad-viewer` must start CAD Viewer if it is not already running and return link(s) to the relevant created or updated file(s); if `$cad-viewer` is unavailable or startup fails, report that instead of silently omitting the handoff.
+
+## Bundled Downloader
+
+Use `scripts/download_step_part.py` for deterministic search, download, and checksum verification:
+
+```bash
+python scripts/download_step_part.py "M3 socket head 12" --download
+python scripts/download_step_part.py --id iso4762_socket_head_cap_screw_m3x12 --download
+python scripts/download_step_part.py "bearing 608zz" --limit 5
+```
+
+Useful options:
+
+- `--origin`: override `https://api.step.parts` only when the user provides another hosted API origin.
+- `--tag`, `--category`, `--family`, `--standard`: repeatable facet filters.
+- `--out-dir`: override the download directory when the user asks for a specific destination.
+- `--all`: with `--download`, download every result on the returned page as individual STEP downloads.
+- `--overwrite`: replace an existing output file.
+
+The script prints JSON to stdout. For searches, it prints matched records. For downloads, it prints saved file paths, checksums, and source URLs.
+
+## API Reference
+
+Read `references/step-parts-api.md` when you need endpoint details, field meanings, or query semantics. Prefer:
+
+- `/v1/parts` for filtered search with absolute asset URLs.
+- `/v1/parts/{id}` for one enriched record.
+- Returned `stepUrl` for STEP downloads.
+- `/v1/catalog/parts.index.json` for a compact discovery index.
+- `/v1/catalog/schema` for field and family attribute meanings.
+- `/v1/openapi.json` when generating a client or tool.
+
+## Search Guidance
+
+- Query tokens are ANDed by the API, so start specific but not overconstrained. For example, use `M3 SHCS 12` before adding exact family and standard filters.
+- Values within one facet are ORed together, and selected `tag`, `category`, `family`, and `standard` fields are ANDed together. Use exact facets to narrow within known categories, then rank manually by name and attributes.
+- Standards can be queried as `ISO 4762`, `ISO4762`, or the exact `standard.designation`.
+- The `attributes` object contains family-specific facts such as `thread`, `lengthMm`, `bore1Mm`, `material`, `profileSeries`, `slotSizeMm`, and dimensions in millimeters.
+- Part, GLB, and PNG URL patterns are predictable on `https://www.step.parts`; STEP URLs are environment-aware and may resolve to GitHub LFS media in production. Use catalog/API `stepUrl` for downloads.

--- a/.qwenpaw-plugin/skills/step-parts/agents/openai.yaml
+++ b/.qwenpaw-plugin/skills/step-parts/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "STEP Parts"
+  short_description: "Find and download STEP files from step.parts"
+  default_prompt: "Use $step-parts to find and download a STEP file from step.parts."

--- a/.qwenpaw-plugin/skills/step-parts/references/step-parts-api.md
+++ b/.qwenpaw-plugin/skills/step-parts/references/step-parts-api.md
@@ -1,0 +1,74 @@
+# step.parts API Reference
+
+## Origins
+
+Default to the API origin `https://api.step.parts`. Use a different origin only when the user supplies another hosted step.parts-compatible API domain. Static HTML pages live on `https://www.step.parts`; GLB and PNG preview URLs in API records point directly at Vercel Blob. STEP URLs are environment-aware and production records use commit-pinned GitHub LFS media. If the API domain does not resolve, treat the hosted service as unavailable and ask for a deployed origin when a live download is required.
+
+## Machine Endpoints
+
+| Endpoint | Use |
+| --- | --- |
+| `https://www.step.parts/llms.txt` | Human-readable agent guide with endpoint summary and examples. |
+| `/v1/parts` | Search, filter, paginate, and retrieve absolute asset URLs. |
+| `/v1/parts/{id}` | Fetch one enriched part record by stable id. |
+| `/v1/catalog/schema` | JSON Schema, field semantics, result ordering, and family attribute meanings. |
+| `/v1/catalog/parts.index.json` | Compact id/name/facet discovery index for cheap lookups before fetching details. |
+| `/v1/openapi.json` | OpenAPI 3.1 contract for generating clients/tools. |
+
+## `/v1/parts` Query Parameters
+
+- `q`: tokenized metadata search across id, name, description, category, family, stepSource, productPage, tags, aliases, standard fields, attribute keys, and attribute values. Every token must match.
+- `tag`, `category`, `family`, `standard`: repeatable filters. Values may also be comma-separated. Values within one facet are ORed, and selected facet fields are ANDed together.
+- `page`: 1-based page number.
+- `pageSize`: default `100`, max `500`.
+
+Unfiltered results start with a fixed 100-part showcase, then continue in stable source catalog order. Filtered results are ordered by stable source catalog order.
+
+Examples:
+
+```text
+https://api.step.parts/v1/parts?q=M3&tag=screw&page=2
+https://api.step.parts/v1/parts?pageSize=100
+https://api.step.parts/v1/parts?category=fastener&family=socket-head-cap-screw&standard=ISO%204762
+https://api.step.parts/v1/parts?q=lengthMm%2012
+```
+
+## Response Fields
+
+`/v1/parts` returns:
+
+- `catalog`: part count, last modified timestamp, catalog checksum, and URLs for schema/OpenAPI.
+- `items`: enriched part records with absolute `pageUrl`, `apiUrl`, `stepUrl`, `glbUrl`, and `pngUrl`.
+- `page`, `pageSize`, `total`, `totalPages`, `hasNextPage`, `hasPreviousPage`.
+- `facets`: available `tags`, `categories`, `families`, and `standards` with counts.
+- `filters`: parsed active filters.
+
+Each part record contains:
+
+- `id`: stable snake_case identifier and asset filename base.
+- `name`, `description`, `category`, `family`, `tags`, `aliases`.
+- `standard`: optional `{ body, number, designation }`.
+- `attributes`: family-specific scalar facts.
+- `stepUrl`, `glbUrl`, `pngUrl`.
+- `byteSize`, `sha256`.
+
+## Asset URL Patterns
+
+Use returned URLs when possible. Patterns are:
+
+```text
+https://www.step.parts/step/{id}.step
+Use the absolute `glbUrl` and `pngUrl` returned by the API record. Preview assets are served from Vercel Blob.
+https://www.step.parts/parts/{id}
+```
+
+The `/step/{id}.step` route serves local checked-out STEP bytes in local/dev mode and redirects to commit-pinned GitHub LFS media in production.
+
+## Download And Verification
+
+When downloading a STEP file:
+
+1. Fetch a part record from `/v1/parts` or `/v1/parts/{id}`.
+2. Download `stepUrl`.
+3. Compare the file SHA-256 to the part record's `sha256` when it is not null.
+4. Keep the original `.step` extension and preserve the source id in the filename unless the user asks otherwise.

--- a/.qwenpaw-plugin/skills/step-parts/scripts/download_step_part.py
+++ b/.qwenpaw-plugin/skills/step-parts/scripts/download_step_part.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Search step.parts for common standard parts and download STEP files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_ORIGIN = "https://api.step.parts"
+DEFAULT_OUT_DIR = tempfile.gettempdir()
+USER_AGENT = "step-parts-skill/1.0"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Search the step.parts hosted catalog for low-level common standard parts "
+            "(screws, bolts, bearings, electronics parts, motors, connectors, etc.) "
+            "and optionally download canonical STEP files."
+        ),
+    )
+    parser.add_argument("query", nargs="?", help="Fuzzy search query, for example 'M3 socket head 12'.")
+    parser.add_argument("--id", dest="part_id", help="Fetch a specific part id instead of searching.")
+    parser.add_argument("--origin", default=DEFAULT_ORIGIN, help=f"API origin. Default: {DEFAULT_ORIGIN}")
+    parser.add_argument("--download", action="store_true", help="Download the selected STEP file.")
+    parser.add_argument("--all", action="store_true", help="With --download, download every result on the returned page.")
+    parser.add_argument("--out-dir", default=DEFAULT_OUT_DIR, help="Directory for downloaded STEP files. Default: active temp directory.")
+    parser.add_argument("--filename", help="Filename to use when downloading one selected part.")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite an existing downloaded file.")
+    parser.add_argument("--limit", type=int, default=10, help="Search page size. The API caps this at 500.")
+    parser.add_argument("--page", type=int, default=1, help="1-based search page.")
+    parser.add_argument("--tag", action="append", default=[], help="Repeatable tag filter.")
+    parser.add_argument("--category", action="append", default=[], help="Repeatable category filter.")
+    parser.add_argument("--family", action="append", default=[], help="Repeatable family filter.")
+    parser.add_argument("--standard", action="append", default=[], help="Repeatable standard filter, for example 'ISO 4762'.")
+    parser.add_argument("--timeout", type=float, default=30.0, help="HTTP timeout in seconds.")
+    return parser.parse_args()
+
+
+def origin_url(origin: str) -> str:
+    parsed = urllib.parse.urlparse(origin)
+    if not parsed.scheme or not parsed.netloc:
+        raise SystemExit(f"Invalid origin: {origin!r}")
+    return origin.rstrip("/")
+
+
+def build_url(origin: str, path: str, params: list[tuple[str, str]] | None = None) -> str:
+    url = f"{origin_url(origin)}{path}"
+    if params:
+        return f"{url}?{urllib.parse.urlencode(params)}"
+    return url
+
+
+def request(url: str, timeout: float) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"HTTP {exc.code} for {url}: {detail}") from exc
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"Failed to fetch {url}: {exc.reason}") from exc
+
+
+def fetch_json(url: str, timeout: float) -> Any:
+    data = request(url, timeout)
+    try:
+        return json.loads(data)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Expected JSON from {url}: {exc}") from exc
+
+
+def search_parts(args: argparse.Namespace) -> dict[str, Any]:
+    params: list[tuple[str, str]] = [
+        ("page", str(max(1, args.page))),
+        ("pageSize", str(max(1, args.limit))),
+    ]
+    if args.query:
+        params.append(("q", args.query))
+    for key in ("tag", "category", "family", "standard"):
+        for value in getattr(args, key):
+            params.append((key, value))
+    return fetch_json(build_url(args.origin, "/v1/parts", params), args.timeout)
+
+
+def get_part(args: argparse.Namespace, part_id: str) -> dict[str, Any]:
+    safe_id = urllib.parse.quote(part_id, safe="")
+    return fetch_json(build_url(args.origin, f"/v1/parts/{safe_id}"), args.timeout)
+
+
+def selected_parts(args: argparse.Namespace) -> list[dict[str, Any]]:
+    if args.part_id:
+        return [get_part(args, args.part_id)]
+
+    result = search_parts(args)
+    items = result.get("items", [])
+    if not items:
+        raise SystemExit("No parts matched the query.")
+    if args.download and args.all:
+        return items
+    return [items[0]]
+
+
+def filename_for(part: dict[str, Any], requested_filename: str | None, allow_requested: bool) -> str:
+    if requested_filename and allow_requested:
+        return requested_filename
+    step_url = str(part.get("stepUrl") or "")
+    name = Path(urllib.parse.urlparse(step_url).path).name
+    if name:
+        return name
+    return f"{part['id']}.step"
+
+
+def step_download_url(part: dict[str, Any], origin: str) -> str:
+    step_url = part.get("stepUrl")
+    if not step_url:
+        raise SystemExit(f"Part {part.get('id', '<unknown>')} does not include stepUrl.")
+    return urllib.parse.urljoin(f"{origin_url(origin)}/", str(step_url))
+
+
+def write_download(part: dict[str, Any], args: argparse.Namespace, allow_requested_filename: bool) -> dict[str, Any]:
+    step_url = step_download_url(part, args.origin)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / filename_for(part, args.filename, allow_requested_filename)
+    if path.exists() and not args.overwrite:
+        raise SystemExit(f"Refusing to overwrite existing file: {path}")
+
+    data = request(step_url, args.timeout)
+    path.write_bytes(data)
+
+    actual_sha256 = hashlib.sha256(data).hexdigest()
+    expected_sha256 = part.get("sha256")
+    checksum_ok = expected_sha256 is None or expected_sha256 == actual_sha256
+    if not checksum_ok:
+        raise SystemExit(
+            f"Checksum mismatch for {path}: expected {expected_sha256}, got {actual_sha256}",
+        )
+
+    return {
+        "id": part.get("id"),
+        "name": part.get("name"),
+        "path": str(path),
+        "stepUrl": step_url,
+        "pageUrl": part.get("pageUrl"),
+        "apiUrl": part.get("apiUrl"),
+        "byteSize": len(data),
+        "sha256": actual_sha256,
+        "checksumVerified": expected_sha256 is not None,
+    }
+
+
+def compact_part(part: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": part.get("id"),
+        "name": part.get("name"),
+        "category": part.get("category"),
+        "family": part.get("family"),
+        "standard": part.get("standard"),
+        "attributes": part.get("attributes"),
+        "stepUrl": part.get("stepUrl"),
+        "pageUrl": part.get("pageUrl"),
+        "apiUrl": part.get("apiUrl"),
+        "sha256": part.get("sha256"),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    if args.filename and (not args.download or args.all):
+        raise SystemExit("--filename can only be used with --download for one selected part.")
+    if not args.part_id and not args.query and not any([args.tag, args.category, args.family, args.standard]):
+        raise SystemExit("Provide a query, --id, or at least one facet filter.")
+
+    if not args.download:
+        if args.part_id:
+            output: Any = compact_part(get_part(args, args.part_id))
+        else:
+            result = search_parts(args)
+            result["items"] = [compact_part(part) for part in result.get("items", [])]
+            output = result
+        json.dump(output, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    parts = selected_parts(args)
+    downloads = [
+        write_download(part, args, allow_requested_filename=len(parts) == 1)
+        for part in parts
+    ]
+    json.dump({"downloads": downloads}, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.qwenpaw-plugin/skills/urdf/LICENSE
+++ b/.qwenpaw-plugin/skills/urdf/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Thompson Labs LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.qwenpaw-plugin/skills/urdf/SKILL.md
+++ b/.qwenpaw-plugin/skills/urdf/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: urdf
+description: URDF robot description authoring and validation. Use when creating, editing, inspecting, validating, or debugging `.urdf` files, robot links, joints, limits, inertials, visual/collision geometry, mesh references, frame conventions, or robot-description artifacts. Use the SRDF skill for MoveIt2 semantic groups and IK/path-planning semantics; use the CAD skill for STEP/STL/3MF/DXF/GLB outputs.
+---
+
+# URDF
+
+Provenance: maintained in [earthtojake/text-to-cad](https://github.com/earthtojake/text-to-cad).
+Use the installed local skill files as the runtime source of truth; the
+repository link is only for provenance and release review.
+
+Use this skill for URDF robot-description outputs. Treat URDF work as constrained kinematic modeling, not just XML writing. The main correctness risks are frame placement, joint-axis semantics, unit consistency, mesh scale, and inertial data.
+
+## Setup
+
+This skill's commands are thin entrypoints over the `cadgen` distribution, which
+carries the Python build runtime and the JavaScript it executes. Install it once:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+Rendering additionally needs a browser, which pip cannot supply:
+
+```bash
+python -m playwright install chromium
+```
+
+## Core Rules
+
+1. The `.urdf` file is the source of truth. Author and edit URDF XML directly; do not build a Python generation pipeline for it. There is no `gen_urdf()` contract.
+2. Before writing or changing URDF XML, establish the robot's frame, joint, geometry, unit, and assumption ledger and embed it as a comment block at the top of the `.urdf` file. See `references/design-ledger.md`.
+3. Use URDF frame semantics exactly. Joint origins, link frames, joint axes, and visual/collision/inertial origins use different reference frames. See `references/frame-semantics.md`.
+4. Do not infer spatial transforms, mesh units, handedness, axes, or joint signs from vague prose. Use CAD transforms, dimensioned drawings, measured values, existing source data, or explicit documented assumptions.
+5. Never freehand numeric values that are the result of computation — inertia tensors, centers of mass, unit conversions across many links, mirrored transforms. Compute them: closed-form formulas for primitives, or a throwaway helper script for mesh-derived values. See `references/inertials.md`.
+6. For physical links, model `inertial`, `visual`, and `collision` separately when the target consumer needs them. Frame-only links may intentionally omit mass and geometry.
+7. Validate every created or modified `.urdf` with `cadgen urdf validate` before reporting completion. See `references/validation.md`.
+8. Helper scripts are allowed and encouraged for computation, but they are scaffolding, not the artifact's source of truth. For complex or genuinely parametric models it is reasonable to keep a model-local helper script on disk next to related source code (for example STEP generator sources) and note it in the ledger; this is optional, and the checked-in `.urdf` remains canonical.
+
+## CAD Viewer Handoff
+
+After completing URDF work that creates or modifies a `.urdf`, you must ALWAYS hand the explicit file path to `$cad-viewer` when that skill is installed. `$cad-viewer` must start CAD Viewer if it is not already running and return link(s) to the relevant created or updated file(s); if `$cad-viewer` is unavailable or startup fails, report that instead of silently omitting the handoff.
+
+## Workflow
+
+1. Identify the target `.urdf` file and its consumers: RViz, robot_state_publisher, Gazebo/Ignition, MoveIt, a real robot driver, or another simulator.
+2. Read or create the design ledger before editing frames, origins, axes, mesh scale, limits, or inertials. Keep the ledger as a comment block in the `.urdf` itself.
+3. Prepare mesh assets first when links reference meshes: one mesh per link, exported in that link's frame by the owning CAD/mesh workflow. See `references/meshes.md`.
+4. Author or edit the URDF XML directly, following `references/authoring-contract.md` for structure, ordering, and naming.
+5. Compute — never guess — inertials and other derived numbers. See `references/inertials.md`.
+6. Validate with `cadgen urdf validate`; fix findings and re-validate until clean.
+7. Run the verification recipe in `references/validation.md`: external tools when available (`check_urdf`), then a viewer review sweeping every joint.
+8. Report remaining assumptions, unchecked spatial data, and validation gaps.
+
+## Commands
+
+Run with the Python environment for the project or workspace. Treat `python` in examples as an interpreter placeholder; if bare `python` is unavailable, substitute `python3`, a project virtualenv interpreter, or the configured interpreter path. The validator uses only the Python standard library.
+
+The validator shape is:
+
+```bash
+cadgen urdf validate path/to/robot.urdf
+cadgen urdf validate path/to/robot.urdf --strict
+cadgen urdf validate path/to/robot.urdf --json
+cadgen urdf validate path/to/robot.urdf --packages robot_description=/path/to/pkg
+cadgen urdf snapshot path/to/robot.urdf review.png
+```
+
+The validator collects all findings in one pass (severity, code, XML path) across XML structure, tree topology, joint semantics (limits, mimic, dynamics), geometry, mesh references, materials, inertial physics, and misspelled elements, and prints a summary. One run validates ONE file: `--strict` treats warnings as failures; `--json` emits the machine-readable findings document; `--packages NAME=PATH` resolves `package://` mesh URIs and repeats for several roots. It exits nonzero if the target fails. Relative targets resolve from the current working directory; run from the workspace that owns the files.
+
+Validation is a guardrail, not spatial proof: a URDF can pass every structural check while placing a joint in the wrong spot. The ledger and viewer sweep exist for that reason.
+
+## Snapshot Tool
+
+`cadgen urdf snapshot` renders the robot to a PNG still, using the same shared
+CLI and headless browser runtime every rendering skill uses — so a snapshot matches what
+the CAD Viewer shows.
+
+```bash
+cadgen urdf snapshot path/to/robot.urdf review.png
+```
+
+It accepts `.urdf` only. Pose the robot with `--joint-values` — `{joint: degrees}` JSON,
+joints you do not name staying at the rest pose (the `"jointValues"` job field is the same
+thing in a packet). Robots are authored in metres and are framed on the robot scene scale
+automatically.
+
+Theme settings live under one `--theme`, mirroring the viewer's Theme tab. The default
+theme is `snapshot` — Workbench Light with the ground grid, origin axis and shadows
+removed, because in a still image those read as geometry. There is no `--display` on this
+door: display settings (mode, clip, exploded, edges) are CAD topology settings, and a robot
+carries none.
+
+Link meshes are resolved relative to the description, so they must be present: an
+unhydrated Git LFS pointer fails as "No link mesh loaded for robot". Run
+`git lfs checkout <mesh dir>` first.
+
+The grammar is `cadgen urdf snapshot TARGET [OUT] [flags]`, the same one every
+format door uses. Use `cadgen urdf snapshot --help` for the complete current
+interface — the flags a robot cannot act on are absent from it, not refused by it.
+
+## References
+
+- Authoring contract (structure, ordering, golden skeleton): `references/authoring-contract.md`
+- Design ledger: `references/design-ledger.md`
+- Frame semantics: `references/frame-semantics.md`
+- Mesh preparation and references: `references/meshes.md`
+- Inertials (formulas, scripts, sanity gates): `references/inertials.md`
+- URDF edit workflow: `references/urdf-workflow.md`
+- Validation and verification recipe: `references/validation.md`

--- a/.qwenpaw-plugin/skills/urdf/agents/openai.yaml
+++ b/.qwenpaw-plugin/skills/urdf/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "URDF"
+  short_description: "Author and validate URDF robot descriptions."
+  default_prompt: "Use $urdf to author, update, and validate URDF robot descriptions as direct XML, handing new or changed URDFs to $cad-viewer when available."

--- a/.qwenpaw-plugin/skills/urdf/references/authoring-contract.md
+++ b/.qwenpaw-plugin/skills/urdf/references/authoring-contract.md
@@ -1,0 +1,136 @@
+# URDF Authoring Contract
+
+Use this reference when writing or editing URDF XML directly. The `.urdf` file is the source of truth: it must carry its own documentation, and its structure must be predictable enough that any later agent or engineer can audit it without external context.
+
+## File Shape
+
+Every authored `.urdf` follows this shape, in this order:
+
+1. XML declaration: `<?xml version="1.0"?>`.
+2. Design-ledger comment block (see below).
+3. One `<robot name="...">` root element.
+4. All `<link>` elements, root link first, then in tree order (parents before children).
+5. All `<joint>` elements, in the same tree order as the child links they create.
+
+Keep two-space indentation and one element per line. Do not interleave links and joints arbitrarily; a reader should be able to walk the kinematic tree top-to-bottom.
+
+## Design-Ledger Comment Block
+
+The ledger lives in the file, immediately after the XML declaration, as XML comments. Minimum content:
+
+```xml
+<?xml version="1.0"?>
+<!--
+  robot: <name> | consumers: <RViz / Gazebo / MoveIt / driver / viewer>
+  units: meters, kilograms, radians | frames: +X forward, +Y left, +Z up (REP-103)
+  root: <root_link> | source of dimensions: <CAD file / drawing / measured / assumption>
+  meshes: <dir>, exported per-link in link frame, source units <mm|m>, scale <...>
+  inertials: <CAD mass properties / primitive formulas / assumed density X kg/m^3 / omitted>
+  assumptions: <every guessed value, sign convention, or approximation, one per line>
+-->
+```
+
+Update the ledger in the same edit that changes the modeled facts. A stale ledger is worse than no ledger. See `references/design-ledger.md` for the full ledger checklist.
+
+## Naming
+
+- Links: `<part>_link` for physical links (`base_link`, `forearm_link`), bare descriptive names for frame-only links (`base_footprint`, `tool0`, `camera_optical_frame`).
+- Joints: `<child-function>_joint` or `<parent>_to_<child>` (`shoulder_pan_joint`, `wrist_roll`). One convention per file.
+- Names are identifiers consumed by SRDF, controllers, and TF; never rename casually. If a rename is required, update every consumer (SRDF groups, group states, disabled collisions) in the same task.
+
+## Element Contract
+
+For every `<link>` that represents physical geometry, author the subelements in this order: `inertial`, `visual`, `collision`. Frame-only links are empty (`<link name="tool0" />`) and must be listed as frame-only in the ledger.
+
+For every `<joint>`:
+
+- Attributes: `name`, `type` (`fixed`, `revolute`, `continuous`, or `prismatic`; use `floating`/`planar` only when the consumer and validation path support them — the bundled validator rejects them).
+- Children in order: `<parent>`, `<child>`, `<origin>`, `<axis>` (movable joints), `<limit>` (revolute/prismatic), then optional `<dynamics>`, `<mimic>`, `<calibration>`, `<safety_controller>`.
+- `<origin>` is the parent-link-frame transform to the joint frame at zero position; the child link frame coincides with the joint frame.
+- `<axis>` is expressed in the joint (child) frame and should be a signed unit vector along a principal axis whenever the mechanism allows (`1 0 0`, `0 -1 0`, ...). A non-principal axis is a red flag: re-check the frame definitions before accepting one.
+- `<limit>` carries radians (revolute) or meters (prismatic) plus `effort` and `velocity` when the consumer needs them. `continuous` joints take no lower/upper limits.
+
+Never encode a kinematic fix by offsetting only the visual mesh; correct the joint/link frames instead, unless the mesh is genuinely offset from the link frame.
+
+## Golden Skeleton
+
+Copy this shape for new robots. It shows the ledger, ordering, a frame-only root, one fixed and one revolute joint, mesh + primitive geometry, and a computed inertial:
+
+```xml
+<?xml version="1.0"?>
+<!--
+  robot: example_arm | consumers: CAD Viewer, MoveIt
+  units: meters, kilograms, radians | frames: +X forward, +Y left, +Z up (REP-103)
+  root: base_footprint | source of dimensions: STEP/example_arm.step
+  meshes: 3MF/, exported per-link in link frame, source units mm, scale 0.001
+  inertials: primitive-formula approximations at assumed uniform density 1200 kg/m^3
+  assumptions:
+  - shoulder axis sign chosen so positive motion raises the arm (+Y rotation)
+  - base mass 1.2 kg estimated, not weighed
+-->
+<robot name="example_arm">
+  <link name="base_footprint" />
+  <link name="base_link">
+    <inertial>
+      <origin xyz="0 0 0.03" rpy="0 0 0" />
+      <mass value="1.2" />
+      <!-- solid cylinder r=0.06 l=0.06: ixx=iyy=m(3r^2+l^2)/12, izz=m r^2/2 -->
+      <inertia ixx="0.00144" ixy="0" ixz="0" iyy="0.00144" iyz="0" izz="0.00216" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="3MF/base_link.3mf" scale="0.001 0.001 0.001" />
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0.03" rpy="0 0 0" />
+      <geometry>
+        <cylinder radius="0.06" length="0.06" />
+      </geometry>
+    </collision>
+  </link>
+  <link name="shoulder_link">
+    <inertial>
+      <origin xyz="0 0 0.08" rpy="0 0 0" />
+      <mass value="0.6" />
+      <!-- solid box 0.06x0.06x0.16: ixx=iyy=m(y^2+z^2)/12, izz=m(x^2+y^2)/12 -->
+      <inertia ixx="0.00146" ixy="0" ixz="0" iyy="0.00146" iyz="0" izz="0.00036" />
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <geometry>
+        <mesh filename="3MF/shoulder_link.3mf" scale="0.001 0.001 0.001" />
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0.08" rpy="0 0 0" />
+      <geometry>
+        <box size="0.06 0.06 0.16" />
+      </geometry>
+    </collision>
+  </link>
+  <joint name="base_footprint_to_base" type="fixed">
+    <parent link="base_footprint" />
+    <child link="base_link" />
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </joint>
+  <joint name="shoulder_pitch" type="revolute">
+    <parent link="base_link" />
+    <child link="shoulder_link" />
+    <origin xyz="0 0 0.06" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-1.5708" upper="1.5708" effort="8" velocity="2" />
+  </joint>
+</robot>
+```
+
+## Helper Scripts
+
+Direct authoring does not mean freehand numbers. Write a throwaway script whenever:
+
+- inertials come from meshes or CAD solids (mass properties integration);
+- more than a handful of transforms share a conversion (mm-to-m tables, mirrored left/right chains);
+- disabled-collision or adjacency data must be derived downstream.
+
+For complex or genuinely parametric models, the helper may be kept on disk next to related model source (for example beside STEP generator sources) and referenced from the ledger. The checked-in `.urdf` is still canonical: regenerating is an explicit editing action, never an implicit build step.

--- a/.qwenpaw-plugin/skills/urdf/references/design-ledger.md
+++ b/.qwenpaw-plugin/skills/urdf/references/design-ledger.md
@@ -1,0 +1,112 @@
+# URDF Design Ledger
+
+Use this reference before creating or editing a `.urdf`. The ledger is the written spatial model that prevents silent frame, axis, unit, and mesh-scale mistakes.
+
+The ledger's canonical home is a comment block at the top of the `.urdf` file itself (see the compact format in `references/authoring-contract.md`), optionally expanded in an adjacent README for large robots. It must be specific enough that another engineer can audit the URDF without reverse-engineering the XML, and it must be updated in the same edit that changes the modeled facts.
+
+The sections below are the checklist of what the ledger must cover. For small robots the per-link and per-joint tables can collapse into a few comment lines; the information, not the table format, is what is required.
+
+## Required Sections
+
+### Robot Metadata
+
+Record:
+
+- robot name
+- target consumers: RViz, robot_state_publisher, Gazebo/Ignition, MoveIt, real robot driver, or other
+- unit convention: meters, kilograms, seconds, radians unless the project explicitly states otherwise
+- frame convention: REP-103-style body convention when applicable, or a documented exception
+- mesh unit convention: meters, millimeters, inches, or other
+- source of dimensions: CAD, drawing, measured data, vendor documentation, existing URDF, or assumption
+
+### Link Ledger
+
+For every link, record:
+
+| Field | Meaning |
+|---|---|
+| link name | Exact URDF `<link name="...">` value. |
+| role | Physical link, frame-only link, sensor frame, tool frame, base frame, or other. |
+| frame definition | Where the link frame is located and how its axes point. |
+| parent joint | Joint that creates this child link frame, or `none` for root. |
+| visual geometry | Primitive or mesh source, with origin relative to the link frame. |
+| collision geometry | Primitive or mesh source, with origin relative to the link frame. |
+| inertial source | CAD mass properties, vendor data, approximation, or intentionally omitted. |
+
+Frame-only links such as `base_footprint`, optical frames, and `tool0` may omit inertial, visual, and collision blocks. Mark them explicitly as frame-only rather than leaving intent ambiguous.
+
+### Joint Ledger
+
+For every joint, record:
+
+| Field | Meaning |
+|---|---|
+| joint name | Exact URDF `<joint name="...">` value. |
+| type | `fixed`, `revolute`, `continuous`, or `prismatic` for the bundled validator; record `floating` or `planar` only if the project has a different supported validation path. |
+| parent link | Link whose frame expresses the joint origin. |
+| child link | Link whose frame is created at the joint frame. |
+| origin xyz/rpy | Parent-link-frame transform from parent link to joint frame. |
+| axis | Axis vector expressed in the joint frame, for movable joints. |
+| limits | Radians for revolute, meters for prismatic, no finite lower/upper limits for continuous. |
+| positive motion | What positive joint motion physically does. |
+| source | CAD, drawing, measured data, existing model, or documented assumption. |
+
+Do not write a movable joint without an explicit positive-motion convention. The sign of the axis is part of the model, not a cosmetic detail.
+
+### Geometry Ledger
+
+For every visual or collision item, record:
+
+| Field | Meaning |
+|---|---|
+| link | Owning link. |
+| kind | `visual` or `collision`. |
+| geometry type | `mesh`, `box`, `cylinder`, or `sphere`. |
+| source | CAD export, primitive approximation, vendor mesh, generated mesh, or temporary placeholder. |
+| origin xyz/rpy | Transform from link frame to geometry frame. |
+| scale | Mesh scale if applicable. |
+| units | Mesh source units and URDF scale needed to express meters. |
+
+Visual geometry is for display. Collision geometry is for contact, planning, and physics. It may intentionally be simpler than the visual geometry.
+
+### Inertial Ledger
+
+For every physical link, record:
+
+| Field | Meaning |
+|---|---|
+| mass | Kilograms. |
+| center of mass | Inertial origin xyz in the link frame. |
+| inertia tensor | Tensor values and frame. |
+| source | CAD mass properties, vendor data, calculation, approximation, or intentionally omitted. |
+| confidence | Exact, estimated, placeholder, or unknown. |
+
+Do not silently copy visual origins into inertial origins. The visual frame, collision frame, link frame, and center of mass can all differ.
+
+### Assumption Ledger
+
+Record every inferred or guessed value, including:
+
+- unknown dimensions
+- mesh units
+- sign conventions
+- joint axes
+- parent/child direction
+- visual or collision offsets
+- mass, COM, and inertia approximations
+- frame-only link intent
+- unverified package URI resolution
+
+List assumptions one per line in the ledger comment block so they survive with the file. In helper scripts, name assumed values by physical meaning (`ASSUMED_BASE_TO_SHOULDER_Z_M`), never as unlabelled numeric literals.
+
+## When Information Is Missing
+
+If spatial information is missing, do not invent a precise-looking transform. Choose one of these outcomes:
+
+1. preserve existing source data unchanged;
+2. create a frame-only or placeholder structure with explicit assumption comments;
+3. use a clearly named approximate constant;
+4. ask for dimensions or CAD data when the workflow allows interaction;
+5. report that the model is structurally valid but spatially provisional.
+
+A provisional URDF is acceptable when clearly labelled. A plausible but undocumented URDF is not.

--- a/.qwenpaw-plugin/skills/urdf/references/frame-semantics.md
+++ b/.qwenpaw-plugin/skills/urdf/references/frame-semantics.md
@@ -1,0 +1,105 @@
+# URDF Frame Semantics
+
+Use this reference whenever editing origins, axes, visual placement, collision placement, or inertials. Most URDF authoring errors are frame errors.
+
+## Core Semantics
+
+URDF represents a robot as a tree of links connected by joints.
+
+For a joint:
+
+- `<parent link="...">` names the parent link.
+- `<child link="...">` names the child link.
+- `<origin xyz="..." rpy="...">` is the transform from the parent link frame to the joint frame.
+- The child link frame is coincident with the joint frame.
+- `<axis xyz="...">` for a movable joint is expressed in the joint frame, not automatically in the world frame and not in the visual mesh frame.
+
+For link subelements:
+
+- `<visual><origin ...>` is expressed in the link frame.
+- `<collision><origin ...>` is expressed in the link frame.
+- `<inertial><origin ...>` is the center-of-mass/inertial frame expressed in the link frame.
+
+These origins are independent. A mesh can be offset from its link frame, and the center of mass can be offset differently.
+
+## Units and Angles
+
+Use:
+
+- meters for length;
+- kilograms for mass;
+- radians for angles;
+- seconds for time;
+- right-handed coordinate frames unless the project documents an exception.
+
+Do not store revolute limits in degrees in URDF. Convert degrees to radians before writing them.
+
+Do not use finite lower/upper limits for a `continuous` joint unless the project is intentionally not using URDF continuous-joint semantics.
+
+## Joint Axis Checklist
+
+For every non-fixed joint, confirm:
+
+1. the axis is present;
+2. the axis vector has three finite numbers;
+3. the vector is nonzero;
+4. the vector is normalized or intentionally normalized by helper code;
+5. the vector is expressed in the joint frame;
+6. positive motion is documented.
+
+Examples:
+
+```xml
+<joint name="shoulder_pan_joint" type="revolute">
+  <parent link="base_link" />
+  <child link="shoulder_link" />
+  <origin xyz="0 0 0.24" rpy="0 0 0" />
+  <axis xyz="0 0 1" />
+  <limit lower="-3.14159" upper="3.14159" effort="40" velocity="2" />
+</joint>
+```
+
+This means the child link frame is at `z = 0.24` in `base_link`, and positive joint motion rotates about +Z of the joint/child frame.
+
+## Visual and Collision Placement Checklist
+
+For every visual or collision block, confirm:
+
+1. the origin is relative to the owning link frame;
+2. mesh scale converts the mesh source units into meters;
+3. visual and collision geometry are intentionally the same or intentionally different;
+4. collision geometry is simple enough for the intended physics/planning consumer;
+5. mesh paths are stable from the URDF file's location or use an intended package URI.
+
+Example:
+
+```xml
+<link name="forearm_link">
+  <visual>
+    <origin xyz="0 0 0" rpy="0 0 0" />
+    <geometry>
+      <mesh filename="package://robot_description/meshes/forearm.stl" scale="0.001 0.001 0.001" />
+    </geometry>
+  </visual>
+  <collision>
+    <origin xyz="0.12 0 0" rpy="0 1.57079632679 0" />
+    <geometry>
+      <cylinder radius="0.035" length="0.24" />
+    </geometry>
+  </collision>
+</link>
+```
+
+This places the visual mesh at the link frame and uses a simplified collision cylinder offset in the same link frame.
+
+## Inertial Placement Checklist
+
+For every physical link with inertial data, confirm:
+
+1. mass is positive and finite;
+2. inertial origin is the center of mass in the link frame;
+3. inertia tensor values are in SI units;
+4. tensor values correspond to the inertial frame being declared;
+5. approximations are documented.
+
+Do not infer inertial origin from visual or collision origin unless the source data proves they coincide.

--- a/.qwenpaw-plugin/skills/urdf/references/inertials.md
+++ b/.qwenpaw-plugin/skills/urdf/references/inertials.md
@@ -1,0 +1,63 @@
+# URDF Inertials
+
+Inertials are the most-freehanded and least-checked part of LLM-authored URDFs. The rule is absolute: **never type inertia numbers from intuition.** Every `mass`, inertial `origin`, and `inertia` value is either copied from source data (CAD mass properties, vendor datasheet, measurement) or computed by a formula or script in the same task. Record which, per link, in the design ledger.
+
+## When Inertials Are Required
+
+- Simulation and dynamics consumers (Gazebo/Ignition, physics engines, torque control): every physical link needs a valid `inertial`.
+- Visualization-only or kinematics-only consumers (RViz, CAD Viewer, MoveIt kinematic planning): inertials are optional but still recommended so the model stays simulator-ready.
+- Frame-only links (`base_footprint`, optical frames, TCP markers): intentionally omit `inertial` and mark the link frame-only in the ledger.
+
+Do not give movable physical links zero or missing mass for a simulation target; most engines misbehave. If mass is unknown, use a documented assumed density or assumed total mass distributed by volume, and say so in the ledger.
+
+## Semantics
+
+- `<inertial><origin>` is the center of mass expressed in the link frame. It is not the visual origin, the collision origin, or the joint origin.
+- `<inertia>` is the rotational inertia tensor about the center of mass, expressed in the inertial frame (link frame rotated by the inertial origin `rpy`), in kg·m².
+- If source data gives the tensor about another point, transfer it to the COM (parallel axis theorem, subtracting) before writing it down — or simpler, re-export CAD mass properties about the COM.
+
+## Closed-Form Formulas (solid, uniform density)
+
+With mass `m` (kg) and dimensions in meters, about the COM, axis-aligned:
+
+- Box `x × y × z`: `ixx = m(y² + z²)/12`, `iyy = m(x² + z²)/12`, `izz = m(x² + y²)/12`.
+- Cylinder radius `r`, length `l`, axis +Z: `ixx = iyy = m(3r² + l²)/12`, `izz = m r²/2`.
+- Sphere radius `r`: `ixx = iyy = izz = 2m r²/5`.
+- Thin rod length `l`, axis +Z: `ixx = iyy = m l²/12`, `izz ≈ 0` (use a small positive value, not 0).
+
+Off-diagonal terms are zero for these primitives when the axes align with the link frame. If the primitive is rotated relative to the link frame, express the rotation in the inertial origin `rpy` instead of hand-rotating the tensor.
+
+## Mesh-Derived Inertials
+
+For mesh geometry, write a throwaway helper script; do not approximate a complex part as a primitive without saying so in the ledger. The standard recipe with `trimesh`:
+
+```python
+import trimesh
+mesh = trimesh.load("3MF/forearm_link.3mf", force="mesh")
+mesh.apply_scale(0.001)          # mm -> m, match the URDF mesh scale
+mesh.density = 1200.0            # documented assumed density, kg/m^3
+print("mass", mesh.mass)
+print("com", mesh.center_mass)   # -> inertial <origin xyz>
+print(mesh.moment_inertia)       # about COM, link-frame axes -> ixx..izz
+```
+
+Requirements for the script route:
+
+- The mesh must be the same file, same frame, and same scale as the URDF reference; otherwise the COM and tensor land in the wrong frame.
+- The mesh should be watertight for volume integration; if it is not, fix the export or fall back to a documented primitive approximation.
+- Uniform density is an assumption — record the chosen density (or the total-mass target it was derived from) in the ledger.
+- CAD-native mass properties (for example OCP/OpenCascade `BRepGProp` on the STEP solid) are better than mesh integration when the STEP source is available; same rules apply.
+
+For complex or parametric models it is reasonable to keep this helper script on disk next to the model's other source files and reference it from the ledger. That is optional; the checked-in URDF values remain canonical.
+
+## Sanity Gates
+
+Before accepting any inertial block, check:
+
+1. `mass > 0`, all values finite; diagonal `ixx, iyy, izz > 0`.
+2. Triangle inequality: `ixx + iyy ≥ izz`, `ixx + izz ≥ iyy`, `iyy + izz ≥ ixx` (the bundled validator enforces this).
+3. Magnitude plausibility: for a part with characteristic size `d` and mass `m`, diagonal terms should be within roughly an order of magnitude of `m·d²/10`. A 0.5 kg, 10 cm part with `ixx = 2.0` kg·m² is wrong by ~1000×.
+4. COM plausibility: the inertial origin lies inside (or very near) the part's bounding volume.
+5. Off-diagonal terms are small relative to diagonals unless the part is genuinely skewed in the link frame — large `ixy/ixz/iyz` values usually mean the tensor was expressed in the wrong frame.
+
+A common unit bug to watch for: CAD systems report mass properties in mm-based units. Converting mm-based inertia to kg·m² requires a factor of `1e-6` on top of any density conversion (lengths enter the tensor squared, volumes cubed). If the magnitude gate fails by a clean power of ten, suspect this first.

--- a/.qwenpaw-plugin/skills/urdf/references/meshes.md
+++ b/.qwenpaw-plugin/skills/urdf/references/meshes.md
@@ -1,0 +1,45 @@
+# URDF Mesh Preparation and References
+
+Bad mesh handling is a top URDF failure mode, and it usually happens *before* any XML is written: source CAD is split into per-link assets incorrectly, exported in the wrong frame, or referenced at the wrong scale. Prepare assets first, then author XML that matches them.
+
+## Splitting Source CAD Into Link Assets
+
+The unit of export is the **link**, not the assembly and not the CAD feature tree:
+
+1. Enumerate the links from the design ledger first. Every link that shows geometry gets exactly one visual asset (or an explicit set of assets); rigidly-joined parts that belong to one link are merged into that link's single export.
+2. Never point multiple links at one combined assembly mesh with compensating origins. If two links share a source body, the body must be split at the joint in CAD before export.
+3. Export each link's mesh **in that link's own frame** — the frame the ledger defines, coincident with the parent joint frame at zero position. Done right, every `<visual><origin>` is identity (`0 0 0`, `0 0 0`), which is the convention to follow and the easiest state to audit.
+4. If an export cannot be re-framed (vendor mesh, scanned part), a nonzero visual origin is acceptable but must be recorded in the ledger with its source; it is a per-link constant, not a tuning knob.
+5. Splitting, re-framing, and exporting STEP/STL/3MF/GLB assets belongs to the owning CAD workflow (`$cad`, `$step-parts` when installed). Do not attempt to fix a wrong split by editing URDF origins.
+
+Checklist after export, before authoring:
+
+- one file per link, named after the link (`3MF/forearm_link.3mf`);
+- zero pose in the mesh file corresponds to the link frame;
+- units of the export are known and recorded (mm is common for 3MF/STL);
+- the export actually contains only that link's geometry (open it, or check bounding boxes with a one-line script).
+
+## Units and Scale
+
+- URDF lengths are meters. Mesh files are frequently millimeters, and STL carries no unit metadata at all.
+- Express the conversion explicitly with `scale` on every mesh reference: `scale="0.001 0.001 0.001"` for mm sources. Omit `scale` only when the mesh is genuinely authored in meters.
+- One convention per robot: do not mix mm and m assets in the same file without a ledger entry per exception.
+- A robot rendering ~1000× too large or too small in the viewer is a scale-attribute bug; fix the scale, not the joint origins.
+
+## Reference Forms
+
+- **Local relative paths** (`3MF/forearm_link.3mf`) resolve from the `.urdf` file's directory. Preferred for a robot kept in a project tree — the bundled validator verifies these files exist.
+- **`package://name/path` URIs** are for ROS-package consumers. The validator checks syntax only and warns that resolution is consumer-specific; confirm the consuming environment resolves the package root as expected.
+- Remote URIs are accepted with warnings; avoid them for durable fixtures.
+
+Keep mesh files under the same model directory tree as the URDF, so the file and its assets move together.
+
+## Visual vs Collision Assets
+
+- Visual meshes are for display: full detail, colors preserved where the format supports it.
+- Collision geometry is for physics/planning: prefer primitives (`box`, `cylinder`, `sphere`) sized from the part's bounding volume, or a coarse closed mesh. Using the visual mesh for collision is a temporary fallback, not a default — concave visual meshes make physics engines slow and unstable.
+- Collision origins are expressed in the link frame, independent of the visual origin.
+
+## When Meshes Change
+
+Mesh assets are owned by the CAD workflow. If the CAD source changed shape, re-export the affected link assets with the owning workflow first, then re-check the URDF: link frames, visual origins, collision approximations, and inertials may all be stale. Re-run the validator and the viewer sweep afterwards.

--- a/.qwenpaw-plugin/skills/urdf/references/urdf-workflow.md
+++ b/.qwenpaw-plugin/skills/urdf/references/urdf-workflow.md
@@ -1,0 +1,79 @@
+# URDF Workflow
+
+Use this reference when editing robot-description structure, frame placement, mesh references, inertial data, or any `.urdf` output.
+
+## Edit Loop
+
+1. Locate the target `.urdf`. It is the source of truth; edit it directly.
+2. Identify target consumers and strictness requirements: visualization, TF tree, simulation, planning, or real robot integration.
+3. Read the design-ledger comment block at the top of the file; create it if missing (see `references/design-ledger.md`). Update the ledger in the same edit that changes modeled facts.
+4. If links reference meshes, prepare or verify the per-link assets first (see `references/meshes.md`).
+5. Apply URDF frame semantics exactly: joint origin in parent frame, child link frame at joint frame, joint axis in joint frame, visual/collision/inertial origins in link frame (see `references/frame-semantics.md`).
+6. Author links, joints, limits, axes, origins, inertials, and geometry per `references/authoring-contract.md`. Compute derived numbers — inertia tensors, unit conversions, mirrored transforms — with formulas or a helper script; never freehand them (see `references/inertials.md`).
+7. Validate with `cadgen urdf validate <file.urdf>` and fix findings until clean.
+8. Run the rest of the verification recipe in `references/validation.md`: external tools when available, then a `$cad-viewer` sweep of every movable joint against the ledger's positive-motion statements.
+9. Report smoke tests run, checks skipped, and remaining assumptions.
+
+## Spatial-Reasoning Guardrails
+
+LLMs are prone to plausible-looking spatial mistakes. Use these guardrails:
+
+- Do not infer dimensions, handedness, axes, mesh units, or joint signs from vague descriptions.
+- Do not silently mirror left/right parts. A mirrored chain changes axis signs and off-diagonal inertia terms; derive the mirror transform explicitly (helper script) and record it in the ledger.
+- Do not assume visual mesh origin equals link frame, collision frame, or center of mass.
+- Do not assume CAD mesh units are meters. STL files carry no reliable unit metadata.
+- Do not encode a kinematic correction by offsetting only the visual mesh; correct the link and joint frames unless the visual mesh is genuinely offset.
+- Preserve existing proven transforms unless the task explicitly requires changing them.
+- Record every assumed value in the ledger comment block; in helper scripts, name constants by physical meaning (`ASSUMED_BASE_TO_SHOULDER_Z_M`).
+
+## Standard Link Tags
+
+Use these tags for each link that represents physical robot geometry:
+
+- `inertial`: mass, center of mass, and inertia tensor used by simulators.
+- `visual`: display geometry and optional material.
+- `collision`: contact geometry used by physics and planning.
+
+Frame-only links, such as `base_footprint`, optical frames, or tool-center marker frames, may intentionally omit these tags when they represent no physical mass or geometry.
+
+For movable physical links, avoid zero or missing mass unless the target simulator explicitly supports that modeling choice. If exact mass properties are unavailable, use a documented approximation and make the approximation easy to replace later.
+
+## Joint Authoring
+
+For every joint, confirm:
+
+- parent and child direction are correct;
+- joint origin is expressed in the parent link frame and places the child frame at zero position;
+- non-fixed joint axis is expressed in the joint frame, preferably a signed unit vector along a principal axis;
+- positive motion is stated in words in the ledger ("positive shoulder_pitch raises the arm") — the axis sign is part of the model, not a cosmetic detail;
+- revolute limits are radians, prismatic limits are meters;
+- continuous joints are not given artificial finite lower/upper limits;
+- fixed joints are used for frame relationships and rigid assemblies.
+
+Supported joint types may vary by consumer. The bundled validator supports `fixed`, `continuous`, `revolute`, and `prismatic`; do not author `floating` or `planar` joints unless the consumer and validation path support them.
+
+After authoring, the axis-sign check is non-negotiable: sweep the joint in the viewer and compare the motion with the ledger statement. Structural validation cannot catch a flipped sign.
+
+## Collision Geometry
+
+Add collision geometry under each `<link>` that should participate in physics, contact, or collision-aware planning. Do not encode collision behavior on joints.
+
+Use one or more `<collision>` blocks per link. The `<origin>` is expressed in the link frame, just like `<visual>`, and mesh scales must match the units of the exported mesh.
+
+Prefer simplified collision geometry over detailed visual meshes, from simplest to most specific:
+
+- primitive `<box>`, `<cylinder>`, or `<sphere>` geometry when it approximates the part well;
+- a coarse, closed collision mesh exported from CAD;
+- the visual mesh as a temporary fallback for loading and smoke tests.
+
+## Inertials
+
+For each physical link, use an explicit `inertial` block when the target simulator or dynamics consumer needs mass properties. The inertial origin is the center of mass in the link frame — not automatically the visual mesh origin, collision origin, or link origin.
+
+All values are computed or copied from source data, never freehanded; see `references/inertials.md` for formulas, the mesh-script recipe, and sanity gates.
+
+## Downstream Ownership
+
+- CAD or mesh workflows own mesh generation and per-link splitting/export.
+- This skill owns the `.urdf`: references, scales, placements, structure.
+- SRDF/MoveIt workflows own semantic groups, named joint poses via `<group_state>`, and planning metadata. Renaming links or joints here breaks them; update both in the same task.

--- a/.qwenpaw-plugin/skills/urdf/references/validation.md
+++ b/.qwenpaw-plugin/skills/urdf/references/validation.md
@@ -1,0 +1,67 @@
+# URDF Validation and Verification
+
+Every created or modified `.urdf` runs this recipe before the task is reported complete. Validation is a guardrail, not a substitute for the design ledger or a viewer/consumer smoke test: a URDF can pass every structural check while still having incorrect spatial assumptions.
+
+## Recipe
+
+Run in order; stop and fix at the first failing step:
+
+1. **Bundled validator** (always): `cadgen urdf validate path/to/robot.urdf`. It collects *all* findings in one pass (severity, code, XML path); fix them and re-run until clean. Use `--strict` to fail on warnings, `--json` for machine-readable output, and `--packages NAME=PATH` (repeatable) to resolve `package://` mesh URIs.
+2. **External URDF tools** (when installed): `check_urdf robot.urdf` (ros liburdfdom) parses with the reference parser and prints the link tree. Report as skipped when unavailable.
+3. **Viewer sweep** (whenever `$cad-viewer` is available): load the file, confirm meshes appear at sane scale and pose, then sweep **every** movable joint through its limits and compare the motion against the ledger's positive-motion statement, joint by joint. This is the only step that catches a wrong axis sign.
+4. **Consumer smoke test** (when the target runtime is available): RViz display, robot_state_publisher TF tree, Gazebo/Ignition load, or MoveIt model load.
+
+Report which steps ran and which were skipped.
+
+## What the Bundled Validator Checks
+
+Structure:
+
+- root element is `<robot>` with a non-empty name;
+- links and joints have unique, non-empty names;
+- every joint has parent and child links that exist;
+- each child link has at most one parent; exactly one root link; connected, acyclic, exactly `links - 1` joints.
+
+Joints:
+
+- type is `fixed`, `continuous`, `revolute`, or `prismatic` (`floating`/`planar` are rejected — use them only with a consumer-specific validation path);
+- origins have three finite values for `xyz`/`rpy` when present;
+- movable joints have a nonzero, finite axis; warnings for an omitted axis (spec default `1 0 0`) and non-unit axes;
+- revolute/prismatic joints have finite `lower <= upper` limits; `effort`/`velocity` must be non-negative and warn when omitted; fixed/continuous joints warn when they carry ignored position limits;
+- `<dynamics>` damping/friction must be non-negative;
+- `<mimic>` must reference an existing, non-fixed, non-self joint with no mimic cycles;
+- joint names colliding with link names warn (URDF-to-SDF conversion breaks).
+
+Geometry and meshes:
+
+- each visual/collision has exactly one geometry child from `mesh`, `box`, `cylinder`, `sphere`;
+- primitive dimensions are positive and finite; mesh `scale` values nonzero and finite (negative scale mirrors the mesh and warns — consumer support varies);
+- local mesh paths resolve to existing files relative to the `.urdf`; `package://` and remote URIs pass with a warning because resolution is consumer-specific.
+
+Inertials (when present):
+
+- at most one `<inertial>` per link; `mass` positive and finite; all six tensor values present and finite;
+- diagonal values positive; the full tensor must be positive semidefinite (eigenvalue check — catches bad off-diagonals);
+- principal moments violating the triangle inequality (`l1 + l2 >= l3`) warn (real-world exports often violate slightly; `--strict` promotes it);
+- movable links with geometry but no inertial warn.
+
+Authoring hygiene:
+
+- unknown elements under `<robot>`, `<link>`, `<joint>`, `<visual>`, `<collision>`, and `<inertial>` warn — misspelled elements are otherwise silently ignored by consumers (namespaced extensions like `<gazebo>` pass through);
+- visual `<material name>` references without a matching definition warn;
+- mesh extensions outside the common set (stl/dae/obj/3mf/glb/gltf/ply) warn.
+
+The validator intentionally does not require inertials or collision geometry on every link — that is target-consumer policy, decided in the ledger (see `references/inertials.md`). When a file fails a *project* policy rather than these checks, report it as policy failure, not URDF invalidity.
+
+## What Validation Cannot Prove
+
+- That a joint origin or axis matches the physical robot — only the ledger plus the viewer sweep checks that.
+- That mesh source units match the declared `scale`.
+- That inertial values match the actual part, beyond plausibility gates.
+- That `package://` URIs resolve in the target environment.
+
+Call these out explicitly in the final report when they were not independently verified.
+
+## Failure Handling
+
+When validation fails: fix the `.urdf` (and the ledger if the modeled facts changed), re-run the validator, and continue the recipe from the top. If the root cause is a bad mesh export, fix it in the owning CAD workflow first — do not paper over asset problems with URDF origins.

--- a/.qwenpaw-plugin/skills/urdf/requirements.txt
+++ b/.qwenpaw-plugin/skills/urdf/requirements.txt
@@ -1,0 +1,1 @@
+cadgen[snapshot]==0.5.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,9 @@ for the full flow, the resume path, the rehearsal, and local/manual fallbacks.
 ## Repo Map
 
 - `skills/`: agent skills and their references/scripts.
-- `.claude-plugin/`, `.codex-plugin/`: agent plugin manifests. The repository
-  root is the plugin package; its skills are `skills/` directly.
+- `.claude-plugin/`, `.codex-plugin/`, `.qwenpaw-plugin/`: agent plugin
+  manifests. The repository root is the plugin package; its skills are
+  `skills/` directly.
 - `models/`: sample and durable CAD/robot-description fixtures.
 - `apps/viewer/`: the CAD Viewer's React client (its backend is `cadgen.viewer`).
 - `packages/cadgen-js`: shared JS CAD/render/runtime code, UI-framework agnostic.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,9 +284,9 @@ production-output check.
 `main` is the source tree, what installers clone, and what releases are cut
 from. There is no development symlink layout and no generated publish tree:
 every path is the real file, and the repository root is itself the agent plugin
-package (`.claude-plugin/` and `.codex-plugin/` hold the manifests; the plugin's
-skills are `skills/` directly), so whatever is on `main` is what agent
-installers copy.
+package (`.claude-plugin/`, `.codex-plugin/`, and `.qwenpaw-plugin/` hold the
+manifests; the plugin's skills are `skills/` directly), so whatever is on
+`main` is what agent installers copy.
 
 Three consequences are enforced by `scripts/github-workflows/check-builds.sh`
 on every push:

--- a/README.md
+++ b/README.md
@@ -139,6 +139,15 @@ grok plugin install earthtojake/text-to-cad --trust
 grok plugin enable cad
 ```
 
+```bash
+# QwenPaw (clone the repo, then install the plugin directory)
+git clone https://github.com/earthtojake/text-to-cad.git
+qwenpaw plugin install text-to-cad/.qwenpaw-plugin
+```
+
+The QwenPaw plugin registers the skills as a skill provider: every skill is
+copied into each QwenPaw workspace and enabled by default.
+
 Restart your agent if newly installed skills do not appear. For local
 development, branch from `main`, open PRs against `main`, and follow
 [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/apps/docs/src/app/page.tsx
+++ b/apps/docs/src/app/page.tsx
@@ -24,6 +24,13 @@ const pluginInstallCommands = [
     agent: "Grok Build",
     command: "grok plugin install earthtojake/text-to-cad --trust",
   },
+  // QwenPaw has no marketplace resolution over GitHub; its CLI installs a plugin
+  // from a local directory or a ZIP, so the repo is cloned first.
+  {
+    agent: "QwenPaw",
+    command:
+      "git clone https://github.com/earthtojake/text-to-cad.git\nqwenpaw plugin install text-to-cad/.qwenpaw-plugin",
+  },
 ];
 
 const skillGroups = [

--- a/scripts/release/sync-version.mjs
+++ b/scripts/release/sync-version.mjs
@@ -25,6 +25,7 @@ export const jsonTargets = [
   },
   { path: ".claude-plugin/plugin.json", fields: [["version"]] },
   { path: ".codex-plugin/plugin.json", fields: [["version"]] },
+  { path: ".qwenpaw-plugin/plugin.json", fields: [["version"]] },
   { path: ".claude-plugin/marketplace.json", fields: [["version"]], pluginEntries: ["cad"] },
 ];
 

--- a/tests/python/global/test_qwenpaw_plugin.py
+++ b/tests/python/global/test_qwenpaw_plugin.py
@@ -1,0 +1,298 @@
+"""The QwenPaw plugin mirrors the other agent plugin manifests.
+
+`.qwenpaw-plugin/` is the third installer-facing plugin package beside
+`.claude-plugin/` and `.codex-plugin/`. Its manifest must carry the release
+version (stamped from VERSION by `scripts/release/sync-version.mjs`), and its
+entry point must import cleanly without QwenPaw installed — the QwenPaw loader
+validates a plugin by importing the backend entry and requiring a `plugin`
+instance, and a checkout has no `qwenpaw` package.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_DIR = REPO_ROOT / ".qwenpaw-plugin"
+MANIFEST_PATH = PLUGIN_DIR / "plugin.json"
+
+VALID_QWENPAW_TYPES = {
+    "tool",
+    "provider",
+    "hook",
+    "command",
+    "channel",
+    "frontend",
+    "app",
+    "general",
+}
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+class QwenPawPluginManifestTest(unittest.TestCase):
+    def test_manifest_exists(self) -> None:
+        self.assertTrue(
+            MANIFEST_PATH.is_file(),
+            "missing .qwenpaw-plugin/plugin.json",
+        )
+
+    def test_manifest_has_the_required_fields(self) -> None:
+        manifest = load_manifest()
+        for field in ("id", "version", "name"):
+            self.assertTrue(
+                str(manifest.get(field, "")).strip(),
+                f"plugin.json must declare a non-empty {field!r}",
+            )
+
+    def test_manifest_type_is_a_known_plugin_type(self) -> None:
+        self.assertIn(load_manifest().get("type"), VALID_QWENPAW_TYPES)
+
+    def test_backend_entry_is_declared(self) -> None:
+        entry = load_manifest().get("entry") or {}
+        self.assertTrue(
+            entry.get("backend"),
+            "entry.backend must name the Python entry file",
+        )
+        self.assertTrue(
+            (PLUGIN_DIR / entry["backend"]).is_file(),
+            "entry.backend must exist in the plugin directory",
+        )
+
+    def test_version_matches_the_canonical_release_version(self) -> None:
+        version = (REPO_ROOT / "VERSION").read_text(encoding="utf-8").strip()
+        self.assertEqual(
+            load_manifest().get("version"),
+            version,
+            ".qwenpaw-plugin/plugin.json version must equal VERSION "
+            "(scripts/release/sync-version.mjs stamps it)",
+        )
+
+    def test_entry_imports_without_qwenpaw_installed(self) -> None:
+        """The loader imports the entry and requires a `plugin` instance.
+
+        The module must keep its importable surface stdlib-only (the
+        qwenpaw import sits under `if TYPE_CHECKING`), so validation
+        succeeds in a checkout and on any machine before dependencies
+        are installed.
+        """
+        saved = [k for k in sys.modules if k == "qwenpaw" or k.startswith("qwenpaw.")]
+        sys.modules.pop("qwenpaw", None)
+        try:
+            import importlib.util
+
+            spec = importlib.util.spec_from_file_location(
+                "_test_qwenpaw_plugin_entry", PLUGIN_DIR / "plugin.py"
+            )
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            self.assertTrue(hasattr(module, "plugin"), "must export `plugin`")
+            self.assertTrue(hasattr(module.plugin, "register"))
+        finally:
+            for key in [k for k in sys.modules if k.startswith("_test_qwenpaw_plugin_entry")]:
+                sys.modules.pop(key, None)
+            for key in saved:
+                sys.modules.setdefault(key, sys.modules.get(key))
+
+    def test_skills_dir_resolves_from_checkout_and_installed_copy(self) -> None:
+        """The loader copies only .qwenpaw-plugin/ into ~/.qwenpaw/plugins/<id>/.
+
+        The plugin therefore bundles its own skills/ copy, generated from the
+        canonical tree; the checkout sibling is the fallback. Both layouts
+        must resolve, and the bundled copy must match the canonical tree —
+        a stale copy would ship different skills to QwenPaw than every other
+        installer ships.
+        """
+        import filecmp
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "_test_qwenpaw_plugin_entry", PLUGIN_DIR / "plugin.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        try:
+            resolved = module._resolve_skills_dir()
+            self.assertIsNotNone(resolved, "checkout layout must resolve")
+            # The resolver prefers the bundled copy; the canonical tree is the
+            # fallback. What matters is that whichever it picks has content
+            # matching the canonical tree, asserted by the snapshot below.
+            self.assertIn(
+                resolved.resolve(),
+                {
+                    (REPO_ROOT / "skills").resolve(),
+                    (PLUGIN_DIR / "skills").resolve(),
+                },
+                "the skill provider must resolve to a skills tree",
+            )
+        finally:
+            sys.modules.pop("_test_qwenpaw_plugin_entry", None)
+
+        canonical = REPO_ROOT / "skills"
+        bundled = PLUGIN_DIR / "skills"
+        self.assertTrue(bundled.is_dir(), "missing generated copy .qwenpaw-plugin/skills/")
+
+        def snapshot(root: Path) -> dict[str, bytes]:
+            return {
+                str(p.relative_to(root)): p.read_bytes()
+                for p in sorted(root.rglob("*"))
+                if p.is_file()
+                and "__pycache__" not in p.parts
+                and p.name not in (".DS_Store", "Thumbs.db")
+            }
+
+        left, right = snapshot(canonical), snapshot(bundled)
+        self.assertEqual(
+            sorted(left),
+            sorted(right),
+            ".qwenpaw-plugin/skills/ file set diverged from skills/ — "
+            "regenerate the copy (see .qwenpaw-plugin/README.md)",
+        )
+        drift = [
+            name
+            for name, data in left.items()
+            if name in right and data != right[name]
+        ]
+        self.assertEqual(
+            [],
+            drift,
+            ".qwenpaw-plugin/skills/ content diverged from skills/ — "
+            "regenerate the copy (see .qwenpaw-plugin/README.md)",
+        )
+        self.assertTrue(
+            left,
+            "the skills snapshot found no files; the glob is broken",
+        )
+
+    def test_skills_dir_missing_layout_does_not_crash_register(self) -> None:
+        """A plugin copy with no skills/ anywhere near it must not raise.
+
+        The loader's install hook silently no-ops on a missing skills_dir;
+        if the resolver returned a nonexistent path, every startup would
+        provision nothing and only a log line would say why. register()
+        must take the skip branch and still register the rest.
+        """
+        import importlib.util
+        import tempfile
+
+        saved = [k for k in sys.modules if k == "qwenpaw" or k.startswith("qwenpaw.")]
+        sys.modules.pop("qwenpaw", None)
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "plugin.py"
+            orphan.write_text((PLUGIN_DIR / "plugin.py").read_text(encoding="utf-8"))
+            spec = importlib.util.spec_from_file_location(
+                "_test_qwenpaw_plugin_orphan", orphan
+            )
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            try:
+                self.assertIsNone(module._resolve_skills_dir())
+                registered: list[str] = []
+
+                class FakeApi:
+                    def register_skill_provider(self, skills_dir, **kwargs):
+                        registered.append("skills")
+
+                    def register_slash_command(self, name, handler, **kwargs):
+                        registered.append(f"slash:{name}")
+
+                    def register_startup_hook(self, hook_name, callback, priority=100):
+                        registered.append(f"hook:{hook_name}")
+
+                    def register_workspace_created_hook(self, hook_name, callback, priority=100):
+                        registered.append(f"wshook:{hook_name}")
+
+                    def register_prompt_section(self, name, after, provider, **kwargs):
+                        registered.append(f"prompt:{name}")
+
+                module.plugin.register(FakeApi())
+                self.assertNotIn(
+                    "skills",
+                    registered,
+                    "no skills dir: skill registration must be skipped",
+                )
+                self.assertIn(
+                    "slash:cad-setup",
+                    registered,
+                    "the preflight command registers regardless of skills",
+                )
+                self.assertNotIn(
+                    "prompt:text_to_cad_setup_hint",
+                    registered,
+                    "no skills: the setup hint must not advertise them",
+                )
+            finally:
+                sys.modules.pop("_test_qwenpaw_plugin_orphan", None)
+                for key in saved:
+                    sys.modules.setdefault(key, sys.modules.get(key))
+
+    def test_skills_dir_missing_layout_does_not_crash_register(self) -> None:
+        """A plugin copy with no skills/ anywhere near it must not raise.
+
+        The loader's install hook silently no-ops on a missing skills_dir;
+        if the resolver returned a nonexistent path, every startup would
+        provision nothing and only a log line would say why. register()
+        must take the skip branch and still register the rest.
+        """
+        import importlib.util
+        import tempfile
+
+        saved = [k for k in sys.modules if k == "qwenpaw" or k.startswith("qwenpaw.")]
+        sys.modules.pop("qwenpaw", None)
+        with tempfile.TemporaryDirectory() as tmp:
+            orphan = Path(tmp) / "plugin.py"
+            orphan.write_text((PLUGIN_DIR / "plugin.py").read_text(encoding="utf-8"))
+            spec = importlib.util.spec_from_file_location(
+                "_test_qwenpaw_plugin_orphan", orphan
+            )
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            try:
+                self.assertIsNone(module._resolve_skills_dir())
+                registered: list[str] = []
+
+                class FakeApi:
+                    def register_skill_provider(self, skills_dir, **kwargs):
+                        registered.append("skills")
+
+                    def register_slash_command(self, name, handler, **kwargs):
+                        registered.append(f"slash:{name}")
+
+                    def register_startup_hook(self, hook_name, callback, priority=100):
+                        registered.append(f"hook:{hook_name}")
+
+                    def register_workspace_created_hook(self, hook_name, callback, priority=100):
+                        registered.append(f"wshook:{hook_name}")
+
+                    def register_prompt_section(self, name, after, provider, **kwargs):
+                        registered.append(f"prompt:{name}")
+
+                module.plugin.register(FakeApi())
+                self.assertNotIn(
+                    "skills",
+                    registered,
+                    "no skills dir: skill registration must be skipped",
+                )
+                self.assertIn(
+                    "slash:cad-setup",
+                    registered,
+                    "the preflight command registers regardless of skills",
+                )
+                self.assertNotIn(
+                    "prompt:text_to_cad_setup_hint",
+                    registered,
+                    "no skills: the setup hint must not advertise them",
+                )
+            finally:
+                sys.modules.pop("_test_qwenpaw_plugin_orphan", None)
+                for key in saved:
+                    sys.modules.setdefault(key, sys.modules.get(key))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bundle the repo's skills (cad, cad-viewer, srdf, urdf, step-parts, bambu-labs, ...) as a QwenPaw plugin under .qwenpaw-plugin/, including plugin.json manifest, backend entry (plugin.py), per-skill SKILL.md/references/scripts, i18n descriptions, and a global test suite (tests/python/global/test_qwenpaw_plugin.py).

Also update AGENTS.md, CONTRIBUTING.md, README.md, docs landing page and sync-version script for the new plugin surface.